### PR TITLE
Fix startup SyntaxError in ImageAnalysisResult.from_dict

### DIFF
--- a/src/kwb/core/workspace.py
+++ b/src/kwb/core/workspace.py
@@ -282,6 +282,9 @@ class ImageAnalysisResult:
     review_status: ImageReviewStatus = ImageReviewStatus.PENDING
     review_comment: str = ""
     reviewer: str = ""
+    prompt_name: str = ""
+    prompt_version: str = ""
+    review_note: str = ""
     reviewed_at: str = ""
 
     @property
@@ -323,12 +326,6 @@ class ImageAnalysisResult:
                 self.result = {}
             self.result.update(result_updates)
         self.reviewed_at = datetime.utcnow().isoformat()
-    prompt_name: str = ""
-    prompt_version: str = ""
-    review_status: str = "pending"
-    review_note: str = ""
-    reviewed_at: str = ""
-
     def to_dict(self) -> dict:
         return {
             "image_id": self.image_id,
@@ -344,12 +341,11 @@ class ImageAnalysisResult:
             "model": self.model,
             "analyzed_at": self.analyzed_at,
             "record_id": self.record_id,
-            "review_status": self.review_status.value,
             "review_comment": self.review_comment,
             "reviewer": self.reviewer,
             "prompt_name": self.prompt_name,
             "prompt_version": self.prompt_version,
-            "review_status": self.review_status,
+            "review_status": self.review_status.value,
             "review_note": self.review_note,
             "reviewed_at": self.reviewed_at,
         }
@@ -375,7 +371,6 @@ class ImageAnalysisResult:
             reviewer=d.get("reviewer", ""),
             prompt_name=d.get("prompt_name", ""),
             prompt_version=d.get("prompt_version", ""),
-            review_status=d.get("review_status", "pending"),
             review_note=d.get("review_note", ""),
             reviewed_at=d.get("reviewed_at", ""),
         )


### PR DESCRIPTION
### Motivation
- Importing the API raised a `SyntaxError` at startup because `ImageAnalysisResult.from_dict` contained `review_status` as a duplicated keyword argument and some related fields were declared incorrectly outside the dataclass body.

### Description
- Move `prompt_name`, `prompt_version`, and `review_note` into the `ImageAnalysisResult` dataclass as proper fields to avoid stray attributes after methods.
- Remove the duplicated `review_status` keyword from `ImageAnalysisResult.from_dict` so the constructor call is valid at import time.
- Normalize `to_dict()` to include a single `review_status` entry serialized as the enum `.value` and clean up the serialized output.

### Testing
- Ran `python -m py_compile src/kwb/core/workspace.py src/kwb/api/app.py` and the files compiled successfully after the changes. 
- Ran `PYTHONPATH=src python -c "import kwb.api.app; print('ok')"` which fails due to missing runtime dependencies and prints a suggestion to install `fastapi uvicorn python-multipart` (this indicates import-time runtime deps are still required).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaca85ff448328a68b7f543ea786f1)