### PR TITLE
Include implemented features with incomplete tests in roadmap proposals

### DIFF
--- a/src/kwb/core/roadmap.py
+++ b/src/kwb/core/roadmap.py
@@ -53,6 +53,7 @@ def _priority(e):
     score = 0
     if e.status.lower().startswith("geplant"): score += 100
     elif e.status.lower().startswith("teilweise"): score += 60
+    elif e.status.lower().startswith("umgesetzt") and e.tests_done < e.tests_total: score += 40
     if e.tests_total == 0: score += 30
     elif e.tests_done < e.tests_total: score += 15
     if any(d in e.category.lower() for d in ("ingest","export","enrichment","infrastruktur")): score += 10
@@ -60,7 +61,11 @@ def _priority(e):
 
 
 def build_improvement_proposals(entries, top_n=6):
-    candidates = [e for e in entries if e.status != "Umgesetzt"]
+    candidates = [
+        e
+        for e in entries
+        if e.status != "Umgesetzt" or (e.status == "Umgesetzt" and e.tests_done < e.tests_total)
+    ]
     ranked = sorted(candidates, key=lambda e: (_priority(e), e.feature_id), reverse=True)
     proposals = []
     for entry in ranked[:top_n]:

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from kwb.core.roadmap import (
+    FeatureEntry,
     build_improvement_proposals,
     parse_function_catalog,
     render_proposals_markdown,
@@ -65,3 +66,40 @@ def test_parse_function_catalog_on_custom_file(tmp_path: Path):
     assert entries[0].feature_id == "F99"
     assert entries[0].tests_done == 1
     assert entries[0].tests_total == 2
+
+
+def test_proposals_include_implemented_features_with_test_gaps():
+    entries = [
+        FeatureEntry(
+            category="Core",
+            feature_id="F01",
+            title="Geplantes Feature",
+            status="Geplant",
+            tests_done=0,
+            tests_total=0,
+            module="core.py",
+            note="",
+        ),
+        FeatureEntry(
+            category="Core",
+            feature_id="F02",
+            title="Umgesetztes Feature mit Testlücke",
+            status="Umgesetzt",
+            tests_done=0,
+            tests_total=1,
+            module="core.py",
+            note="",
+        ),
+    ]
+
+    proposals = build_improvement_proposals(entries, top_n=5)
+
+    proposal_ids = [p.feature_id for p in proposals]
+    assert "F02" in proposal_ids
+
+    planned = next(p for p in proposals if p.feature_id == "F01")
+    implemented_gap = next(p for p in proposals if p.feature_id == "F02")
+
+    assert planned.priority > implemented_gap.priority
+    assert "Status 'Umgesetzt'" in implemented_gap.rationale
+    assert "0/1 Tests" in implemented_gap.rationale


### PR DESCRIPTION
### Motivation
- Ensure features with status "Umgesetzt" but incomplete test coverage (`tests_done < tests_total`) are considered as improvement candidates so test gaps become visible. 
- Keep such implemented-but-untested features ranked below clearly planned work while making their test status and impact explicit in the rationale.

### Description
- Update `build_improvement_proposals()` to include entries that are either not implemented or implemented with a test gap by changing the candidate filter to `not Umgesetzt OR (Umgesetzt AND tests_done < tests_total)`.
- Extend `_priority()` with an explicit weight for `Umgesetzt` entries that have incomplete tests (`+40`) so they remain visible but typically rank below `Geplant` (`+100`).
- Add `FeatureEntry` import to `tests/test_roadmap.py` and introduce `test_proposals_include_implemented_features_with_test_gaps()` which creates an `Umgesetzt` + `0/1` example and asserts it appears in proposals, that its priority is lower than a planned feature, and that the `rationale` contains the status and `0/1 Tests` information.

### Testing
- Running `pytest -q tests/test_roadmap.py` without `PYTHONPATH` failed during collection due to `ModuleNotFoundError: No module named 'kwb'`.
- Running `PYTHONPATH=src pytest -q tests/test_roadmap.py` executed the test file (including the new test) and all tests passed: `6 passed in 1.48s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85d5b507883288c6cbdb4fcfd5308)