### PR TITLE
Harden dashboard init, robust CSV upload, unify field-mapping API, and make tabs generic

### DIFF
--- a/docs/BUGREPORT_CSV_UPLOAD_TABS.md
+++ b/docs/BUGREPORT_CSV_UPLOAD_TABS.md
@@ -1,0 +1,233 @@
+# Debussy Bug Report: CSV-Upload wird nicht geladen & Tabs reagieren nicht
+
+## 1. Zusammenfassung
+
+In der aktuellen Dashboard-UI wurden zwei zusammenhängende Fehlersymptome gemeldet:
+
+1. **CSV-Upload scheint visuell aktiv**, aber die Datei wird nicht effektiv in den Workflow übernommen.
+2. **Tabs sind nicht aktiv / nicht klickbar** (Navigation reagiert nicht wie erwartet).
+
+Die statische Codeanalyse zeigt mehrere plausible Fehlerursachen. Die höchste Priorität hat eine fragile Frontend-Initialisierung: Bereits ein früher JavaScript-Fehler kann Upload- und Tab-Interaktionen gleichzeitig „still“ ausfallen lassen.
+
+---
+
+## 2. Beobachtete Symptome (aus Nutzersicht)
+
+- Datei-Dialog lässt sich öffnen.
+- Dropzone ist sichtbar und wirkt aktiv.
+- Nach Auswahl/Drop erfolgt aber keine verwertbare Datenaufnahme (kein funktionsfähiger weiterer Ablauf).
+- Tabs lassen sich nicht öffnen bzw. reagieren nicht.
+
+Diese Kombination ist typisch für ein **JS-Initialisierungs-/Runtime-Problem im Frontend** (HTML/CSS laden, Interaktionslogik fällt jedoch teilweise oder vollständig aus).
+
+---
+
+## 3. Untersuchungsumfang
+
+Analysierte Hauptdateien:
+
+- `src/kwb/api/parts/dashboard.js`
+- `src/kwb/api/dashboard.html`
+- `src/kwb/api/parts/dashboard.css`
+- `src/kwb/api/routes/analyze.py`
+- `src/kwb/api/routes/workspace.py`
+- `src/kwb/api/app.py`
+
+Methodik:
+
+- Statische Codeanalyse von Upload-, Tab-, Init- und API-Datenfluss.
+- Plausibilitätsprüfung zwischen Frontend-Requestformaten und Backend-Responseformaten.
+- Sichtung von Selektoren/Event-Bindings auf Robustheit gegenüber Teilfehlern.
+
+---
+
+## 4. Technische Befunde (Root-Cause-Hypothesen)
+
+## 4.1 Inkonsistenz im Field-Mapping-API-Vertrag (klarer Funktionsbug)
+
+### Befund
+
+Frontend und Backend verwenden bei `/api/workspace/field-mapping` unterschiedliche Datenstrukturen:
+
+- Frontend sendet aktuell `{"mapping": {...}}` (Dictionary), liest `ex.mapping`.
+- Backend erwartet `{"mappings": [...]}` (Liste von `FieldMapping`-Objekten), liefert `{"mappings": [...]}`.
+
+### Wirkung
+
+- Mapping-Daten werden nicht korrekt gespeichert/zurückgeladen.
+- Folgefehler in Mapping-abhängigen Schritten (insb. Export) sind wahrscheinlich.
+- Führt zu „UI wirkt kaputt“, obwohl Ursache ein stiller Datenvertragsfehler ist.
+
+### Priorität
+
+**Hoch** (P1) – direkter Functional Break.
+
+---
+
+## 4.2 Fragile globale Frontend-Initialisierung (sehr wahrscheinlich für Upload+Tabs gemeinsam)
+
+### Befund
+
+Mehrere Event-Bindings erfolgen unmittelbar und ohne Schutzlogik. Wenn im Startup-Pfad ein Fehler auftritt, kann die Initialisierung nachfolgender Features abbrechen.
+
+Typische Muster:
+
+- Direkte Zuweisung ohne Null-Guard (`fi.onchange = ...`, `$('exp-ds').onchange = ...`).
+- Große IIFE-Initialisierung mit vielen Aufrufen hintereinander, ohne zentrale Fehlerisolation.
+
+### Wirkung
+
+- Bei einem frühen JS-Error können Tabs nicht mehr reagieren.
+- Upload-Handler kann ebenfalls nicht mehr sauber greifen.
+- Für User sichtbar als „Dropzone/Buttons sind da, aber nichts funktioniert richtig“.
+
+### Priorität
+
+**Kritisch** (P0) – passt exakt zur Symptomkombination.
+
+---
+
+## 4.3 Tab-Bindung nur auf einen festen Container (`bindTabs('dt')`)
+
+### Befund
+
+Der Tab-Mechanismus wird explizit nur für den Daten-Subtab mit ID `dt` gebunden.
+
+### Wirkung
+
+- Erweiterungen/Refactorings sind fehleranfällig.
+- Bereits kleine DOM-Änderungen können Tab-Klickbarkeit unbeabsichtigt brechen.
+- Wartbarkeit und Fehlertoleranz sinken.
+
+### Priorität
+
+**Mittel** (P2) – Stabilitäts- und Architekturthema mit UX-Auswirkung.
+
+---
+
+## 4.4 Upload-Dateiverwaltung per Dateiname (Kollisionen) + fehlender Input-Reset
+
+### Befund
+
+`ufiles` wird nach `f.name` indiziert. Gleichnamige Dateien überschreiben sich. Zusätzlich wird der Datei-Input nach Verarbeitung nicht zurückgesetzt.
+
+### Wirkung
+
+- Upload wirkt inkonsistent (insb. bei gleichen Dateinamen aus unterschiedlichen Ordnern).
+- Erneute Auswahl derselben Datei triggert unter Umständen keinen `change`.
+- Kann als „CSV wird nicht geladen“ wahrgenommen werden.
+
+### Priorität
+
+**Mittel** (P2) – Edge Cases, aber realistisch im Alltag.
+
+---
+
+## 5. Risikoanalyse
+
+## 5.1 Produktionsrisiken
+
+- Funktionsketten brechen ohne klare Fehlermeldung (schlechte Diagnosefähigkeit).
+- Nutzer verlieren Vertrauen in Upload-/Tab-Workflow.
+- Mehr Supportaufwand wegen schwer reproduzierbarer „UI reagiert nicht“-Meldungen.
+
+## 5.2 Entwicklungsrisiken
+
+- API-Vertrag driftet weiter auseinander (Frontend/Backend).
+- Regressionen bei künftigen UI-Änderungen durch fehlende Init-Härtung.
+- Höhere Kosten für spätere Stabilisierung.
+
+---
+
+## 6. Konkrete Entwicklungsempfehlungen / Bugfix-Plan
+
+## 6.1 P0: Frontend-Init robust machen (Upload/Tabs absichern)
+
+1. Initialisierung in Teilfunktionen aufteilen:
+   - `initNav()`
+   - `initTabs()`
+   - `initUpload()`
+   - `initPanels()`
+2. Jede Funktion mit lokaler Fehlerisolierung (`try/catch`) versehen.
+3. Elementzugriffe konsequent mit Existenzprüfung absichern.
+4. Bei Init-Fehlern sichtbaren Banner anzeigen + `console.error` mit Kontext.
+
+**Akzeptanzkriterium:** Ein Fehler in einem Teilmodul darf nicht mehr das gesamte UI lahmlegen.
+
+---
+
+## 6.2 P1: Mapping-API-Vertrag vereinheitlichen
+
+1. Einheitliches Payloadformat definieren (empfohlen: `mappings[]`).
+2. Frontend-Funktionen `saveFM()` und `loadFMCols()` auf dieses Format umstellen.
+3. Interne UI-Struktur `fmMapping` sauber in/aus `mappings[]` konvertieren.
+4. Kurz-Dokumentation im Code ergänzen.
+
+**Akzeptanzkriterium:** Mapping speichern/laden ist deterministisch und roundtrip-sicher.
+
+---
+
+## 6.3 P2: Tabs generisch und lokal binden
+
+1. Tab-Binding über alle `.tabs`-Container iterieren.
+2. `bindTabs()` auf Element- statt ID-Basis umbauen.
+3. Panel-Toggle strikt auf den zugehörigen Container scopen.
+
+**Akzeptanzkriterium:** Tabverhalten bleibt stabil bei DOM-Erweiterungen.
+
+---
+
+## 6.4 P2: Upload-Datenmodell verbessern
+
+1. Dateischlüssel nicht nur über Namen bilden (ID aus Name+Size+mtime o.ä.).
+2. UI soll Kollisionen transparent machen.
+3. Nach Verarbeitung `fi.value = ''` setzen.
+
+**Akzeptanzkriterium:** Wiederholte Uploads + gleichnamige Dateien verhalten sich erwartbar.
+
+---
+
+## 7. Teststrategie (empfohlen)
+
+## 7.1 Frontend-Interaktions-Checks
+
+- Upload per Click und per Drag&Drop.
+- Re-Upload derselben Datei.
+- Zwei gleichnamige Dateien aus verschiedenen Ordnern.
+- Tabwechsel vor/nach Upload, inklusive Fehlerfällen.
+
+## 7.2 API-Vertrags-Tests
+
+- POST `/api/workspace/field-mapping` mit `mappings[]`.
+- GET `/api/workspace/field-mapping` und Roundtrip-Vergleich.
+- Negativtests bei unvollständigen Mapping-Objekten.
+
+## 7.3 Regressionstests
+
+- Exportpfade nach Mapping (XML/CSV/JSON-LD) verifizieren.
+- Smoke-Test des Dashboards nach Init-Refactor.
+
+---
+
+## 8. Kurzfristige Hotfix-Reihenfolge
+
+1. **P0:** Init-Härtung + defensives Binding.
+2. **P1:** Mapping-Vertrag reparieren.
+3. **P2:** Tabs generisch binden.
+4. **P2:** Upload-Kollisionen + Input-Reset.
+
+---
+
+## 9. Erwarteter Nutzen nach Fix
+
+- CSV-Upload wird zuverlässig verarbeitet.
+- Tabs reagieren konsistent.
+- Fehler werden sichtbar statt „still“.
+- Geringere Regressionen bei UI-Weiterentwicklung.
+- Deutlich bessere Wartbarkeit durch klaren API-Vertrag.
+
+---
+
+## 10. Abschluss
+
+Die gemeldeten Symptome sind mit hoher Wahrscheinlichkeit kein einzelner „Mini-Bug“, sondern ein **Cluster aus Frontend-Robustheitslücken plus mindestens einem klaren API-Vertragsfehler**. Die empfohlenen Maßnahmen sind überschaubar, priorisierbar und liefern schnell stabilere UX.

--- a/docs/BUGREPORT_CSV_UPLOAD_TABS_RECHECK.md
+++ b/docs/BUGREPORT_CSV_UPLOAD_TABS_RECHECK.md
@@ -1,0 +1,28 @@
+# Debussy Re-Check Report (aktualisiert): CSV-Upload & Tabs
+
+## Status (aktuell)
+
+Die ursprünglichen Hauptprobleme wurden **größtenteils behoben**:
+
+- Tabs sind nicht mehr starr an `bindTabs('dt')` gekoppelt, sondern werden generisch über `.tabs` initialisiert.
+- Die Initialisierung ist in abgesicherte Schritte geteilt (mit `try/catch`), wodurch ein Teilfehler nicht mehr alles blockiert.
+- Der Field-Mapping-Vertrag ist auf `mappings[]` vereinheitlicht (Frontend ↔ Backend).
+
+Zusätzlich wurde jetzt die Upload-Robustheit weiter verbessert:
+
+- Upload-Namen werden bei Kollisionen eindeutig gemacht (z. B. `datei (2).csv`).
+- CSV-Dateien mit gleichem Originalnamen überschreiben sich im Upload-Flow nicht mehr.
+- Der Datei-Input wird nach Verarbeitung zurückgesetzt.
+
+---
+
+## Verbleibende Restpunkte
+
+- Die interne Dateiverwaltung bleibt in-memory (kein Persistenzlayer über Browser-Reload hinaus) – erwartbar für die aktuelle Architektur.
+- Für langfristige Stabilität wären UI-E2E-Tests für Upload + Tab-Navigation sinnvoll.
+
+---
+
+## Kurzfazit
+
+Der zuvor gemeldete „alles blockiert“-Zustand ist im aktuellen Stand nicht mehr der erwartete Normalfall. Die Kernursachen (Init-Fragilität + Mapping-Drift) sind adressiert; Dateinamenskollisionen im Upload wurden nachgezogen.

--- a/issues/ISSUE-001-frontend-init-hardening.md
+++ b/issues/ISSUE-001-frontend-init-hardening.md
@@ -1,0 +1,43 @@
+# ISSUE-001 — Frontend-Init härten (P0)
+
+## Typ
+Bug / Stabilität
+
+## Priorität
+P0 (kritisch)
+
+## Problem
+Die Dashboard-Interaktion ist fragil, weil zentrale Event-Bindings im Top-Level ohne defensive Guards initialisiert werden. Ein früher JS-Fehler kann Upload und Tab-Interaktionen gleichzeitig ausfallen lassen.
+
+## Betroffene Bereiche
+- `src/kwb/api/parts/dashboard.js`
+- Upload-Bindings (`fi`, `uz`)
+- Navigation und Tab-Initialisierung
+
+## Reproduktion (typisch)
+1. Dashboard öffnen.
+2. CSV auswählen oder Dropzone verwenden.
+3. Tabs wechseln.
+4. Beobachtung: UI wirkt teilweise „sichtbar aber inaktiv“ (je nach Fehlerpfad).
+
+## Zielzustand
+Ein Teilfehler in der Initialisierung darf nicht mehr die gesamte UI blockieren.
+
+## Umsetzung
+- Initialisierung in Funktionen aufteilen:
+  - `initNav()`
+  - `initTabs()`
+  - `initUpload()`
+  - `initAsyncPanels()`
+- Pro Init-Funktion `try/catch` + `console.error('[initX]', err)`.
+- Vor DOM-Bindings Existenzchecks einbauen.
+- Optional: kleines Dev-Diagnostic-Banner bei Init-Fehlern.
+
+## Akzeptanzkriterien
+- Upload bleibt funktionsfähig, selbst wenn ein nicht-kritisches Panel-Init fehlschlägt.
+- Tabs bleiben klickbar bei Teilfehlern.
+- Fehler sind in Konsole klar den Init-Modulen zugeordnet.
+
+## Testhinweise
+- Manueller Smoke-Test: Upload (Click + DnD), Tabwechsel, wiederholtes Laden.
+- Optional UI-E2E-Test für „Init-Teilfehler blockiert Kernfunktionen nicht“.

--- a/issues/ISSUE-002-field-mapping-api-contract.md
+++ b/issues/ISSUE-002-field-mapping-api-contract.md
@@ -1,0 +1,38 @@
+# ISSUE-002 — Field-Mapping API-Vertrag vereinheitlichen (P1)
+
+## Typ
+Bug / API-Vertragsfehler
+
+## Priorität
+P1 (hoch)
+
+## Problem
+Frontend und Backend verwenden unterschiedliche Payload-/Response-Formate beim Field Mapping.
+
+- Frontend verwendet `mapping` / `ex.mapping`
+- Backend erwartet/liefert `mappings` (Liste)
+
+Dadurch ist Speichern/Laden nicht roundtrip-sicher.
+
+## Betroffene Bereiche
+- `src/kwb/api/parts/dashboard.js`
+- `src/kwb/api/routes/workspace.py`
+
+## Zielzustand
+Ein einheitlicher, stabiler Vertrag für GET/POST `/api/workspace/field-mapping`.
+
+## Umsetzung
+- Frontend auf `mappings[]` umstellen:
+  - `saveFM()` sendet `{mappings:[...]}`
+  - `loadFMCols()` liest `ex.mappings`
+- UI-interne Datenstruktur sauber in/aus Liste konvertieren.
+- API-Vertrag im Code kurz dokumentieren.
+
+## Akzeptanzkriterien
+- POST → GET Roundtrip liefert konsistente Daten.
+- Mapping bleibt nach Reload erhalten und wird korrekt im UI angezeigt.
+- Exportpfad nutzt korrekt gespeichertes Mapping.
+
+## Testhinweise
+- API-Test: POST/GET Roundtrip inkl. Negativfall.
+- UI-Test: Mapping setzen, speichern, neu laden, Export-Vorschau prüfen.

--- a/issues/ISSUE-003-generic-tab-binding.md
+++ b/issues/ISSUE-003-generic-tab-binding.md
@@ -1,0 +1,30 @@
+# ISSUE-003 — Tab-Binding generisch und container-lokal machen (P2)
+
+## Typ
+Verbesserung / Robustheit
+
+## Priorität
+P2 (mittel)
+
+## Problem
+Tabs werden derzeit über festen Container (`bindTabs('dt')`) gebunden. Das ist bei DOM-Änderungen/Erweiterungen fragil.
+
+## Betroffene Bereiche
+- `src/kwb/api/parts/dashboard.js`
+
+## Zielzustand
+Tab-Binding funktioniert für alle Tab-Container robust und unabhängig von fester ID.
+
+## Umsetzung
+- `bindTabs` auf Elementbasis umstellen.
+- Über alle `.tabs` iterieren und binden.
+- Nur lokale zugehörige `.tp` Panels toggeln.
+
+## Akzeptanzkriterien
+- Bestehende Data-Tabs funktionieren unverändert.
+- Neue `.tabs`-Container funktionieren ohne zusätzliche JS-Änderung.
+- Keine Seiteneffekte auf andere Panelbereiche.
+
+## Testhinweise
+- Klicktests für alle vorhandenen Tabs.
+- Regression bei zukünftigen zusätzlichen Tab-Containern.

--- a/issues/ISSUE-004-upload-file-keying-and-input-reset.md
+++ b/issues/ISSUE-004-upload-file-keying-and-input-reset.md
@@ -1,0 +1,31 @@
+# ISSUE-004 — Upload-Keying und Datei-Input-Reset verbessern (P2)
+
+## Typ
+Bug / UX-Robustheit
+
+## Priorität
+P2 (mittel)
+
+## Problem
+Dateien werden per Dateiname als Key gespeichert (`ufiles[f.name] = f`). Gleichnamige Dateien können sich überschreiben. Zudem kann Wieder-Auswahl derselben Datei je nach Browser nicht erneut triggern.
+
+## Betroffene Bereiche
+- `src/kwb/api/parts/dashboard.js`
+
+## Zielzustand
+Upload verhält sich deterministisch bei gleichnamigen Dateien und wiederholter Auswahl.
+
+## Umsetzung
+- Stabilen internen Key verwenden (z. B. Name+Size+LastModified oder UUID).
+- Anzeige von internem Key entkoppeln (UI zeigt lesbaren Dateinamen).
+- Nach Verarbeitung `fi.value=''` setzen.
+- Optional: Hinweis bei Kollisionen.
+
+## Akzeptanzkriterien
+- Zwei gleichnamige Dateien können gleichzeitig ausgewählt/verwaltet werden.
+- Gleiches File kann direkt erneut ausgewählt werden.
+- Dateiliste bleibt konsistent und nachvollziehbar.
+
+## Testhinweise
+- Upload von zwei gleichnamigen Dateien aus unterschiedlichen Ordnern.
+- Re-Upload derselben Datei ohne Seitenreload.

--- a/issues/README.md
+++ b/issues/README.md
@@ -1,0 +1,20 @@
+# Issue Backlog: CSV-Upload & Tabs
+
+Diese Issues wurden aus folgenden Reports abgeleitet:
+
+- `docs/BUGREPORT_CSV_UPLOAD_TABS.md`
+- `docs/BUGREPORT_CSV_UPLOAD_TABS_RECHECK.md`
+
+## Enthaltene Issues
+
+1. `ISSUE-001-frontend-init-hardening.md` (P0)
+2. `ISSUE-002-field-mapping-api-contract.md` (P1)
+3. `ISSUE-003-generic-tab-binding.md` (P2)
+4. `ISSUE-004-upload-file-keying-and-input-reset.md` (P2)
+
+## Empfohlene Reihenfolge
+
+1. P0 (Init-Härtung)
+2. P1 (API-Vertrag Mapping)
+3. P2 (Tabs generisch)
+4. P2 (Upload-Keying/Reset)

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -48,20 +48,50 @@ function safeOpt(val,label){return '<option value="'+esc(val)+'">'+esc(label)+'<
 function dl(name,content,type){const b=new Blob([content],{type});const a=document.createElement('a');a.href=URL.createObjectURL(b);a.download=name;a.click()}
 
 // === NAV ===
-document.querySelector('.nav').onclick=e=>{if(!e.target.classList.contains('nt'))return;const p=e.target.dataset.p;document.querySelectorAll('.nt').forEach(t=>t.classList.toggle('a',t.dataset.p===p));document.querySelectorAll('.pg').forEach(x=>x.classList.toggle('a',x.dataset.p===p))};
-function bindTabs(id){const el=$(id);if(!el)return;el.onclick=e=>{if(!e.target.classList.contains('tab'))return;const t=e.target.dataset.t;e.currentTarget.querySelectorAll('.tab').forEach(x=>x.classList.toggle('a',x.dataset.t===t));e.currentTarget.parentElement.querySelectorAll('[data-t].tp').forEach(x=>x.classList.toggle('a',x.dataset.t===t))}}
-bindTabs('dt');
+function bindNav(){
+  const nav=document.querySelector('.nav');
+  if(!nav)return;
+  nav.onclick=e=>{if(!e.target.classList.contains('nt'))return;const p=e.target.dataset.p;document.querySelectorAll('.nt').forEach(t=>t.classList.toggle('a',t.dataset.p===p));document.querySelectorAll('.pg').forEach(x=>x.classList.toggle('a',x.dataset.p===p))};
+}
+function bindTabs(el){if(!el)return;el.onclick=e=>{if(!e.target.classList.contains('tab'))return;const t=e.target.dataset.t;el.querySelectorAll('.tab').forEach(x=>x.classList.toggle('a',x.dataset.t===t));el.parentElement.querySelectorAll('[data-t].tp').forEach(x=>x.classList.toggle('a',x.dataset.t===t))}}
 
 // === UPLOAD ===
-const uz=$('uz'),fi=$('fi');
-fi.onchange=e=>hf(e.target.files);uz.ondragover=e=>{e.preventDefault();uz.classList.add('dr')};uz.ondragleave=()=>uz.classList.remove('dr');uz.ondrop=e=>{e.preventDefault();uz.classList.remove('dr');hf(e.dataTransfer.files)};
-function hf(files){for(const f of files)ufiles[f.name]=f;rfl()}
+function bindUpload(){
+  const uz=$('uz'),fi=$('fi');
+  if(!uz||!fi)return;
+  fi.onchange=e=>hf(e.target.files,fi);
+  uz.ondragover=e=>{e.preventDefault();uz.classList.add('dr')};
+  uz.ondragleave=()=>uz.classList.remove('dr');
+  uz.ondrop=e=>{e.preventDefault();uz.classList.remove('dr');hf(e.dataTransfer.files,fi)};
+}
+function _splitExt(name){const i=name.lastIndexOf('.');if(i<=0)return[name,''];return[name.slice(0,i),name.slice(i)]}
+function _uniqueUploadName(name){
+  const existing=new Set(Object.values(ufiles).map(x=>x.uploadName));
+  if(!existing.has(name))return name;
+  const parts=_splitExt(name),base=parts[0],ext=parts[1];
+  let n=2,cand='';
+  do{cand=base+' ('+n+')'+ext;n++;}while(existing.has(cand));
+  return cand;
+}
+function hf(files,fiEl){
+  for(const f of files||[]){
+    const uploadName=_uniqueUploadName(f.name);
+    const id=uploadName+'__'+f.size+'__'+f.lastModified;
+    ufiles[id]={file:f,displayName:f.name,uploadName,size:f.size};
+  }
+  if(fiEl)fiEl.value='';
+  rfl();
+}
 function rfl(){
   const n=Object.keys(ufiles);$('fc').style.display=n.length?'block':'none';
-  $('fcl').innerHTML=n.map(x=>'<div class="ci"><input type="checkbox" checked value="'+esc(x)+'" class="fcb"><span>'+esc(x)+'</span><span class="m">'+(ufiles[x].size/1024).toFixed(0)+'KB</span></div>').join('');
+  $('fcl').innerHTML=n.map(id=>{
+    const f=ufiles[id];
+    const lbl=f.displayName===f.uploadName?esc(f.displayName):esc(f.displayName)+' <span class="m" title="Uploadname">→ '+esc(f.uploadName)+'</span>';
+    return '<div class="ci"><input type="checkbox" checked value="'+esc(id)+'" class="fcb"><span>'+lbl+'</span><span class="m">'+(f.size/1024).toFixed(0)+'KB</span></div>';
+  }).join('');
 }
 function populateDS(){
-  const n=Object.keys(ufiles);
+  const n=Object.values(ufiles).map(f=>f.uploadName);
   for(const id of['ner-ds','scan-ds','edtf-ds','exp-ds','exp-csv-ds','exp-ld-ds','fm-ds','terms-ds']){
     const s=$(id);if(!s)continue;
     s.innerHTML=n.map((x,i)=>'<option value="'+esc(x)+'"'+(i===0?' selected':'')+'>'+esc(x)+'</option>').join('')}
@@ -103,7 +133,7 @@ async function loadRecords(reset=false){
   }catch(e){}
 }
 function pageRecords(dir){recordOffset=Math.max(0,recordOffset+(dir*recordLimit));loadRecords(false)}
-$('exp-ds').onchange=()=>loadRecords(true);
+const expDsEl=$('exp-ds');if(expDsEl)expDsEl.onchange=()=>loadRecords(true);
 
 // === FIELD MAPPING ===
 let fmCols=[];
@@ -116,7 +146,7 @@ async function loadFMCols(){
     fmCols=d.columns;
     // Load existing mapping
     const ex=await(await fetch('/api/workspace/field-mapping')).json();
-    fmMapping=ex.mapping||{};
+    fmMapping=((ex.mappings||[]).reduce((acc,m)=>{acc[m.csv_column]=[m.label||m.goobi_type||'',m.goobi_type||''];return acc;},{}));
     renderFMTable();
     $('fm-table-wrap').style.display='block';
   }catch(e){}
@@ -197,7 +227,7 @@ async function saveFM(){
     }
   });
   try{
-    await fetch('/api/workspace/field-mapping',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({mapping})});
+    await fetch('/api/workspace/field-mapping',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({mappings:Object.entries(mapping).map(([csv_column,v])=>({csv_column,label:Array.isArray(v)?(v[0]||''):'',goobi_type:Array.isArray(v)?(v[1]||''):'',enabled:true}))})});
     fmMapping=mapping;
     $('fm-saved').style.display='inline';
     setTimeout(()=>{$('fm-saved').style.display='none'},2000);
@@ -209,7 +239,7 @@ async function runStruct(){
   const sel=[...document.querySelectorAll('.fcb:checked')].map(c=>c.value);
   if(!sel.length){alert('Mindestens eine Datei auswählen.');return}
   sp('Strukturelle Analyse …',sel.length+' Datei(en)');
-  const fd=new FormData();for(const n of sel)fd.append('files',ufiles[n]);
+  const fd=new FormData();for(const id of sel){const it=ufiles[id];if(it)fd.append('files',it.file,it.uploadName)}
   try{const r=await(await fetch('/api/analyze',{method:'POST',body:fd})).json();
     if(r.error)throw Error(r.error);curRep=r;rrep(r);populateDS();updWS()
   }catch(e){alert(e.message)}finally{hp()}
@@ -755,8 +785,10 @@ let uploadedImages = [];
 let imgFilter = 'all';
 
 function applyImgPreset(){
-  const key = $('img-preset').value;
-  if(key !== 'custom') $('img-sp').value = PRESETS[key] || '';
+  const presetEl=$('img-preset'),spEl=$('img-sp');
+  if(!presetEl||!spEl)return;
+  const key=presetEl.value;
+  if(key!=='custom')spEl.value=PRESETS[key]||'';
 }
 
 async function uploadImages(){
@@ -1077,6 +1109,10 @@ function sp(t,x){$('pt').textContent=t;$('pp').textContent=x||'';$('po').classLi
 function hp(){$('po').classList.remove('a')}
 
 // === INIT ===
-(function(){loadPreset(); applyImgPreset(); applyActionPreset('ner'); applyActionPreset('scan'); applyActionPreset('edtf'); applyActionPreset('ocr'); refreshReviewStats();
-  $('cfg-tasks').innerHTML=Object.values(TASKS).map(t=>'<div class="ft"><span class="bg ac">'+esc(t.type||'')+'</span><div><strong>'+esc(t.name)+'</strong><br><span class="d">'+esc(t.description||'')+'</span></div></div>').join('');
-  renderCatalog();chkGPU();updWS();loadImages();loadTermsDict();})();
+(function(){
+  try{bindNav();document.querySelectorAll('.tabs').forEach(bindTabs);bindUpload();}catch(e){console.error('[init-bind]',e)}
+  try{loadPreset();applyImgPreset();applyActionPreset('ner');applyActionPreset('scan');applyActionPreset('edtf');applyActionPreset('ocr');refreshReviewStats();}catch(e){console.error('[init-presets]',e)}
+  try{const t=$('cfg-tasks');if(t)t.innerHTML=Object.values(TASKS).map(x=>'<div class="ft"><span class="bg ac">'+esc(x.type||'')+'</span><div><strong>'+esc(x.name)+'</strong><br><span class="d">'+esc(x.description||'')+'</span></div></div>').join('');}catch(e){console.error('[init-tasks]',e)}
+  try{renderCatalog();}catch(e){console.error('[init-catalog]',e)}
+  try{chkGPU();updWS();loadImages();loadTermsDict();}catch(e){console.error('[init-async]',e)}
+})();


### PR DESCRIPTION
### Motivation

- The dashboard UI was fragile: a single early JS error could stop multiple interaction paths (tabs, uploads) causing the UI to appear "visible but inactive". 
- The frontend and backend used mismatched field-mapping payloads which prevented reliable save/load roundtrips. 
- Upload handling keyed files by filename and did not reset the file input, producing silent failures on collisions or repeated selections.

### Description

- Split and hardened initialization by adding `bindNav()`, `bindTabs()` and `bindUpload()` and wrapping init stages in `try/catch` blocks to avoid a single error breaking the whole UI. 
- Made tab binding container-local and generic by iterating over all `.tabs` containers and scoping panel toggles to the container. 
- Reworked upload internals to keep files keyed by a stable internal id (uploadName + size + lastModified), ensure unique upload names with `_uniqueUploadName()`, display mapping between original and upload names, and reset the file input after processing. 
- Unified the field-mapping API contract by switching frontend load/save to use `mappings[]` and converting internal `fmMapping` to/from that list, and updated `runStruct()` to append actual `File` objects with the upload name into the `FormData`. 
- Added multiple defensive DOM guards and small fixes (guards for `exp-ds` onchange, `applyImgPreset` null-checks, and safer rendering of file list UI). 
- Added documentation and issue files: a detailed bugreport, re-check report, and four ISSUE-* markdown files plus an issues README describing fixes/priorities.

### Testing

- Executed the existing automated test suite (unit + integration) against the changes; the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aedc4d04d88328903ccc51eaee8ce1)