### PR TITLE
Refactor parse_function_catalog zu headerbasiertem Tabellen-Parsing

### DIFF
--- a/src/kwb/core/roadmap.py
+++ b/src/kwb/core/roadmap.py
@@ -30,21 +30,57 @@ def _clean_status(s):
 def parse_function_catalog(path):
     lines = Path(path).read_text(encoding="utf-8").splitlines()
     current_category, entries = "", []
+    header_to_index = None
+
+    def _is_separator_row(row_cells):
+        return all(set(cell.replace(":", "")) <= {"-"} for cell in row_cells if cell)
+
+    def _build_header_map(row_cells):
+        normalized = [cell.strip().lower() for cell in row_cells]
+        required = {"id", "funktion", "status", "tests"}
+        if not required.issubset(set(normalized)):
+            return None
+        return {name: idx for idx, name in enumerate(normalized)}
+
     for line in lines:
         if line.startswith("## "):
             heading = line.lstrip("# ").strip()
             current_category = heading.split("—", 1)[1].strip() if "—" in heading else heading.split(".", 1)[-1].strip()
+            header_to_index = None
             continue
-        if not line.startswith("|"): continue
+
+        if not line.startswith("|"):
+            header_to_index = None
+            continue
+
         cells = [c.strip() for c in line.strip().split("|")[1:-1]]
-        if len(cells) < 5: continue
-        if cells[0] in ("ID","") or cells[0].startswith("----"): continue
-        tests_done, tests_total = _parse_tests(cells[3])
-        note = cells[6] if len(cells) > 6 else ""
+
+        maybe_header = _build_header_map(cells)
+        if maybe_header is not None:
+            header_to_index = maybe_header
+            continue
+
+        if _is_separator_row(cells) or not header_to_index:
+            continue
+
+        def _cell(name):
+            idx = header_to_index.get(name)
+            return cells[idx] if idx is not None and idx < len(cells) else ""
+
+        feature_id = _cell("id")
+        if not feature_id:
+            continue
+
+        tests_done, tests_total = _parse_tests(_cell("tests"))
         entries.append(FeatureEntry(
-            category=current_category, feature_id=cells[0], title=cells[1],
-            status=_clean_status(cells[2]), tests_done=tests_done, tests_total=tests_total,
-            module=cells[4], note=note,
+            category=current_category,
+            feature_id=feature_id,
+            title=_cell("funktion"),
+            status=_clean_status(_cell("status")),
+            tests_done=tests_done,
+            tests_total=tests_total,
+            module=_cell("modul"),
+            note=_cell("hinweis"),
         ))
     return entries
 

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -65,3 +65,26 @@ def test_parse_function_catalog_on_custom_file(tmp_path: Path):
     assert entries[0].feature_id == "F99"
     assert entries[0].tests_done == 1
     assert entries[0].tests_total == 2
+    assert entries[0].module == "`demo.py`"
+    assert entries[0].note == "Noch offen"
+
+
+def test_parse_function_catalog_without_modul_column(tmp_path: Path):
+    file = tmp_path / "catalog_without_modul.md"
+    file.write_text(
+        "\n".join(
+            [
+                "## 1. Demo",
+                "| ID | Funktion | Status | Tests | Hinweis |",
+                "|----|----------|--------|-------|---------|",
+                "| F42 | Nur Hinweis | ✅ Umgesetzt | 2/2 | Fertig dokumentiert |",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    entries = parse_function_catalog(file)
+    assert len(entries) == 1
+    assert entries[0].feature_id == "F42"
+    assert entries[0].module == ""
+    assert entries[0].note == "Fertig dokumentiert"


### PR DESCRIPTION
### Motivation
- Die bisherige Implementierung las Tabellen spaltenpositionsbasiert und übernahm bei fehlenden optionalen Spalten falsche Werte aus folgenden Spalten.    
- Ziel ist robustes Parsen unterschiedlicher Tabellenvarianten im `FUNKTIONSKATALOG.md` durch Erkennen von Headern statt fester Indizes.    

### Description
- `parse_function_catalog()` wurde auf headerbasiertes Parsing umgestellt und baut pro Tabelle ein `Name -> Index`-Mapping aus der Headerzeile auf; erforderliche Header sind `ID`, `Funktion`, `Status`, `Tests`.    
- Optionale Header `Modul` und `Hinweis` werden unterstützt und falls nicht vorhanden explizit als `""` gesetzt, damit keine falschen Spalteninhalte übernommen werden.    
- Trennzeilen werden erkannt und Headererkennung wird vor Datenerfassung angewendet; Datenspalten werden über Hilfsfunktion ` _cell(name)` gezogen und durch `_parse_tests()` / `_clean_status()` verarbeitet.    
- Tests in `tests/test_roadmap.py` wurden erweitert: eine Variante mit `Modul`+`Hinweis` und eine Variante ohne `Modul` (nur `Hinweis`) wurden ergänzt, die `module` und `note`-Verhalten prüfen.    

### Testing
- `pytest -q tests/test_roadmap.py` lief zunächst in der Default-Umgebung in dieser CI nicht durch wegen `ModuleNotFoundError` (erforderlicher `PYTHONPATH` war nicht gesetzt).    
- Mit `PYTHONPATH=src pytest -q tests/test_roadmap.py` wurden alle Tests erfolgreich ausgeführt (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85d6e4a588328a29a5ccf16070e13)