### PR TITLE
Harden roadmap tests with deterministic fixture-based assertions

### DIFF
--- a/tests/fixtures/roadmap_small_catalog.md
+++ b/tests/fixtures/roadmap_small_catalog.md
@@ -1,0 +1,16 @@
+## 1. Ingest
+| ID | Funktion | Status | Tests | Modul | Hinweis |
+|----|----------|--------|-------|-------|---------|
+| F10 | Ingest Core | Geplant | — | `ingest.py` | offen |
+| F12 | Ingest Delta | Geplant | 1/2 | `ingest.py` | offen |
+| F11 | Ingest Validate | Teilweise | — | `ingest.py` | offen |
+| F09 | Ingest Retry | Teilweise | 1/2 | `ingest.py` | offen |
+| F13 | Ingest Done | Umgesetzt | 3/3 | `ingest.py` | done |
+
+## 2. Sonstiges
+| ID | Funktion | Status | Tests | Modul | Hinweis |
+|----|----------|--------|-------|-------|---------|
+| F20 | Tie Low | Geplant | — | `misc.py` | tie |
+| F21 | Tie Mid | Geplant | — | `misc.py` | tie |
+| F22 | Tie High | Geplant | — | `misc.py` | tie |
+| F30 | Defekter Testwert | Geplant | n/a | `misc.py` | invalid tests cell |

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -8,6 +8,9 @@ from kwb.core.roadmap import (
 from kwb.cli import main
 
 
+FIXTURE_CATALOG = Path("tests/fixtures/roadmap_small_catalog.md")
+
+
 def test_parse_function_catalog_reads_known_feature():
     entries = parse_function_catalog("docs/FUNKTIONSKATALOG.md")
     feature_ids = {entry.feature_id for entry in entries}
@@ -19,22 +22,57 @@ def test_parse_function_catalog_reads_known_feature():
 
 
 def test_proposals_prioritize_unimplemented_features():
-    entries = parse_function_catalog("docs/FUNKTIONSKATALOG.md")
-    proposals = build_improvement_proposals(entries, top_n=5)
+    entries = [
+        e
+        for e in parse_function_catalog(FIXTURE_CATALOG)
+        if e.feature_id in {"F10", "F12", "F11", "F09", "F13"}
+    ]
+    proposals = build_improvement_proposals(entries, top_n=4)
 
-    assert len(proposals) == 5
-    assert all(p.priority >= 100 for p in proposals)
-    assert all("Status" in p.rationale for p in proposals)
+    assert [p.feature_id for p in proposals] == ["F10", "F12", "F11", "F09"]
+    assert [p.priority for p in proposals] == [140, 125, 100, 85]
+
+
+def test_proposals_are_deterministic_for_equal_priorities():
+    entries = [e for e in parse_function_catalog(FIXTURE_CATALOG) if e.feature_id in {"F20", "F21", "F22"}]
+
+    first = build_improvement_proposals(entries, top_n=3)
+    second = build_improvement_proposals(entries, top_n=3)
+
+    assert [p.feature_id for p in first] == ["F22", "F21", "F20"]
+    assert [p.feature_id for p in second] == ["F22", "F21", "F20"]
+
+
+def test_parse_function_catalog_handles_invalid_tests_cell_as_zero_zero():
+    entries = parse_function_catalog(FIXTURE_CATALOG)
+
+    malformed = next(e for e in entries if e.feature_id == "F30")
+
+    assert malformed.tests_done == 0
+    assert malformed.tests_total == 0
+
+    proposal = next(p for p in build_improvement_proposals(entries, top_n=8) if p.feature_id == "F30")
+    assert "0/0 Tests" in proposal.rationale
 
 
 def test_render_proposals_markdown_contains_sections():
-    entries = parse_function_catalog("docs/FUNKTIONSKATALOG.md")
+    entries = parse_function_catalog(FIXTURE_CATALOG)
     proposals = build_improvement_proposals(entries, top_n=2)
     md = render_proposals_markdown(proposals)
 
     assert md.startswith("# Konkrete Entwicklungsvorschläge")
     assert "**Nächste Schritte:**" in md
     assert "**Akzeptanzkriterien:**" in md
+
+    sections = [s for s in md.split("\n## ")[1:] if s.strip()]
+    assert len(sections) == 2
+    for section in sections:
+        assert " — " in section
+        assert "**Begründung:**" in section
+        action_lines = section.split("**Nächste Schritte:**", 1)[1].split("**Akzeptanzkriterien:**", 1)[0]
+        acceptance_lines = section.split("**Akzeptanzkriterien:**", 1)[1]
+        assert action_lines.count("\n-") >= 3
+        assert acceptance_lines.count("\n-") >= 3
 
 
 def test_cli_plan_command_outputs_recommendations(capsys):


### PR DESCRIPTION
### Motivation
- Make roadmap tests independent from the large production catalog by using a small, controlled fixture to improve reliability.
- Verify exact ordering and priority scores for proposals rather than coarse threshold checks to catch regressions in ranking logic.
- Ensure deterministic tie-breaking and robust handling of malformed `Tests` cells to avoid flaky test behavior.

### Description
- Add a small fixture file `tests/fixtures/roadmap_small_catalog.md` containing a compact roadmap catalog used by the tests.
- Update `tests/test_roadmap.py` to use the fixture and strengthen `test_proposals_prioritize_unimplemented_features` to assert exact `feature_id` order and exact priorities for a controlled subset.
- Add `test_proposals_are_deterministic_for_equal_priorities` to assert stable ordering for equal-priority entries and `test_parse_function_catalog_handles_invalid_tests_cell_as_zero_zero` to validate fallback parsing of malformed `Tests` cells and inclusion in the proposal rationale.
- Extend `test_render_proposals_markdown_contains_sections` to check per-proposal completeness, ensuring each proposal has a title, rationale, at least three action items, and at least three acceptance criteria.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_roadmap.py` and all tests in that file passed (7 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a85d7e19308328830d0fe82f8ab9e8)