### PR TITLE
Add CLAUDE.md and SessionStart hook for IDE workflow

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (web) environment
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Install all dependencies (core + optional groups)
+pip install pandas">=2.0" pydantic">=2.0" \
+    fastapi">=0.100" "uvicorn[standard]>=0.20" python-multipart">=0.0.6" \
+    httpx">=0.24" \
+    pytest">=7.0" pytest-cov">=4.0" ruff">=0.1" \
+    --quiet
+
+# Set PYTHONPATH so tests/linter/CLI work without prefix
+echo 'export PYTHONPATH="'"$CLAUDE_PROJECT_DIR"'/src"' >> "$CLAUDE_ENV_FILE"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# Debussy — Kuratierwerkbank
+
+KI-gestützte Kuratierungswerkbank für GLAM-Sammlungsdaten (Galerien, Bibliotheken, Archive, Museen).
+Python 3.10+, MIT-Lizenz, v0.5.1.
+
+## Schnellreferenz
+
+```bash
+# Tests ausführen (immer vor Commit!)
+PYTHONPATH=src python -m unittest discover tests
+
+# Linting
+ruff check src/ tests/
+
+# API-Server starten
+PYTHONPATH=src python -m kwb.api.app
+# → http://localhost:8765
+
+# CLI
+PYTHONPATH=src python -m kwb.cli analyze daten.csv
+PYTHONPATH=src python -m kwb.cli plan --top 8
+```
+
+## Projektstruktur
+
+```
+src/kwb/
+├── core/           # Typen (models.py), Config, Workspace-Persistenz
+├── ingest/         # CSV/TSV-Loader, Bild-Loader (TIFF/JPEG/PNG)
+├── analyze/        # Strukturanalyse (7 Checks), NER, Semantik
+├── normalize/      # EDTF-Datumsnormalisierung
+├── enrich/         # GND, Geonames (teilweise geplant)
+├── export/         # Goobi-XML
+├── ai/             # Provider-Abstraktion (GPUStack, Mock), Batch, Prompts
+├── report/         # Markdown-Report
+├── api/            # FastAPI-Server + Dashboard (Single-Page HTML)
+└── cli.py          # Kommandozeile
+```
+
+## Architektur-Regeln
+
+- **Provider-Abstraktion**: Alle LLM-Aufrufe über `ai/provider.py`-Interface. GPUStack für Produktion, Mock für Tests.
+- **Modularer Aufbau**: Jedes GLAM-Institut nutzt nur, was es braucht.
+- **Sprache**: Code auf Englisch, UI/Doku auf Deutsch.
+- **Dependencies minimal halten**: Kern nur pandas + pydantic. Extras über optional-dependencies.
+- **Tests**: unittest-basiert. Jedes neue Feature braucht Tests.
+
+## Abhängigkeiten
+
+- **Kern**: pandas ≥ 2.0, pydantic ≥ 2.0
+- **API**: fastapi, uvicorn, python-multipart
+- **AI**: httpx
+- **Dev**: pytest, pytest-cov, ruff
+
+## Aktueller Stand
+
+- **Phase 1** (Strukturanalyse): ✅ abgeschlossen
+- **Phase 2** (KI-Kern + Bilder): 🟡 in Arbeit
+- **Phase 3–5**: geplant (siehe docs/ARCHITECTURE.md)
+
+Detaillierter Feature-Katalog: docs/FUNKTIONSKATALOG.md
+
+## Konventionen
+
+- Ruff Line-Length: 100
+- Python Target: 3.10
+- PYTHONPATH=src ist nötig zum Ausführen (kein pip install im Dev)
+- `.env` für lokale Konfiguration (nie committen), Vorlage: `.env.example`


### PR DESCRIPTION
Set up Claude Code integration with project context (CLAUDE.md) and
a SessionStart hook that auto-installs dependencies and configures
PYTHONPATH for web sessions. Replaces patch-based workflow.

https://claude.ai/code/session_01FibFrruuadpn2xMVKy4Hmi