### PR TITLE
Fix OCR prompt schema to include missing `text_type` key

### DIFF
--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 442/458 Tests bestanden, 0 fehlgeschlagen, 16 übersprungen
+**Gesamtstatus:** 414/517 Tests bestanden, 0 fehlgeschlagen, 103 übersprungen
 
 ---
 
@@ -238,24 +238,24 @@
 | Test-Suite | Bestanden | Fehlgeschlagen | Übersprungen | Status |
 |------------|-----------|----------------|--------------|--------|
 | test_ai.py | 19/19 | 0 | 0 | ✅ |
-| test_api.py | 42/42 | 0 | 0 | ✅ |
-| test_comprehensive.py | 25/25 | 0 | 0 | ✅ |
+| test_api.py | 0/44 | 0 | 44 | ✅ |
+| test_cli.py | 8/8 | 0 | 0 | ✅ |
+| test_comprehensive.py | 22/22 | 0 | 0 | ✅ |
 | test_core.py | 18/18 | 0 | 0 | ✅ |
 | test_edtf.py | 82/82 | 0 | 0 | ✅ |
 | test_gnd.py | 14/14 | 0 | 0 | ✅ |
 | test_gnd_enrich.py | 24/40 | 0 | 16 | ✅ |
 | test_goobi_export.py | 32/32 | 0 | 0 | ✅ |
 | test_image_fixtures.py | 10/10 | 0 | 0 | ✅ |
-| test_image_upload.py | 31/31 | 0 | 0 | ✅ |
+| test_image_upload.py | 0/31 | 0 | 31 | ✅ |
 | test_ner.py | 29/29 | 0 | 0 | ✅ |
 | test_ner_edtf.py | 31/31 | 0 | 0 | ✅ |
-| test_new_features.py | 39/39 | 0 | 0 | ✅ |
-| test_roadmap.py | 5/5 | 0 | 0 | ✅ |
+| test_new_features.py | 29/41 | 0 | 12 | ✅ |
+| test_roadmap.py | 8/8 | 0 | 0 | ✅ |
 | test_utils.py | 30/30 | 0 | 0 | ✅ |
 | test_workspace.py | 33/33 | 0 | 0 | ✅ |
-| test_cli.py | 8/8 | 0 | 0 | ✅ |
-| test_workspace_export.py | 24/24 | 0 | 0 | ✅ |
-| **Gesamt** | **442/458** | **0** | **16** | **✅** |
+| test_workspace_export.py | 25/25 | 0 | 0 | ✅ |
+| **Gesamt** | **414/517** | **0** | **103** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/ai/prompts.py
+++ b/src/kwb/ai/prompts.py
@@ -123,6 +123,7 @@ def prompt_ocr_transcription_quality(additional_context="", language="de"):
         + '  "prompt_name": "ocr_transcription_quality",\n'
         + '  "prompt_version": "1.0.0",\n'
         + '  "text_found": false,\n'
+        + '  "text_type": "printed|handwritten|mixed|unknown",\n'
         + '  "script_type": "latin|kurrent|fraktur|mixed|unknown",\n'
         + '  "language": "de|en|fr|it|la|unknown",\n'
         + '  "transcription": "...",\n'


### PR DESCRIPTION
### Motivation
- A comprehensive test expected the OCR prompt JSON to include a `text_type` key but the prompt schema only contained `script_type`, causing a test failure in `tests/test_comprehensive.py`.

### Description
- Added the `"text_type": "printed|handwritten|mixed|unknown",` field to the OCR prompt JSON schema in `src/kwb/ai/prompts.py`, preserving existing fields like `script_type`.

### Testing
- Running `pytest -q` without the test path setup initially failed due to import path issues (`ModuleNotFoundError: No module named 'kwb'`).
- Running the full suite with `PYTHONPATH=src pytest -q` after the change succeeded: `389 passed, 103 skipped, 25 subtests passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad23919c0832896b8dc21417d8574)