### PR TITLE
Fix CSV-Upload-Fehler: JSON-Serialisierung, Encoding-Fallback, Server…

### DIFF
--- a/src/kwb/api/app.py
+++ b/src/kwb/api/app.py
@@ -225,8 +225,12 @@ async def analyze(files: list[UploadFile] = File(...)):
         except Exception as e:
             return JSONResponse({"error": f"{u.filename}: {e}"}, 400)
         finally: tp.unlink(missing_ok=True)
-    report = analyze_datasets(datasets); _state["report"] = report
-    return _report_json(report, render_report(report))
+    try:
+        report = analyze_datasets(datasets)
+        _state["report"] = report
+        return _report_json(report, render_report(report))
+    except Exception as e:
+        return JSONResponse({"error": f"Analyse fehlgeschlagen: {e}"}, 500)
 
 @app.get("/api/dataset/{name}/columns")
 async def dataset_columns(name: str):

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -275,7 +275,9 @@ async function runStruct(){
   if(!sel.length){alert('Mindestens eine Datei auswählen.');return}
   sp('Strukturelle Analyse …',sel.length+' Datei(en)');
   const fd=new FormData();for(const n of sel)fd.append('files',ufiles[n]);
-  try{const r=await(await fetch('/api/analyze',{method:'POST',body:fd})).json();
+  try{
+    const resp=await fetch('/api/analyze',{method:'POST',body:fd});
+    let r;try{r=await resp.json()}catch{throw new Error('Server-Fehler ('+resp.status+')')}
     if(r.error)throw Error(r.error);curRep=r;analysed=true;rrep(r);populateDS();updWS()
   }catch(e){alert(e.message)}finally{hp()}
 }

--- a/src/kwb/ingest/csv_loader.py
+++ b/src/kwb/ingest/csv_loader.py
@@ -17,11 +17,16 @@ from kwb.core.models import ColumnProfile, DatasetProfile
 
 
 def detect_encoding(path: Path) -> tuple[str, bool]:
-    """Detect file encoding and BOM presence."""
+    """Detect file encoding and BOM presence. Falls back to latin-1 for non-UTF-8 files."""
     raw = path.read_bytes()[:4096]
     has_bom = raw[:3] == b"\xef\xbb\xbf"
-    encoding = "utf-8-sig" if has_bom else "utf-8"
-    return encoding, has_bom
+    if has_bom:
+        return "utf-8-sig", True
+    try:
+        raw.decode("utf-8")
+        return "utf-8", False
+    except UnicodeDecodeError:
+        return "latin-1", False
 
 
 def detect_line_ending(path: Path) -> str:
@@ -71,7 +76,7 @@ def profile_column(series: pd.Series) -> ColumnProfile:
         dtype=str(series.dtype),
         total_count=len(series),
         non_null_count=len(non_null),
-        unique_count=series.nunique(),
+        unique_count=int(series.nunique()),
         fill_rate=round(len(non_null) / len(series), 4) if len(series) > 0 else 0.0,
         sample_values=sample,
         value_lengths={


### PR DESCRIPTION
…-Fehler

- csv_loader.py: unique_count explizit zu int() casten – numpy.int64 ist nicht JSON-serialisierbar und verursachte einen stillen TypeError in FastAPI, den Starlette als Plain-Text "Internal Server Error" zurückgab (Browser: "Unexpected token 'I'…")
- csv_loader.py: detect_encoding() fällt jetzt auf latin-1 zurück wenn die Datei kein valides UTF-8 ist (Windows-1252-CSVs aus Excel)
- app.py: analyze_datasets()/render_report() in try/except gewrappt – unbehandelte Exceptions werden jetzt als JSON 500 {"error":…} zurückgegeben statt als Plain-Text
- dashboard.html: runStruct() prüft zuerst ob die Antwort JSON ist; bei nicht-JSON-Antworten wird "Server-Fehler (500)" angezeigt statt des kryptischen JSON-Parse-Fehlers

https://claude.ai/code/session_01UWXSTLAsP23iwW3BuWwinP