### PR TITLE
Fix required attribute handling in form field options

### DIFF
--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -131,7 +131,7 @@ async function loadFMCols(){
 
 // Build type options: Minimaldatensatz 1.1 group + Goobi group
 function _fmTypeOpts(selectedType){
-  const mdsOpts=MDS_FIELDS.map(f=>'<option value="'+esc(f.goobi)+'"'+(f.goobi===selectedType?' selected':'')+(f.pflicht?'')+'>'+esc(f.mds+(f.pflicht?' ★':''))+' ('+esc(f.goobi)+')</option>').join('');
+  const mdsOpts=MDS_FIELDS.map(f=>'<option value="'+esc(f.goobi)+'"'+(f.goobi===selectedType?' selected':'')+(f.pflicht?' required':'')+'>'+esc(f.mds+(f.pflicht?' ★':''))+' ('+esc(f.goobi)+')</option>').join('');
   const goobiOpts=GOOBI_TYPES.filter(t=>!MDS_FIELDS.find(f=>f.goobi===t)).map(t=>'<option value="'+esc(t)+'"'+(t===selectedType?' selected':'')+'>'+esc(t)+'</option>').join('');
   return '<option value="">— kein Export —</option>'+
     '<optgroup label="Minimaldatensatz 1.1 (★ = Pflichtfeld)">'+mdsOpts+'</optgroup>'+


### PR DESCRIPTION
## Summary
Fixed the conditional logic for adding the `required` attribute to form field options in the dashboard's field type selector.

## Changes
- Updated the `_fmTypeOpts()` function to properly set the `required` attribute on mandatory fields
- Changed from `(f.pflicht?'')+` (which added nothing when true) to `(f.pflicht?' required':'')` (which correctly adds the required attribute when the field is mandatory)

## Details
The previous implementation had a logic error where mandatory fields (`f.pflicht === true`) would not receive the HTML `required` attribute. The fix ensures that when a field is marked as required (`pflicht`), the `required` attribute is properly included in the generated option element, improving form validation and accessibility.

https://claude.ai/code/session_01HxQyfy2rtAKNzTKxytE2wi