### PR TITLE
Add image review triage and export integration

### DIFF
--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -292,6 +292,17 @@ label{display:block;font-size:.73rem;font-weight:600;margin-top:.5rem;color:#555
 <button class="btn" style="margin-top:.5rem" onclick="exportJSONLD()">⬇️ JSON-LD herunterladen</button>
 </div>
 
+
+<div class="c" style="margin-top:1rem"><h2>Bildresultate-Export</h2>
+<p style="font-size:.78rem;color:#666;margin-bottom:.5rem">Exportiert Vision-Ergebnisse inkl. Review-Status, Konfidenz und Provenienz (CSV/JSON-LD).</p>
+<div style="display:flex;gap:.4rem;align-items:center;flex-wrap:wrap">
+<label style="font-size:.75rem">Filter</label>
+<select id="exp-img-status" style="width:180px"><option value="">Alle</option><option value="pending">pending</option><option value="accepted">accepted</option><option value="rejected">rejected</option></select>
+<button class="btn" onclick="exportImageResults('csv')">⬇️ Bildresultate CSV</button>
+<button class="btn s" onclick="exportImageResults('jsonld')">⬇️ Bildresultate JSON-LD</button>
+</div>
+</div>
+
 <div class="c" style="margin-top:1rem"><h2>Workspace-Export</h2>
 <div style="display:flex;gap:.5rem">
 <button class="btn" onclick="saveWS()">💾 Workspace speichern</button>
@@ -352,6 +363,7 @@ const GOOBI_TYPES=[
 let ufiles={},curRep=null,gpuM=[],nerData=[],edtfData=[];
 let nerStatusFilter='all', nerTypeFilter='all';
 let fmMapping={}; // current field mapping state
+let latestImageResults=[];
 
 // === SECURITY ===
 function esc(s){return s==null?'':String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
@@ -765,23 +777,58 @@ async function analyzeImages(){
 }
 
 function renderImgResults(results){
+  latestImageResults = results || [];
   const el=$('img-results');
   const empty=$('img-results-empty');
-  if(!results.length){empty.style.display='block';el.innerHTML='';return}
+  if(!latestImageResults.length){empty.style.display='block';el.innerHTML='';return}
   empty.style.display='none';
-  el.innerHTML = results.map(res=>{
+  el.innerHTML = latestImageResults.map(function(res, idx){
     if(res.error) return '<div class="card" style="border-color:#e55"><strong>'+esc(res.id||res.filename||'')+'</strong><br><span style="color:#c00">'+esc(res.error)+'</span></div>';
     var r = res.result || {};
+    var status = res.review_status || 'pending';
     return '<div class="card" style="margin-bottom:.5rem">'
       +'<strong style="font-size:.8rem">'+esc(res.filename||res.id)+'</strong>'
-      +'<p style="font-size:.78rem;margin:.3rem 0">'+esc(r.description||'')+'</p>'
-      +(r.objects&&r.objects.length?'<div style="font-size:.72rem;color:#555">Objekte: '+r.objects.map(esc).join(', ')+'</div>':'')
+      +'<div style="display:grid;grid-template-columns:1fr 1fr;gap:.4rem;margin:.35rem 0">'
+      +'<input type="text" id="img-record-'+idx+'" placeholder="record_id (optional)" value="'+esc(res.record_id||'')+'">'
+      +'<select id="img-status-'+idx+'"><option value="pending"'+(status==='pending'?' selected':'')+'>pending</option><option value="accepted"'+(status==='accepted'?' selected':'')+'>accepted</option><option value="rejected"'+(status==='rejected'?' selected':'')+'>rejected</option></select>'
+      +'</div>'
+      +'<textarea id="img-desc-'+idx+'" style="height:4rem">'+esc(r.description||'')+'</textarea>'
+      +'<p style="font-size:.78rem;margin:.3rem 0">Objekte: '+esc((r.objects||[]).join(', '))+'</p>'
       +(r.period?'<div style="font-size:.72rem;color:#555">Periode: '+esc(r.period)+'</div>':'')
       +(r.confidence?'<div style="font-size:.65rem;color:#888">Konfidenz: '+(r.confidence*100).toFixed(0)+'%</div>':'')
+      +'<input type="text" id="img-comment-'+idx+'" placeholder="Kommentar" value="'+esc(res.review_comment||'')+'" style="margin-top:.25rem">'
+      +'<input type="text" id="img-reviewer-'+idx+'" placeholder="Reviewer" value="'+esc(res.reviewer||'')+'" style="margin-top:.25rem">'
+      +'<div style="display:flex;gap:.3rem;margin-top:.35rem">'
+      +'<button class="btn sm" onclick="saveImageReview('+idx+',\'pending\')">💾 anpassen</button>'
+      +'<button class="btn sm" style="background:var(--ok)" onclick="saveImageReview('+idx+',\'accepted\')">✅ bestätigen</button>'
+      +'<button class="btn sm" style="background:var(--crit)" onclick="saveImageReview('+idx+',\'rejected\')">🗑 verwerfen</button>'
+      +'</div>'
       +'</div>';
   }).join('');
 }
 
+async function saveImageReview(idx, forceStatus){
+  const item = latestImageResults[idx];
+  if(!item)return;
+  const payload={
+    status:forceStatus || $('img-status-'+idx).value,
+    record_id:$('img-record-'+idx).value,
+    comment:$('img-comment-'+idx).value,
+    reviewer:$('img-reviewer-'+idx).value,
+    result_updates:{description:$('img-desc-'+idx).value}
+  };
+  try{
+    const r=await fetch('/api/images/'+encodeURIComponent(item.id)+'/review',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)});
+    const d=await r.json();
+    if(d.error){alert('Review-Fehler: '+d.error);return;}
+    item.review_status=d.image.review_status;
+    item.review_comment=d.image.review_comment;
+    item.reviewer=d.image.reviewer;
+    item.record_id=d.image.record_id;
+    item.result=d.image.result;
+    renderImgResults(latestImageResults);
+  }catch(e){alert('Review-Fehler: '+e.message);}
+}
 
 // === WIKIDATA ===
 async function runWikidataLookup(){
@@ -793,6 +840,22 @@ async function runWikidataLookup(){
     alert('Wikidata: '+(r.matched||0)+' von '+(r.total||0)+' Entitäten gefunden und im Wörterbuch gespeichert.');
     updWS();
   }catch(e){alert('Fehler: '+e.message);}finally{hp();}
+}
+
+
+async function loadImages(){
+  try{
+    const r=await fetch('/api/images');
+    const d=await r.json();
+    uploadedImages=d.images||[];
+    renderImgGrid();
+    const reviewed=uploadedImages.filter(i=>i.result).map(i=>({
+      id:i.id,filename:i.filename,result:i.result,record_id:i.record_id||'',
+      review_status:i.review_status||'pending',review_comment:i.review_comment||'',
+      reviewer:i.reviewer||''
+    }));
+    if(reviewed.length) renderImgResults(reviewed);
+  }catch(e){}
 }
 
 // === OCR ===
@@ -844,6 +907,19 @@ async function exportCSV(){
 }
 
 // === JSON-LD EXPORT ===
+async function exportImageResults(format){
+  sp('Bildresultate Export …','');
+  try{
+    const st=($('exp-img-status')&&$('exp-img-status').value)||'';
+    const r=await fetch('/api/export/image-results',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({format:format,review_status:st,as_file:true})});
+    if(!r.ok){var e=await r.json();alert('Fehler: '+(e.error||r.statusText));hp();return;}
+    var blob=await r.blob();
+    if(format==='jsonld') dl('image_results.jsonld',await blob.text(),'application/ld+json');
+    else dl('image_results.csv',await blob.text(),'text/csv;charset=utf-8-sig');
+  }catch(e){alert('Fehler: '+e.message);}finally{hp();}
+}
+
 async function exportJSONLD(){
   const ds=($('exp-ld-ds')&&$('exp-ld-ds').value)||($('exp-ds')&&$('exp-ds').value)||'';
   if(!ds){alert('Datensatz wählen');return;}
@@ -868,7 +944,7 @@ function hp(){$('po').classList.remove('a')}
 // === INIT ===
 (function(){loadPreset(); applyImgPreset();
   $('cfg-tasks').innerHTML=Object.values(TASKS).map(t=>'<div class="ft"><span class="bg ac">'+esc(t.type||'')+'</span><div><strong>'+esc(t.name)+'</strong><br><span class="d">'+esc(t.description||'')+'</span></div></div>').join('');
-  renderCatalog();chkGPU();updWS()})();
+  renderCatalog();chkGPU();updWS();loadImages()})();
 </script>
 </body>
 </html>

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -238,6 +238,18 @@ label{display:block;font-size:.73rem;font-weight:600;margin-top:.5rem;color:#555
 <div id="img-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:.6rem;margin-top:.4rem"></div>
 
 <h3 style="margin-top:1rem">Analyseergebnisse</h3>
+<div style="display:flex;gap:.35rem;align-items:center;flex-wrap:wrap;margin:.35rem 0">
+<select id="img-review-filter" style="width:170px" onchange="applyImageFilter()">
+  <option value="all">Alle Status</option>
+  <option value="pending">pending</option>
+  <option value="accepted">accepted</option>
+  <option value="rejected">rejected</option>
+</select>
+<input type="text" id="img-bulk-reviewer" placeholder="Reviewer (Bulk)" style="width:180px">
+<input type="text" id="img-bulk-comment" placeholder="Kommentar (Bulk)">
+<button class="btn sm" onclick="bulkReviewVisible('accepted')">Alle sichtbaren bestätigen</button>
+<button class="btn sm" style="background:var(--crit)" onclick="bulkReviewVisible('rejected')">Alle sichtbaren verwerfen</button>
+</div>
 <div id="img-results-empty" class="em" style="font-size:.78rem">Noch keine Ergebnisse.</div>
 <div id="img-results"></div>
 </div></div>
@@ -364,6 +376,7 @@ let ufiles={},curRep=null,gpuM=[],nerData=[],edtfData=[];
 let nerStatusFilter='all', nerTypeFilter='all';
 let fmMapping={}; // current field mapping state
 let latestImageResults=[];
+let filteredImageResults=[];
 
 // === SECURITY ===
 function esc(s){return s==null?'':String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
@@ -778,11 +791,20 @@ async function analyzeImages(){
 
 function renderImgResults(results){
   latestImageResults = results || [];
+  applyImageFilter();
+}
+
+function applyImageFilter(){
   const el=$('img-results');
   const empty=$('img-results-empty');
-  if(!latestImageResults.length){empty.style.display='block';el.innerHTML='';return}
+  const filter=($('img-review-filter')&&$('img-review-filter').value)||'all';
+  filteredImageResults = latestImageResults.filter(function(res){
+    return filter==='all' || (res.review_status||'pending')===filter;
+  });
+  if(!filteredImageResults.length){empty.style.display='block';el.innerHTML='';return}
   empty.style.display='none';
-  el.innerHTML = latestImageResults.map(function(res, idx){
+  el.innerHTML = filteredImageResults.map(function(res, idx){
+    const originalIdx = latestImageResults.indexOf(res);
     if(res.error) return '<div class="card" style="border-color:#e55"><strong>'+esc(res.id||res.filename||'')+'</strong><br><span style="color:#c00">'+esc(res.error)+'</span></div>';
     var r = res.result || {};
     var status = res.review_status || 'pending';
@@ -803,12 +825,13 @@ function renderImgResults(results){
       +'<button class="btn sm" style="background:var(--ok)" onclick="saveImageReview('+idx+',\'accepted\')">✅ bestätigen</button>'
       +'<button class="btn sm" style="background:var(--crit)" onclick="saveImageReview('+idx+',\'rejected\')">🗑 verwerfen</button>'
       +'</div>'
+      +'<div style="font-size:.65rem;color:#777;margin-top:.2rem">ID: '+esc(res.id)+' • #'+(originalIdx+1)+'</div>'
       +'</div>';
   }).join('');
 }
 
 async function saveImageReview(idx, forceStatus){
-  const item = latestImageResults[idx];
+  const item = filteredImageResults[idx];
   if(!item)return;
   const payload={
     status:forceStatus || $('img-status-'+idx).value,
@@ -826,7 +849,7 @@ async function saveImageReview(idx, forceStatus){
     item.reviewer=d.image.reviewer;
     item.record_id=d.image.record_id;
     item.result=d.image.result;
-    renderImgResults(latestImageResults);
+    applyImageFilter();
   }catch(e){alert('Review-Fehler: '+e.message);}
 }
 
@@ -842,6 +865,30 @@ async function runWikidataLookup(){
   }catch(e){alert('Fehler: '+e.message);}finally{hp();}
 }
 
+
+
+async function bulkReviewVisible(status){
+  const ids=filteredImageResults.filter(x=>!x.error).map(x=>x.id);
+  if(!ids.length){alert('Keine sichtbaren Ergebnisse.');return;}
+  try{
+    const r=await fetch('/api/images/review/batch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({
+      image_ids:ids,
+      status:status,
+      reviewer:$('img-bulk-reviewer')?$('img-bulk-reviewer').value:'',
+      comment:$('img-bulk-comment')?$('img-bulk-comment').value:''
+    })});
+    const d=await r.json();
+    if(d.error){alert('Bulk-Review-Fehler: '+d.error);return;}
+    latestImageResults.forEach(function(item){
+      if(ids.includes(item.id)){
+        item.review_status=status;
+        if($('img-bulk-reviewer') && $('img-bulk-reviewer').value) item.reviewer=$('img-bulk-reviewer').value;
+        if($('img-bulk-comment') && $('img-bulk-comment').value) item.review_comment=$('img-bulk-comment').value;
+      }
+    });
+    applyImageFilter();
+  }catch(e){alert('Bulk-Review-Fehler: '+e.message);}
+}
 
 async function loadImages(){
   try{

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -869,6 +869,7 @@ async function runWikidataLookup(){
 
 async function bulkReviewVisible(status){
   const ids=filteredImageResults.filter(x=>!x.error).map(x=>x.id);
+  if(!confirm('Bulk-Review für '+ids.length+' sichtbare Ergebnisse ausführen?')) return;
   if(!ids.length){alert('Keine sichtbaren Ergebnisse.');return;}
   try{
     const r=await fetch('/api/images/review/batch',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -28,7 +28,7 @@ from kwb.api.deps import (
 from kwb.ai.provider import AIMessage
 from kwb.ai.batch import process_batch
 from kwb.ai.prompts import SYSTEM_VISION_EXPERT_DE, SYSTEM_METADATA_EXPERT_DE
-from kwb.core.workspace import ImageAnalysisResult
+from kwb.core.workspace import ImageAnalysisResult, ImageReviewStatus
 
 router = APIRouter()
 
@@ -174,6 +174,11 @@ def _sync_index() -> None:
                     "path": str(p),
                     "analyzed": ws_result.analyzed if ws_result else False,
                     "result": ws_result.result if ws_result else None,
+                    "record_id": ws_result.record_id if ws_result else "",
+                    "review_status": ws_result.review_status.value if ws_result else "pending",
+                    "review_comment": ws_result.review_comment if ws_result else "",
+                    "reviewer": ws_result.reviewer if ws_result else "",
+                    "reviewed_at": ws_result.reviewed_at if ws_result else "",
                 }
 
 
@@ -220,6 +225,11 @@ async def images_upload(files: list[UploadFile] = File(...)):
             "path": str(img_path),
             "analyzed": False,
             "result": None,
+            "record_id": "",
+            "review_status": "pending",
+            "review_comment": "",
+            "reviewer": "",
+            "reviewed_at": "",
         }
         accepted.append({
             "id": img_id,
@@ -252,6 +262,11 @@ async def images_list():
                 "id": img["id"], "filename": img["filename"],
                 "size_bytes": img["size_bytes"], "analyzed": img["analyzed"],
                 "result": img["result"],
+                "record_id": img.get("record_id", ""),
+                "review_status": img.get("review_status", "pending"),
+                "review_comment": img.get("review_comment", ""),
+                "reviewer": img.get("reviewer", ""),
+                "reviewed_at": img.get("reviewed_at", ""),
             }
             for img in _uploaded_images.values()
         ]
@@ -269,6 +284,7 @@ async def images_analyze(request: dict):
         system_prompt: str     — optional system prompt override
     """
     image_ids = request.get("image_ids", list(_uploaded_images.keys()))
+    image_record_map = request.get("image_record_map", {})
     mod = request.get("model", "")
     syp = request.get("system_prompt", SYSTEM_VISION_EXPERT_DE)
 
@@ -305,7 +321,14 @@ async def images_analyze(request: dict):
             parsed = try_parse_json(resp.content) or {"description": resp.content}
             img["analyzed"] = True
             img["result"] = parsed
-            results.append({"id": img_id, "filename": img["filename"], "result": parsed})
+            img["record_id"] = image_record_map.get(img_id, img.get("record_id", ""))
+            results.append({
+                "id": img_id,
+                "filename": img["filename"],
+                "record_id": img.get("record_id", ""),
+                "review_status": img.get("review_status", "pending"),
+                "result": parsed,
+            })
 
             # Persist to workspace and auto-save to disk (ARCH-03)
             from datetime import datetime
@@ -318,6 +341,11 @@ async def images_analyze(request: dict):
                 result=parsed,
                 model=mod or "default",
                 analyzed_at=datetime.utcnow().isoformat(),
+                record_id=img.get("record_id", ""),
+                review_status=ImageReviewStatus(img.get("review_status", "pending")),
+                review_comment=img.get("review_comment", ""),
+                reviewer=img.get("reviewer", ""),
+                reviewed_at=img.get("reviewed_at", ""),
             ))
             ws.save(workspace_dir() / safe_filename(ws.name))
 
@@ -333,6 +361,80 @@ async def images_analyze(request: dict):
         "analyzed": len([r for r in results if "result" in r]),
         "model": mod or "default",
         "results": results,
+    }
+
+
+@router.post("/api/images/{img_id}/review")
+async def image_review_update(img_id: str, request: dict):
+    """Update review decision and optional corrected result for one image analysis."""
+    img = _uploaded_images.get(img_id)
+    if not img:
+        return JSONResponse({"error": "Nicht gefunden"}, 404)
+
+    status_raw = request.get("status", "pending")
+    try:
+        status = ImageReviewStatus(status_raw)
+    except ValueError:
+        return JSONResponse({"error": "Ungültiger Review-Status"}, 400)
+
+    comment = request.get("comment", "")
+    reviewer = request.get("reviewer", "")
+    result_updates = request.get("result_updates") or {}
+    record_id = request.get("record_id", img.get("record_id", ""))
+
+    if result_updates:
+        if not isinstance(img.get("result"), dict):
+            img["result"] = {}
+        img["result"].update(result_updates)
+
+    img["record_id"] = record_id
+    img["review_status"] = status.value
+    img["review_comment"] = comment
+    img["reviewer"] = reviewer
+    from datetime import datetime
+    img["reviewed_at"] = datetime.utcnow().isoformat()
+
+    ws = get_workspace()
+    existing = ws.get_image_analysis(img_id)
+    if existing:
+        existing.result = img.get("result") or {}
+        existing.record_id = record_id
+        existing.update_review(
+            status=status,
+            comment=comment,
+            reviewer=reviewer,
+        )
+        ws.save_image_analysis(existing)
+    else:
+        ana = ImageAnalysisResult(
+            image_id=img_id,
+            filename=img.get("filename", ""),
+            media_type=img.get("media_type", ""),
+            analyzed=bool(img.get("analyzed")),
+            result=img.get("result") or {},
+            model="manual",
+            analyzed_at="",
+            record_id=record_id,
+            review_status=status,
+            review_comment=comment,
+            reviewer=reviewer,
+            reviewed_at=img["reviewed_at"],
+        )
+        ws.save_image_analysis(ana)
+
+    ws.save(workspace_dir() / safe_filename(ws.name))
+
+    return {
+        "ok": True,
+        "image": {
+            "id": img_id,
+            "record_id": img["record_id"],
+            "review_status": img["review_status"],
+            "review_comment": img["review_comment"],
+            "reviewer": img["reviewer"],
+            "reviewed_at": img["reviewed_at"],
+            "result": img.get("result") or {},
+        },
     }
 
 
@@ -366,6 +468,7 @@ async def images_ocr(request: dict):
     from kwb.core.utils import try_parse_json
 
     image_ids = request.get("image_ids", list(_uploaded_images.keys()))
+    image_record_map = request.get("image_record_map", {})
     mod = request.get("model", "")
     ctx = request.get("additional_context", "")
 

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -438,6 +438,53 @@ async def image_review_update(img_id: str, request: dict):
     }
 
 
+
+
+@router.post("/api/images/review/batch")
+async def image_review_batch(request: dict):
+    """Batch-update review decisions for multiple image analyses."""
+    image_ids = request.get("image_ids", [])
+    if not image_ids:
+        return JSONResponse({"error": "Keine Bilder ausgewählt"}, 400)
+
+    status_raw = request.get("status", "pending")
+    try:
+        status = ImageReviewStatus(status_raw)
+    except ValueError:
+        return JSONResponse({"error": "Ungültiger Review-Status"}, 400)
+
+    comment = request.get("comment", "")
+    reviewer = request.get("reviewer", "")
+
+    ws = get_workspace()
+    updated = 0
+    from datetime import datetime
+
+    for img_id in image_ids:
+        img = _uploaded_images.get(img_id)
+        if not img:
+            continue
+
+        img["review_status"] = status.value
+        if comment:
+            img["review_comment"] = comment
+        if reviewer:
+            img["reviewer"] = reviewer
+        img["reviewed_at"] = datetime.utcnow().isoformat()
+
+        existing = ws.get_image_analysis(img_id)
+        if existing:
+            existing.update_review(
+                status=status,
+                comment=img.get("review_comment", ""),
+                reviewer=img.get("reviewer", ""),
+            )
+            ws.save_image_analysis(existing)
+            updated += 1
+
+    ws.save(workspace_dir() / safe_filename(ws.name))
+    return {"updated": updated, "status": status.value}
+
 @router.delete("/api/images")
 async def images_clear():
     """Clear all uploaded images from memory and disk."""

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -32,6 +32,13 @@ from kwb.core.workspace import ImageAnalysisResult, ImageReviewStatus
 
 router = APIRouter()
 
+
+def _parse_image_review_status(status_raw: str) -> ImageReviewStatus | None:
+    try:
+        return ImageReviewStatus(status_raw)
+    except ValueError:
+        return None
+
 # ---------------------------------------------------------------------------
 # GPU / Provider status
 # ---------------------------------------------------------------------------
@@ -372,9 +379,8 @@ async def image_review_update(img_id: str, request: dict):
         return JSONResponse({"error": "Nicht gefunden"}, 404)
 
     status_raw = request.get("status", "pending")
-    try:
-        status = ImageReviewStatus(status_raw)
-    except ValueError:
+    status = _parse_image_review_status(status_raw)
+    if status is None:
         return JSONResponse({"error": "Ungültiger Review-Status"}, 400)
 
     comment = request.get("comment", "")
@@ -448,9 +454,8 @@ async def image_review_batch(request: dict):
         return JSONResponse({"error": "Keine Bilder ausgewählt"}, 400)
 
     status_raw = request.get("status", "pending")
-    try:
-        status = ImageReviewStatus(status_raw)
-    except ValueError:
+    status = _parse_image_review_status(status_raw)
+    if status is None:
         return JSONResponse({"error": "Ungültiger Review-Status"}, 400)
 
     comment = request.get("comment", "")

--- a/src/kwb/api/routes/export.py
+++ b/src/kwb/api/routes/export.py
@@ -5,6 +5,9 @@ Router prefix: /api
 """
 from __future__ import annotations
 
+import csv
+import io
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -19,6 +22,57 @@ from kwb.api.deps import get_datasets, get_workspace
 from kwb.export.goobi_xml import export_goobi_xml, export_goobi_batch
 
 router = APIRouter()
+
+
+def _build_image_result_rows(ws):
+    rows = []
+    for r in ws.image_analyses:
+        payload = r.result if isinstance(r.result, dict) else {}
+        rows.append({
+            "image_id": r.image_id,
+            "record_id": r.record_id,
+            "filename": r.filename,
+            "review_status": r.review_status.value,
+            "review_comment": r.review_comment,
+            "reviewer": r.reviewer,
+            "confidence": r.confidence,
+            "description": payload.get("description", ""),
+            "objects": "; ".join(payload.get("objects", []) or []),
+            "persons": "; ".join(payload.get("persons", []) or []),
+            "places": "; ".join(payload.get("places", []) or []),
+            "style": payload.get("style", ""),
+            "period": payload.get("period", ""),
+            "provenance": json.dumps(r.provenance, ensure_ascii=False),
+        })
+    return rows
+
+
+def _image_rows_as_jsonld(rows, base_url: str = "https://example.org/images/") -> dict:
+    context = {
+        "@vocab": "https://schema.org/",
+        "prov": "http://www.w3.org/ns/prov#",
+        "reviewStatus": "prov:wasInvalidatedBy",
+        "confidence": "http://example.org/vocab/confidence",
+    }
+    graph = []
+    for row in rows:
+        graph.append({
+            "@id": f"{base_url}{row['image_id']}",
+            "@type": "ImageObject",
+            "identifier": row["image_id"],
+            "name": row["filename"],
+            "isPartOf": row.get("record_id") or None,
+            "description": row.get("description", ""),
+            "keywords": [x for x in row.get("objects", "").split("; ") if x],
+            "contentLocation": [x for x in row.get("places", "").split("; ") if x],
+            "about": [x for x in row.get("persons", "").split("; ") if x],
+            "confidence": row.get("confidence", 0),
+            "reviewStatus": row.get("review_status", "pending"),
+            "comment": row.get("review_comment", ""),
+            "creator": row.get("reviewer", ""),
+            "prov:wasGeneratedBy": row.get("provenance", ""),
+        })
+    return {"@context": context, "@graph": graph}
 
 
 @router.post("/api/export/goobi-preview")
@@ -164,3 +218,44 @@ async def export_jsonld_route(request: dict):
     except Exception as e:
         return JSONResponse({"error": str(e)}, 500)
 
+
+
+@router.post("/api/export/image-results")
+async def export_image_results(request: dict):
+    """Export image analysis results including review status and provenance."""
+    ws = get_workspace()
+    rows = _build_image_result_rows(ws)
+    review_status = request.get("review_status", "")
+    if review_status:
+        rows = [r for r in rows if r["review_status"] == review_status]
+
+    fmt = (request.get("format", "csv") or "csv").lower()
+    if fmt == "csv":
+        fieldnames = [
+            "image_id", "record_id", "filename", "review_status", "review_comment",
+            "reviewer", "confidence", "description", "objects", "persons", "places",
+            "style", "period", "provenance",
+        ]
+        buf = io.StringIO()
+        w = csv.DictWriter(buf, fieldnames=fieldnames)
+        w.writeheader()
+        w.writerows(rows)
+        return Response(
+            content=("\ufeff" + buf.getvalue()).encode("utf-8"),
+            media_type="text/csv; charset=utf-8-sig",
+            headers={"Content-Disposition": 'attachment; filename="image_results.csv"'},
+        )
+
+    if fmt == "jsonld":
+        base_url = request.get("base_url", "https://example.org/images/")
+        doc = _image_rows_as_jsonld(rows, base_url=base_url)
+        payload = json.dumps(doc, ensure_ascii=False, indent=2).encode("utf-8")
+        if request.get("as_file", True):
+            return Response(
+                content=payload,
+                media_type="application/ld+json",
+                headers={"Content-Disposition": 'attachment; filename="image_results.jsonld"'},
+            )
+        return {"jsonld": doc, "count": len(rows)}
+
+    return JSONResponse({"error": "format must be csv or jsonld"}, 400)

--- a/src/kwb/api/routes/export.py
+++ b/src/kwb/api/routes/export.py
@@ -47,6 +47,16 @@ def _build_image_result_rows(ws):
     return rows
 
 
+
+
+def _validate_review_status(review_status: str, rows: list[dict]) -> list[dict]:
+    if not review_status:
+        return rows
+    allowed = {"pending", "accepted", "rejected"}
+    if review_status not in allowed:
+        return []
+    return [r for r in rows if r["review_status"] == review_status]
+
 def _image_rows_as_jsonld(rows, base_url: str = "https://example.org/images/") -> dict:
     context = {
         "@vocab": "https://schema.org/",
@@ -226,8 +236,9 @@ async def export_image_results(request: dict):
     ws = get_workspace()
     rows = _build_image_result_rows(ws)
     review_status = request.get("review_status", "")
-    if review_status:
-        rows = [r for r in rows if r["review_status"] == review_status]
+    rows = _validate_review_status(review_status, rows)
+    if review_status and not rows:
+        return JSONResponse({"error": "Ungültiger oder leerer review_status-Filter"}, 400)
 
     fmt = (request.get("format", "csv") or "csv").lower()
     if fmt == "csv":

--- a/src/kwb/core/workspace.py
+++ b/src/kwb/core/workspace.py
@@ -289,6 +289,10 @@ class ImageAnalysisResult:
         return 0.0
 
     @property
+    def is_reviewed(self) -> bool:
+        return bool(self.reviewed_at and self.review_status != ImageReviewStatus.PENDING)
+
+    @property
     def provenance(self) -> dict:
         return {
             "source": "vision_ai",

--- a/src/kwb/core/workspace.py
+++ b/src/kwb/core/workspace.py
@@ -144,6 +144,12 @@ class ReviewStatus(str, Enum):
     MERGED   = "merged"
 
 
+class ImageReviewStatus(str, Enum):
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
 @dataclass
 class EntityReview:
     """Review decision for one named entity candidate."""
@@ -267,6 +273,47 @@ class ImageAnalysisResult:
     result: dict = field(default_factory=dict)
     model: str = ""
     analyzed_at: str = ""
+    record_id: str = ""
+    review_status: ImageReviewStatus = ImageReviewStatus.PENDING
+    review_comment: str = ""
+    reviewer: str = ""
+    reviewed_at: str = ""
+
+    @property
+    def confidence(self) -> float:
+        if isinstance(self.result, dict):
+            try:
+                return float(self.result.get("confidence", 0.0) or 0.0)
+            except (TypeError, ValueError):
+                return 0.0
+        return 0.0
+
+    @property
+    def provenance(self) -> dict:
+        return {
+            "source": "vision_ai",
+            "model": self.model,
+            "analyzed_at": self.analyzed_at,
+            "reviewed_at": self.reviewed_at,
+            "reviewer": self.reviewer,
+        }
+
+    def update_review(
+        self,
+        *,
+        status: ImageReviewStatus | str,
+        comment: str = "",
+        reviewer: str = "",
+        result_updates: dict | None = None,
+    ) -> None:
+        self.review_status = ImageReviewStatus(status) if isinstance(status, str) else status
+        self.review_comment = comment
+        self.reviewer = reviewer
+        if result_updates:
+            if not isinstance(self.result, dict):
+                self.result = {}
+            self.result.update(result_updates)
+        self.reviewed_at = datetime.utcnow().isoformat()
 
     def to_dict(self) -> dict:
         return {
@@ -277,6 +324,11 @@ class ImageAnalysisResult:
             "result": self.result,
             "model": self.model,
             "analyzed_at": self.analyzed_at,
+            "record_id": self.record_id,
+            "review_status": self.review_status.value,
+            "review_comment": self.review_comment,
+            "reviewer": self.reviewer,
+            "reviewed_at": self.reviewed_at,
         }
 
     @staticmethod
@@ -289,6 +341,11 @@ class ImageAnalysisResult:
             result=d.get("result", {}),
             model=d.get("model", ""),
             analyzed_at=d.get("analyzed_at", ""),
+            record_id=d.get("record_id", ""),
+            review_status=ImageReviewStatus(d.get("review_status", "pending")),
+            review_comment=d.get("review_comment", ""),
+            reviewer=d.get("reviewer", ""),
+            reviewed_at=d.get("reviewed_at", ""),
         )
 
 
@@ -573,6 +630,18 @@ class Workspace:
                 return r
         return None
 
+    def image_review_stats(self) -> dict[str, int]:
+        stats: dict[str, int] = {s.value: 0 for s in ImageReviewStatus}
+        for r in self.image_analyses:
+            stats[r.review_status.value] += 1
+        stats["total"] = len(self.image_analyses)
+        return stats
+
+    def reviewed_image_analyses(self, status: ImageReviewStatus | None = None) -> list[ImageAnalysisResult]:
+        if status is None:
+            return list(self.image_analyses)
+        return [r for r in self.image_analyses if r.review_status == status]
+
     # ------------------------------------------------------------------
     # AI run logging
     # ------------------------------------------------------------------
@@ -603,6 +672,8 @@ class Workspace:
             "entity_status": self.entities_by_status(),
             "ai_runs": len(self.ai_runs),
             "source_files": self.source_files,
+            "image_analysis_count": len(self.image_analyses),
+            "image_review_status": self.image_review_stats(),
         }
 
     # ------------------------------------------------------------------

--- a/src/kwb/export/csv_export.py
+++ b/src/kwb/export/csv_export.py
@@ -42,6 +42,7 @@ def export_enriched_csv(
     include_ner: bool = True,
     include_edtf: bool = True,
     include_gnd: bool = True,
+    include_image_review: bool = True,
     id_column: str = "record_id",
     separator: str = "; ",
 ) -> str:
@@ -124,6 +125,38 @@ def export_enriched_csv(
                 )
             else:
                 out[new_col] = ""
+
+    # ------------------------------------------------------------------
+    # Accepted image analysis columns (mapped via field_mapping image.*)
+    # ------------------------------------------------------------------
+    if include_image_review and workspace.image_analyses:
+        image_rows: dict[str, dict[str, str]] = {}
+        for img in workspace.image_analyses:
+            if img.review_status.value != "accepted":
+                continue
+            rid = img.record_id
+            if not rid:
+                continue
+            payload = img.result if isinstance(img.result, dict) else {}
+            image_rows.setdefault(rid, {})
+            image_rows[rid]["image_review_status"] = img.review_status.value
+            image_rows[rid]["image_review_comment"] = img.review_comment
+            image_rows[rid]["image_reviewer"] = img.reviewer
+            for k, v in payload.items():
+                col_name = f"image_{k}"
+                if isinstance(v, list):
+                    rendered = separator.join(str(x) for x in v if str(x).strip())
+                else:
+                    rendered = str(v)
+                if rendered.strip():
+                    image_rows[rid][col_name] = rendered
+
+        image_cols = sorted({k for row in image_rows.values() for k in row.keys()})
+        for col in image_cols:
+            if id_column in out.columns:
+                out[col] = out[id_column].astype(str).map(lambda rid: image_rows.get(rid, {}).get(col, ""))
+            else:
+                out[col] = ""
 
     # ------------------------------------------------------------------
     # GND columns — add gnd_id / gnd_preferred for known terms

--- a/src/kwb/export/goobi_xml.py
+++ b/src/kwb/export/goobi_xml.py
@@ -112,6 +112,44 @@ def _parse_name(full_name: str) -> tuple[str, str]:
     return "", full_name.strip()
 
 
+
+
+def _iter_accepted_image_metadata(workspace: Workspace, record_id: str):
+    """Yield tuples of (key, value) for accepted image analyses mapped to a record."""
+    for analysis in workspace.image_analyses:
+        if analysis.record_id != record_id:
+            continue
+        if analysis.review_status.value != "accepted":
+            continue
+        payload = analysis.result if isinstance(analysis.result, dict) else {}
+        for k, v in payload.items():
+            if isinstance(v, list):
+                value = "; ".join(str(x) for x in v if str(x).strip())
+            else:
+                value = str(v)
+            if value.strip():
+                yield f"image.{k}", value
+
+
+def _apply_image_mappings_to_xml(data_elem: Element, workspace: Workspace, record_id: str):
+    """Append mapped accepted image metadata as <metadata> elements."""
+    image_values = dict(_iter_accepted_image_metadata(workspace, record_id))
+    if not image_values:
+        return
+    for m in workspace.active_mappings():
+        if not m.csv_column.startswith("image."):
+            continue
+        value = image_values.get(m.csv_column, "")
+        if not value:
+            continue
+        if m.repeatable and ";" in value:
+            for part in _split_repeatable(value):
+                me = SubElement(data_elem, "metadata", label=m.label or m.goobi_type, type=m.goobi_type)
+                me.text = part
+        else:
+            me = SubElement(data_elem, "metadata", label=m.label or m.goobi_type, type=m.goobi_type)
+            me.text = value
+
 # ---------------------------------------------------------------------------
 # Single-record export
 # ---------------------------------------------------------------------------
@@ -278,7 +316,7 @@ def export_goobi_xml(
         dict_lookup.setdefault(d.term.lower(), d)
 
     for ent in workspace.entities:
-        if ent.status != "rejected" and ent.gnd_id:
+        if getattr(ent.status, "value", ent.status) != "rejected" and ent.gnd_id:
             key = ent.text.lower()
             if key not in dict_lookup:
                 dict_lookup[key] = DictionaryEntry(
@@ -316,11 +354,10 @@ def export_goobi_xml(
 
         record_entities = [
             e for e in workspace.entities
-            if e.record_id == record_id and e.status != "rejected"
+            if e.record_id == record_id and getattr(e.status, "value", e.status) != "rejected"
         ]
-        if record_entities:
-            data_elem = elem.find("data")
-            if data_elem is not None:
+        data_elem = elem.find("data")
+        if record_entities and data_elem is not None:
                 for ent in record_entities:
                     gnd_attrs: dict[str, str] = {}
                     ent_entry = dict_lookup.get(ent.text.lower())
@@ -352,6 +389,9 @@ def export_goobi_xml(
                         attrs.update(gnd_attrs)
                         se = SubElement(data_elem, "metadata", **attrs)
                         se.text = ent.text
+
+        if data_elem is not None:
+            _apply_image_mappings_to_xml(data_elem, workspace, record_id)
 
         _et_indent(elem, space="  ")
         xml_str = tostring(elem, encoding="unicode")

--- a/src/kwb/export/jsonld.py
+++ b/src/kwb/export/jsonld.py
@@ -77,6 +77,7 @@ def _make_record_node(
     field_mapping: list,
     entities_by_record: dict[str, list],
     dates_by_record: dict[str, list],
+    image_by_record: dict[str, dict[str, str]],
 ) -> dict[str, Any]:
     """Convert a single DataFrame row to a JSON-LD CreativeWork node."""
     record_id = str(row.get(id_column, ""))
@@ -138,6 +139,20 @@ def _make_record_node(
     if dates:
         node["temporal"] = [{"@type": "edtf", "@value": d} for d in dates if d]
 
+    # Add accepted image analysis values via field mapping (csv_column = image.*)
+    img_vals = image_by_record.get(record_id, {})
+    for fm in field_mapping:
+        if fm.is_ignored or not fm.csv_column.startswith("image."):
+            continue
+        val = img_vals.get(fm.csv_column, "")
+        if not val:
+            continue
+        schema_key = type_to_schema.get(fm.goobi_type, fm.goobi_type)
+        if fm.repeatable and ";" in val:
+            node[schema_key] = [v.strip() for v in val.split(";") if v.strip()]
+        else:
+            node[schema_key] = val
+
     return node
 
 
@@ -183,13 +198,28 @@ def export_jsonld(
             dates_by_record.setdefault(rid, [])
             dates_by_record[rid].append(cd.edtf)
 
+    # Build accepted image-analysis lookup per record
+    image_by_record: dict[str, dict[str, str]] = {}
+    for img in workspace.image_analyses:
+        if img.review_status.value != "accepted" or not img.record_id:
+            continue
+        payload = img.result if isinstance(img.result, dict) else {}
+        image_by_record.setdefault(img.record_id, {})
+        for key, value in payload.items():
+            if isinstance(value, list):
+                rendered = "; ".join(str(x) for x in value if str(x).strip())
+            else:
+                rendered = str(value)
+            if rendered.strip():
+                image_by_record[img.record_id][f"image.{key}"] = rendered
+
     # Build record nodes
     rows = df.head(limit) if limit else df
     items = []
     for _, row in rows.iterrows():
         node = _make_record_node(
             row, id_col, active_mappings,
-            entities_by_record, dates_by_record,
+            entities_by_record, dates_by_record, image_by_record,
         )
         record_id = str(row.get(id_col, ""))
         if "@id" not in node:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -425,6 +425,31 @@ class TestExportEndpoints(unittest.TestCase):
         self.assertEqual(body["record_count"], 5)
         self.assertIn("goobi-import-batch", body["xml"])
 
+    def test_image_results_export_csv(self):
+        img = ("files", ("test.jpg", io.BytesIO(_SAMPLE_IMAGE_BYTES), "image/jpeg"))
+        up = self.client.post("/api/images/upload", files=[img])
+        self.assertEqual(up.status_code, 200)
+        image_id = up.json()["images"][0]["id"]
+
+        self.client.post("/api/images/analyze", json={"image_ids": [image_id]})
+        rv = self.client.post(f"/api/images/{image_id}/review", json={
+            "status": "accepted", "comment": "ok", "reviewer": "fachperson", "record_id": "obj_001"
+        })
+        self.assertEqual(rv.status_code, 200)
+
+        ex = self.client.post("/api/export/image-results", json={"format": "csv"})
+        self.assertEqual(ex.status_code, 200)
+        self.assertIn("text/csv", ex.headers.get("content-type", ""))
+        self.assertIn("review_status", ex.text)
+        self.assertIn("accepted", ex.text)
+
+    def test_image_results_export_jsonld(self):
+        ex = self.client.post("/api/export/image-results", json={"format": "jsonld", "as_file": False})
+        self.assertEqual(ex.status_code, 200)
+        body = ex.json()
+        self.assertIn("jsonld", body)
+        self.assertIn("@graph", body["jsonld"])
+
 
 # ---------------------------------------------------------------------------
 # Tests: Workspace endpoints

--- a/tests/test_workspace_export.py
+++ b/tests/test_workspace_export.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from kwb.core.workspace import Workspace, CuratedEntity, CuratedDate, DictionaryEntry
+from kwb.core.workspace import Workspace, CuratedEntity, CuratedDate, DictionaryEntry, ImageAnalysisResult, ImageReviewStatus
 from kwb.export.goobi_xml import export_goobi_xml, export_goobi_batch
 
 
@@ -191,6 +191,26 @@ class TestGoobiExport(unittest.TestCase):
         results = export_goobi_xml(df, ws)
         xml = results[0][1]
         self.assertEqual(xml.count("singleDigCollection"), 3)
+
+    def test_accepted_image_mapping_flows_into_goobi(self):
+        df = pd.DataFrame({"record_id": ["obj_1"], "title": ["Test"]})
+        ws = Workspace()
+        ws.field_mapping = {
+            "title": ("Titel", "TitleDocMain"),
+            "image.description": ("Bildbeschreibung", "Description"),
+            "image.objects": ("Bildobjekte", "SubjectTopic"),
+        }
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img_1",
+            filename="test.jpg",
+            analyzed=True,
+            result={"description": "Architekturansicht", "objects": ["Kirche", "Turm"]},
+            record_id="obj_1",
+            review_status=ImageReviewStatus.ACCEPTED,
+        ))
+        xml = export_goobi_xml(df, ws)[0][1]
+        self.assertIn("Architekturansicht", xml)
+        self.assertIn("Kirche", xml)
 
 
 # GND tests are network-dependent, so we test the module structure only


### PR DESCRIPTION
### Motivation
- Enable per-image human triage (pending/accepted/rejected + reviewer + comment) and persist decisions so accepted vision outputs flow into downstream metadata exports. 
- Allow efficient curation and bulk triage of large AI image result sets (500+ items) and provide exportable, provenance-rich reviewed data for Goobi/CSV/JSON‑LD pipelines.

### Description
- Extend the workspace model with `ImageReviewStatus` and enrich `ImageAnalysisResult` with `record_id`, `review_status`, `review_comment`, `reviewer`, `reviewed_at`, derived `confidence` and `provenance`, plus helper methods and workspace review stats (`src/kwb/core/workspace.py`).
- Add an image review API `POST /api/images/{img_id}/review` and include review fields in `GET /api/images` and analysis flow so reviews persist to the workspace (`src/kwb/api/routes/ai.py`).
- Implement an export endpoint `POST /api/export/image-results` supporting CSV and JSON‑LD including review status, confidence and provenance, and added helper functions for row/JSON‑LD generation (`src/kwb/api/routes/export.py`).
- Integrate accepted (`review_status == accepted`) image metadata into existing mappings so `image.*` field mappings are applied in Goobi XML, JSON‑LD and enriched CSV exports (`src/kwb/export/goobi_xml.py`, `src/kwb/export/jsonld.py`, `src/kwb/export/csv_export.py`).
- Update the dashboard UI to show image analysis results with inline triage actions (anpassen, bestätigen, verwerfen), editable description/comment/reviewer/record_id, and client-side export triggers (`src/kwb/api/dashboard.html`).
- Add and update tests to cover image-review flows and export integration (`tests/test_api.py`, `tests/test_workspace_export.py`).

### Testing
- Ran unit/integration tests: `PYTHONPATH=src python -m pytest tests/test_workspace_export.py tests/test_api.py -q` which passed with `25 passed, 44 skipped`.
- Verified bytecode/packaging sanity via `PYTHONPATH=src python -m compileall -q src` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac2cb08248328903c4017fc4c9281)