### PR TITLE
Add image data endpoint to serve raw image bytes for thumbnails

### DIFF
--- a/src/kwb/api/app.py
+++ b/src/kwb/api/app.py
@@ -548,6 +548,18 @@ async def images_upload(files: list[UploadFile] = File(...)):
     return {"uploaded": len(accepted), "images": accepted}
 
 
+@app.get("/api/images/{img_id}/data")
+async def image_data(img_id: str):
+    """Serve raw image bytes so the browser can display thumbnails."""
+    from fastapi.responses import Response
+    img = _uploaded_images.get(img_id)
+    if not img:
+        return JSONResponse({"error": "Nicht gefunden"}, 404)
+    import base64
+    content = base64.b64decode(img["b64"])
+    return Response(content=content, media_type=img["media_type"])
+
+
 @app.get("/api/images")
 async def images_list():
     return {"images": [

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -688,6 +688,8 @@ function renderImgGrid(){
   empty.style.display='none';
   grid.innerHTML = uploadedImages.map(function(img){
     return '<div style="border:1px solid var(--brd);border-radius:4px;padding:.4rem;font-size:.72rem;background:#fafafa">'
+      +'<img src="/api/images/'+esc(img.id)+'/data" alt="'+esc(img.filename)+'" loading="lazy"'
+      +' style="width:100%;height:110px;object-fit:cover;border-radius:2px;display:block;margin-bottom:.3rem">'
       +'<div style="font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:150px" title="'+esc(img.filename)+'">'+esc(img.filename)+'</div>'
       +'<div style="color:#888;font-size:.65rem">'+(img.size_bytes/1024).toFixed(1)+' KB</div>'
       +'<div style="margin-top:.2rem"><span class="bg '+(img.analyzed?'ac':'no')+'">'+(img.analyzed?'analysiert':'ausstehend')+'</span></div>'

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -186,6 +186,18 @@ async def images_upload(files: list[UploadFile] = File(...)):
     return {"uploaded": len(accepted), "images": accepted}
 
 
+@router.get("/api/images/{img_id}/data")
+async def image_data(img_id: str):
+    """Serve raw image bytes so the browser can display thumbnails."""
+    import base64
+    from fastapi.responses import Response
+    img = _uploaded_images.get(img_id)
+    if not img:
+        return JSONResponse({"error": "Nicht gefunden"}, 404)
+    content = base64.b64decode(img["b64"])
+    return Response(content=content, media_type=img["media_type"])
+
+
 @router.get("/api/images")
 async def images_list():
     """List all uploaded images and their analysis status."""

--- a/tests/test_image_upload.py
+++ b/tests/test_image_upload.py
@@ -281,5 +281,62 @@ class TestImageAnalyze(unittest.TestCase):
         self.assertEqual(r.json()["analyzed"], 1)
 
 
+# ---------------------------------------------------------------------------
+# Image data (thumbnail) endpoint tests
+# ---------------------------------------------------------------------------
+
+@_skip
+class TestImageData(unittest.TestCase):
+    """GET /api/images/{img_id}/data — serve raw image bytes for thumbnail display."""
+
+    def setUp(self):
+        self.client = _get_client()
+
+    def _upload(self, data: bytes, name: str) -> str:
+        r = self.client.post("/api/images/upload", files=[_img_file(data, name)])
+        self.assertEqual(r.status_code, 200)
+        return r.json()["images"][0]["id"]
+
+    def test_data_jpeg_returns_bytes_and_content_type(self):
+        img_id = self._upload(_JPEG, "foto.jpg")
+        r = self.client.get(f"/api/images/{img_id}/data")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers["content-type"], "image/jpeg")
+        self.assertEqual(r.content, _JPEG)
+
+    def test_data_png_returns_bytes_and_content_type(self):
+        img_id = self._upload(_PNG, "zeichnung.png")
+        r = self.client.get(f"/api/images/{img_id}/data")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.headers["content-type"], "image/png")
+        self.assertEqual(r.content, _PNG)
+
+    def test_data_tiff_returns_bytes_and_content_type(self):
+        img_id = self._upload(_TIFF, "scan.tif")
+        r = self.client.get(f"/api/images/{img_id}/data")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("image/tiff", r.headers["content-type"])
+        self.assertEqual(r.content, _TIFF)
+
+    def test_data_webp_returns_bytes_and_content_type(self):
+        img_id = self._upload(_WEBP, "thumb.webp")
+        r = self.client.get(f"/api/images/{img_id}/data")
+        self.assertEqual(r.status_code, 200)
+        self.assertIn("image/webp", r.headers["content-type"])
+        self.assertEqual(r.content, _WEBP)
+
+    def test_data_unknown_id_returns_404(self):
+        r = self.client.get("/api/images/img_9999_notfound/data")
+        self.assertEqual(r.status_code, 404)
+
+    def test_data_survives_analyze(self):
+        """Image bytes remain accessible after analysis."""
+        img_id = self._upload(_JPEG, "museum.jpg")
+        self.client.post("/api/images/analyze", json={"image_ids": [img_id]})
+        r = self.client.get(f"/api/images/{img_id}/data")
+        self.assertEqual(r.status_code, 200)
+        self.assertEqual(r.content, _JPEG)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
This PR adds a new API endpoint to serve raw image bytes, enabling the dashboard to display thumbnail previews of uploaded images.

## Key Changes
- **New endpoint**: `GET /api/images/{img_id}/data` — serves raw image bytes with appropriate content-type headers
  - Implemented in both `src/kwb/api/app.py` and `src/kwb/api/routes/ai.py`
  - Returns 404 if image ID not found
  - Decodes base64-encoded image data stored in memory
  - Sets correct media type (image/jpeg, image/png, etc.)

- **Dashboard UI enhancement**: Updated `dashboard.html` to display image thumbnails
  - Adds `<img>` tag to render uploaded images in the results grid
  - Lazy loading enabled for performance
  - Styled with fixed height (110px), object-fit cover, and rounded corners
  - Filename used as alt text for accessibility

- **Test coverage**: Added comprehensive test suite (`TestImageData`)
  - Tests all supported image formats (JPEG, PNG, TIFF, WebP)
  - Verifies correct content-type headers
  - Tests 404 handling for non-existent images
  - Validates image data persistence after analysis

## Implementation Details
- Images are stored as base64-encoded strings in memory with their media type
- The endpoint decodes the base64 data and returns it as raw bytes with the appropriate content-type header
- Tests are marked with `@_skip` decorator (consistent with existing test patterns)

https://claude.ai/code/session_01SstpMPSKekRoDK85mtmCTq