### PR TITLE
Add mask_secret utility function for redacting sensitive values

### DIFF
--- a/src/kwb/core/utils.py
+++ b/src/kwb/core/utils.py
@@ -69,5 +69,14 @@ def safe_int(value: Any, default: int = 0) -> int:
         return default
 
 
+def mask_secret(value: str, visible: int = 4) -> str:
+    """Return *value* with all but the first *visible* characters replaced by asterisks."""
+    if not value:
+        return "(nicht gesetzt)"
+    if len(value) <= visible:
+        return "*" * len(value)
+    return value[:visible] + "*" * (len(value) - visible)
+
+
 # Keep old private alias so existing imports work without breakage
 _try_parse_json = try_parse_json


### PR DESCRIPTION
## Summary
Added a new `mask_secret()` utility function to safely redact sensitive information by replacing all but the first few characters with asterisks.

## Changes
- Added `mask_secret(value: str, visible: int = 4) -> str` function to `src/kwb/core/utils.py`
  - Masks sensitive string values while keeping the first `visible` characters (default: 4) for identification
  - Returns "(nicht gesetzt)" for empty/falsy values
  - Returns all asterisks if the value is shorter than or equal to the visible character count
  - Useful for logging and displaying secrets (API keys, tokens, passwords) safely

## Implementation Details
- The function preserves the first N characters to allow users to identify which secret is being referenced
- Handles edge cases: empty strings, very short values, and values shorter than the visible threshold
- Uses German text "(nicht gesetzt)" (not set) for empty values, consistent with the codebase locale

https://claude.ai/code/session_01NqM1YNrcorisdzFwtWUEMg