### PR TITLE
Restructure API response to include datasets and nested summary

### DIFF
--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -31,24 +31,44 @@ router = APIRouter()
 
 def _report_json(report, markdown: str) -> dict:
     """Serialise an AnalysisReport for the API response."""
-    from kwb.core.models import Severity
-    findings = [
-        f for f in report.findings
-        if f.severity in (Severity.CRITICAL, Severity.WARNING)
-    ]
     s = report.summary
+    datasets = [
+        {
+            "source_name": dp.source_name,
+            "row_count": dp.row_count,
+            "column_count": dp.column_count,
+            "id_column": dp.id_column,
+            "columns": [
+                {
+                    "name": c.name,
+                    "fill_rate": c.fill_rate,
+                    "unique_count": c.unique_count,
+                    "sample_values": c.sample_values[:5],
+                }
+                for c in dp.columns
+            ],
+        }
+        for dp in report.datasets
+    ]
     return {
-        "total_rows": s.get("total_records", 0),
-        "total_columns": s.get("total_columns", 0),
-        "total_findings": s.get("total_findings", 0),
+        "summary": {
+            "total_records": s.get("total_records", 0),
+            "total_columns": s.get("total_columns", 0),
+            "critical": s.get("critical", 0),
+            "warnings": s.get("warnings", 0),
+            "info": s.get("info", 0),
+        },
+        "datasets": datasets,
         "findings": [
             {
                 "message": f.message,
                 "severity": f.severity.value,
+                "category": f.category.value,
                 "column": f.column,
+                "suggestion": f.suggestion,
                 "record_ids": f.record_ids[:10],
             }
-            for f in findings[:200]
+            for f in report.findings[:200]
         ],
         "markdown": markdown,
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -145,13 +145,13 @@ class TestCSVIngest(unittest.TestCase):
 
     def test_analyze_returns_report(self):
         data = self._ingest()
-        self.assertIn("total_rows", data)
-        self.assertEqual(data["total_rows"], 5)
+        self.assertIn("summary", data)
+        self.assertEqual(data["summary"]["total_records"], 5)
 
     def test_analyze_reports_columns(self):
         data = self._ingest()
-        self.assertIn("total_columns", data)
-        self.assertEqual(data["total_columns"], 5)
+        self.assertIn("summary", data)
+        self.assertEqual(data["summary"]["total_columns"], 5)
 
     def test_dataset_columns_endpoint(self):
         self._ingest()


### PR DESCRIPTION
## Summary
Refactored the `/analyze` API response structure to provide more detailed dataset information and organize summary metrics under a dedicated `summary` object.

## Key Changes
- **Restructured response format**: Moved top-level metrics (`total_rows`, `total_columns`, `total_findings`) into a nested `summary` object with renamed fields (`total_records`, `total_columns`, `critical`, `warnings`, `info`)
- **Added datasets array**: New `datasets` field containing detailed information about each analyzed dataset, including:
  - Source name, row count, and column count
  - Per-column metadata (name, fill_rate, unique_count, sample_values)
- **Enhanced findings**: Added `category` and `suggestion` fields to finding objects for richer context
- **Removed severity filtering**: Changed from filtering findings by severity (CRITICAL/WARNING only) to returning all findings (up to 200), allowing clients to filter as needed
- **Updated tests**: Modified test assertions to reflect the new nested response structure

## Implementation Details
- The datasets structure mirrors the `report.datasets` model, providing comprehensive data quality metrics at both dataset and column levels
- Sample values are limited to the first 5 items per column to keep response size manageable
- Findings are now limited to 200 items (previously filtered by severity) to provide complete visibility while maintaining performance

https://claude.ai/code/session_012RLzVRLbCU2X7Vcu5oYqvW