### PR TITLE
Add Server-Sent Events (SSE) streaming for long-running analysis tasks

### DIFF
--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -42,7 +42,6 @@
 <div class="pg a" data-p="data"><div class="g2"><div class="sb">
 <div class="c"><h2>Daten laden</h2><div class="uz" id="uz" onclick="document.getElementById('fi').click()"><input type="file" id="fi" accept=".csv,.tsv" multiple><p style="font-size:.8rem">📂 CSV/TSV hierher ziehen oder klicken</p></div></div>
 <div class="c" id="fc" style="display:none"><h2>Dateien</h2><div class="cl" id="fcl"></div><button class="btn f" onclick="runStruct()">🔬 Strukturelle Analyse starten</button></div>
-<div class="c"><h2>GPUStack</h2><div id="gi" style="font-size:.75rem">Prüfe …</div></div>
 </div><div>
 <div id="de" class="em"><h3>Willkommen bei Debussy</h3><p style="font-size:.8rem">Lade CSV-Dateien, starte die Analyse, und nutze dann die anderen Tabs.</p><div style="margin-top:.6rem;padding:.5rem;background:#f0f7ff;border:1px solid #d0e3ff;border-radius:4px;font-size:.75rem;line-height:1.5"><strong>Empfohlener Workflow:</strong><br>① Daten &ndash; CSV laden, ID-Spalte festlegen &amp; Strukturanalyse<br>② NER &ndash; Entit&auml;ten erkennen (Personen, Orte, …)<br>③ Begriffe &ndash; Problematische Begriffe via W&ouml;rterbuch scannen<br>④ Datierung &ndash; EDTF-Normalisierung<br>⑤ Bilder &ndash; Bild-Upload &amp; KI-Analyse<br>⑥ Mapping &ndash; CSV-Spalten &rarr; Minimaldatensatz / Goobi<br>⑦ Export &ndash; Goobi-XML erzeugen (Mapping erforderlich!)</div></div>
 <div id="dr" style="display:none"><div class="sg" id="dsg"></div>
@@ -526,6 +525,10 @@
 <!-- ===== CONFIG ===== -->
 <div class="pg" data-p="config"><div style="max-width:900px">
 <div class="c" style="margin-bottom:1rem"><h2>GPUStack-Verbindung</h2>
+<div style="display:flex;align-items:center;gap:.5rem;margin-bottom:.6rem">
+<span class="dot off" id="gd2"></span><span id="gl2" style="font-size:.75rem">GPUStack …</span>
+</div>
+<div id="gi" style="font-size:.75rem;margin-bottom:.6rem">Prüfe …</div>
 <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:.5rem">
 <div><label>Server-URL</label>
 <input id="cfg-url" type="text" placeholder="http://localhost:80" style="width:100%;box-sizing:border-box"></div>
@@ -537,17 +540,23 @@
 </div>
 <div style="display:flex;gap:.5rem;align-items:center">
 <button class="btn" onclick="saveGPUConfig()">Verbindung speichern</button>
+<button class="btn s" onclick="testConn()">Verbindung testen</button>
 <span id="cfg-save-status" style="font-size:.75rem"></span>
 </div>
+<div id="cfg-test" class="ar" style="display:none;margin-top:.4rem"></div>
 </div>
-<div class="c"><h2>Modelle</h2>
+<div class="c" style="margin-bottom:1rem"><h2>Verfügbare Modelle</h2>
+<p style="font-size:.73rem;color:#666;margin-bottom:.5rem">Wähle das Standard-Modell für Text- und Vision-Aufgaben. Die Hinweise zeigen, wofür jedes Modell geeignet ist.</p>
 <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem">
-<div><label>Text-Modell</label><select id="cfg-mt"></select></div>
-<div><label>Vision-Modell</label><select id="cfg-mv"></select></div>
+<div><label>Text-Modell</label><select id="cfg-mt"></select>
+<p style="font-size:.65rem;color:#888;margin-top:.2rem">NER, Datierung, Begriffsprüfung, Spalten-Beschreibungen</p></div>
+<div><label>Vision-Modell</label><select id="cfg-mv"></select>
+<p style="font-size:.65rem;color:#888;margin-top:.2rem">Bildbeschreibung, OCR, Personen-/Gesichtserkennung</p></div>
 </div>
 <div id="cfg-models" style="font-size:.7rem;font-family:monospace;margin-top:.4rem"></div>
+<div id="model-cards" style="margin-top:.6rem"></div>
 </div>
-<div class="c" style="margin-top:1rem"><h2>System-Instruktionen</h2>
+<div class="c" style="margin-bottom:1rem"><h2>System-Instruktionen</h2>
 <label>Aktive Instruktion</label>
 <select id="cfg-preset" onchange="loadPreset()">
 <option value="meta_de">Metadaten (DE)</option><option value="meta_en">Metadaten (EN)</option>
@@ -557,10 +566,6 @@
 </select>
 <textarea id="cfg-sys" rows="6" style="margin-top:.3rem"></textarea>
 <button class="btn sm" onclick="loadPreset()">Zurücksetzen</button>
-</div>
-<div class="c" style="margin-top:1rem"><h2>Verbindungstest</h2>
-<button class="btn" onclick="testConn()">GPUStack testen</button>
-<div id="cfg-test" class="ar" style="display:none;margin-top:.4rem"></div>
 </div>
 <div class="c" style="margin-top:1rem"><h2>Aufgaben-Übersicht</h2><div id="cfg-tasks"></div></div>
 </div></div>
@@ -598,7 +603,7 @@
 </div>
 
 <!-- Progress overlay -->
-<div class="po" id="po"><div class="pc"><h3 id="pt">…</h3><div class="sp"></div><p id="pp" style="font-size:.8rem"></p></div></div>
+<div class="po" id="po"><div class="pc"><h3 id="pt">…</h3><div class="pb"><div class="pf ind" id="pf"></div></div><p id="pct" style="font-size:.75rem;margin:.3rem 0;color:#555"></p><p id="pp" style="font-size:.8rem"></p><button class="btn s sm" id="po-cancel" onclick="cancelOp()">Abbrechen (ESC)</button></div></div>
 
 <!-- JS_PLACEHOLDER -->
 </body>

--- a/src/kwb/api/parts/dashboard.css
+++ b/src/kwb/api/parts/dashboard.css
@@ -110,3 +110,15 @@ th.sortable{cursor:pointer;white-space:nowrap}th.sortable:hover{color:var(--ac)}
 .dict-type-other{background:#f3f4f6;color:#6b7280}
 .dict-auth{font-size:.62rem;color:var(--ok);font-family:monospace}
 .dict-rids{font-size:.6rem;color:#888;font-family:monospace}
+/* Progress bar */
+.pb{width:100%;height:8px;background:#e5e7eb;border-radius:4px;overflow:hidden;margin:.5rem 0}
+.pf{height:100%;background:var(--ac);border-radius:4px;transition:width .3s;width:0}
+.pf.ind{animation:indeterminate 1.5s infinite linear;background:linear-gradient(90deg,var(--ac) 0%,var(--al) 50%,var(--ac) 100%);background-size:200% 100%;width:100%!important}
+@keyframes indeterminate{0%{background-position:200% 0}100%{background-position:-200% 0}}
+#po-cancel{margin-top:.6rem}
+/* Model cards */
+.model-card{display:flex;align-items:center;gap:.5rem;padding:.35rem .5rem;border:1px solid var(--brd);border-radius:var(--r);margin-bottom:.3rem;font-size:.73rem;background:var(--paper)}
+.model-card .mc-type{font-size:.58rem;font-weight:700;text-transform:uppercase;padding:.1rem .3rem;border-radius:3px;flex-shrink:0}
+.mc-text{background:#dbeafe;color:#1d4ed8}.mc-vision{background:#dcfce7;color:var(--ok)}
+.mc-audio{background:#fce7f3;color:#9d174d}.mc-embed{background:#f3f4f6;color:#6b7280}
+.mc-rerank{background:#fef3c7;color:#92400e}.mc-unknown{background:#f5f5f4;color:#57534e}

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -41,6 +41,32 @@ let termsData=[]; // problematic terms dictionary
 let termsScanResults=[]; // last scan results
 let termsCatFilter='all';
 let colSortKey='name',colSortDir=1; // for combined columns table
+let _abortCtrl=null;
+let _opCancelled=false;
+
+// === MODEL HINTS ===
+const MODEL_HINTS={
+  'qwen3-coder':{type:'text',hint:'Code-Generierung, Reasoning, allgemeine Text-Aufgaben'},
+  'qwen3-vl':{type:'vision',hint:'Bildbeschreibung, OCR, Dokumentenanalyse (Vision-Language)'},
+  'internvl3':{type:'vision',hint:'Bilderkennung, Multi-Sprache, visuelle Fragen (Vision)'},
+  'internvl':{type:'vision',hint:'Vision-Language Modell'},
+  'faster-whisper':{type:'audio',hint:'Spracherkennung / Transkription (Whisper ASR)'},
+  'jina-reranker':{type:'rerank',hint:'Reranking von Suchergebnissen (nicht für Textgenerierung)'},
+  'granite-embedding':{type:'embed',hint:'Embedding-Generierung für Similarity Search'},
+  'deepseek-r1':{type:'text',hint:'Reasoning-Modell, Chain-of-Thought, komplexe Analysen'},
+  'gpt-oss':{type:'text',hint:'Grosses Text-Modell, NER, Datierung, Analyse'},
+  'qwen3-embedding':{type:'embed',hint:'Kompaktes Embedding-Modell (Mehrsprachig)'},
+  'llama':{type:'text',hint:'Allgemeines Text-Modell (Meta)'},
+  'mistral':{type:'text',hint:'Schnelles Text-Modell (Mistral AI)'},
+  'llava':{type:'vision',hint:'Vision-Language Modell'},
+  'phi':{type:'text',hint:'Kompaktes Text-Modell (Microsoft)'},
+  'bakllava':{type:'vision',hint:'Vision-Language Modell'},
+};
+function getModelHint(name){
+  const n=name.toLowerCase();
+  for(const[k,v]of Object.entries(MODEL_HINTS)){if(n.includes(k))return v;}
+  return{type:'unknown',hint:'Modelltyp unbekannt'};
+}
 
 // === SECURITY ===
 function esc(s){return s==null?'':String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;')}
@@ -49,7 +75,7 @@ function dl(name,content,type){const b=new Blob([content],{type});const a=docume
 
 // === NAV ===
 function bindTabs(el){const ps=[];let s=el.nextElementSibling;while(s&&s.classList.contains('tp')){ps.push(s);s=s.nextElementSibling}el.onclick=e=>{if(!e.target.classList.contains('tab'))return;const t=e.target.dataset.t;el.querySelectorAll('.tab').forEach(x=>x.classList.toggle('a',x.dataset.t===t));ps.forEach(x=>x.classList.toggle('a',x.dataset.t===t))}}
-function initNav(){try{const nav=document.querySelector('.nav');if(!nav)return;nav.onclick=e=>{if(!e.target.classList.contains('nt'))return;const p=e.target.dataset.p;document.querySelectorAll('.nt').forEach(t=>t.classList.toggle('a',t.dataset.p===p));document.querySelectorAll('.pg').forEach(x=>x.classList.toggle('a',x.dataset.p===p));if(p==='config')loadGPUConfig();}}catch(err){console.error('[initNav]',err)}}
+function initNav(){try{const nav=document.querySelector('.nav');if(!nav)return;nav.onclick=e=>{if(!e.target.classList.contains('nt'))return;const p=e.target.dataset.p;document.querySelectorAll('.nt').forEach(t=>t.classList.toggle('a',t.dataset.p===p));document.querySelectorAll('.pg').forEach(x=>x.classList.toggle('a',x.dataset.p===p));if(p==='config'){loadGPUConfig();chkGPU();}if(p==='mapping')loadFMCols();if(p==='mds'){loadCustomMdsFields();loadTasks();}if(p==='dict'){loadDictEntries();loadDictTypes();}if(p==='catalog')renderCatalog();if(p==='images')loadImages();}}catch(err){console.error('[initNav]',err)}}
 function initTabs(){try{document.querySelectorAll('.tabs').forEach(bindTabs)}catch(err){console.error('[initTabs]',err)}}
 initNav();initTabs();
 
@@ -220,10 +246,11 @@ async function runStruct(){
   const sel=[...document.querySelectorAll('.fcb:checked')].map(c=>c.value);
   if(!sel.length){alert('Mindestens eine Datei auswählen.');return}
   sp('Strukturelle Analyse …',sel.length+' Datei(en)');
+  _abortCtrl=new AbortController();
   const fd=new FormData();for(const n of sel)fd.append('files',ufiles[n]);
-  try{const r=await(await fetch('/api/analyze',{method:'POST',body:fd})).json();
+  try{const r=await(await fetch('/api/analyze',{method:'POST',body:fd,signal:_abortCtrl.signal})).json();
     if(r.error)throw Error(r.error);curRep=r;rrep(r);populateDS();updWS()
-  }catch(e){alert(e.message)}finally{hp()}
+  }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp()}
 }
 
 // === NER ===
@@ -236,15 +263,19 @@ async function runNER(isPilot=false){
   const n=isPilot?Math.max(1,Math.round(baseN*0.02)):baseN;
   sp(isPilot?'NER Pilotlauf …':'NER läuft …',method+', '+n+' Samples');
   const entityTypes=[...document.querySelectorAll('.ner-type-cb:checked')].map(c=>c.value);
-  try{const r=await(await fetch('/api/ner',{method:'POST',headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({dataset:ds,columns:cols,method,sample_size:n,
-      sample_mode:isPilot?'stratified':'random',sample_percent:isPilot?2:null,
-      stratified:isPilot,chunk_size:parseInt($('ner-chunk').value)||200,
-      model:$('cfg-mt').value||'',
-      entity_types:entityTypes.length<10?entityTypes:[],
-      system_prompt:($('ner-sp')?.value||$('cfg-sys').value)})})).json();
-    if(r.error)throw Error(r.error);nerData=r.entities||[];renderNER(r);renderRunMetrics('ner-metrics',r.run_metrics);updWS()
-  }catch(e){alert(e.message)}finally{hp()}
+  const body={dataset:ds,columns:cols,method,sample_size:n,
+    sample_mode:isPilot?'stratified':'random',sample_percent:isPilot?2:null,
+    stratified:isPilot,chunk_size:parseInt($('ner-chunk').value)||200,
+    model:$('cfg-mt').value||'',
+    entity_types:entityTypes.length<10?entityTypes:[],
+    system_prompt:($('ner-sp')?.value||$('cfg-sys').value)};
+  try{
+    await fetchSSE('/api/ner/stream',body,
+      evt=>spUp(evt.chunk,evt.total_chunks,'Chunk '+evt.chunk+' — '+evt.entities_so_far+' Entities'),
+      result=>{nerData=result.entities||[];renderNER(result);renderRunMetrics('ner-metrics',result.run_metrics);updWS();},
+      msg=>{throw Error(msg);}
+    );
+  }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp();}
 }
 
 function renderNER(r){
@@ -348,14 +379,18 @@ async function runScan(isPilot=false){const ds=$('scan-ds').value;if(!ds){alert(
   const baseN=parseInt($('scan-n').value)||10000;
   const n=isPilot?Math.max(1,Math.round(baseN*0.02)):baseN;
   sp(isPilot?'Scan Pilotlauf …':'Scan …','');
-  try{const r=await(await fetch('/api/scan',{method:'POST',headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({dataset:ds,sample_size:n,
-      sample_mode:isPilot?'stratified':'random',sample_percent:isPilot?2:null,
-      stratified:isPilot,chunk_size:parseInt($('scan-chunk').value)||200,
-      model:$('cfg-mt').value||'',
-      system_prompt:($('scan-sp')?.value||$('cfg-sys').value)})})).json();
-    if(r.error)throw Error(r.error);renderScan(r);renderRunMetrics('scan-metrics',r.run_metrics)
-  }catch(e){alert(e.message)}finally{hp()}}
+  const body={dataset:ds,sample_size:n,
+    sample_mode:isPilot?'stratified':'random',sample_percent:isPilot?2:null,
+    stratified:isPilot,chunk_size:parseInt($('scan-chunk').value)||200,
+    model:$('cfg-mt').value||'',
+    system_prompt:($('scan-sp')?.value||$('cfg-sys').value)};
+  try{
+    await fetchSSE('/api/scan/stream',body,
+      evt=>spUp(evt.chunk,evt.total_chunks,'Chunk '+evt.chunk+' — '+evt.issues_so_far+' Begriffe'),
+      result=>{renderScan(result);renderRunMetrics('scan-metrics',result.run_metrics);},
+      msg=>{throw Error(msg);}
+    );
+  }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp();}}
 
 
 function renderScan(r){$('scan-r').style.display='block';const issues=r.issues||[];
@@ -439,8 +474,10 @@ async function runDictScan(){
   if(!ds){alert('Datensatz wählen.');return;}
   if(!termsData.length){alert('Wörterbuch ist leer. Bitte erst Begriffe hinzufügen.');return;}
   sp('Dictionary-Scan läuft…',termsData.length+' Begriffe');
+  _abortCtrl=new AbortController();
   try{
     const r=await fetch('/api/dict-scan',{method:'POST',headers:{'Content-Type':'application/json'},
+      signal:_abortCtrl.signal,
       body:JSON.stringify({
         dataset:ds,
         whole_word:$('terms-whole-word')?.checked!==false,
@@ -452,7 +489,7 @@ async function runDictScan(){
     termsScanResults=d.matches||[];
     termsCatFilter='all';
     renderDictScanResults(d);
-  }catch(e){alert('Fehler: '+e.message);}finally{hp();}
+  }catch(e){if(e.name!=='AbortError')alert('Fehler: '+e.message);}finally{hp();}
 }
 function renderDictScanResults(d){
   const resEl=$('terms-results');const emptyEl=$('terms-results-empty');
@@ -507,15 +544,19 @@ async function runEDTF(isPilot=false){const ds=$('edtf-ds').value,col=$('edtf-co
   const baseN=parseInt($('edtf-n').value)||0;
   const n=isPilot?Math.max(1,Math.round((baseN||10000)*0.02)):baseN;
   sp(isPilot?'EDTF Pilotlauf …':'EDTF …',esc(col));
-  try{const r=await(await fetch('/api/edtf',{method:'POST',headers:{'Content-Type':'application/json'},
-    body:JSON.stringify({dataset:ds,column:col,sample_size:n,
-      sample_mode:isPilot?'stratified':'random',sample_percent:isPilot?2:null,
-      stratified:isPilot,chunk_size:parseInt($('edtf-chunk').value)||200,
-      use_llm:$('edtf-llm').value==='1',
-      model:$('cfg-mt').value||'',
-      system_prompt:$('edtf-sp').value||$('cfg-sys').value})})).json();
-    if(r.error)throw Error(r.error);edtfData=r.results||[];renderEDTF(r);renderRunMetrics('edtf-metrics',r.run_metrics);updWS()
-  }catch(e){alert(e.message)}finally{hp()}}
+  const body={dataset:ds,column:col,sample_size:n,
+    sample_mode:isPilot?'stratified':'random',sample_percent:isPilot?2:null,
+    stratified:isPilot,chunk_size:parseInt($('edtf-chunk').value)||200,
+    use_llm:$('edtf-llm').value==='1',
+    model:$('cfg-mt').value||'',
+    system_prompt:$('edtf-sp').value||$('cfg-sys').value};
+  try{
+    await fetchSSE('/api/edtf/stream',body,
+      evt=>spUp(evt.chunk,evt.total_chunks,'Chunk '+evt.chunk+' — '+evt.results_so_far+' konvertiert'),
+      result=>{edtfData=result.results||[];renderEDTF(result);renderRunMetrics('edtf-metrics',result.run_metrics);updWS();},
+      msg=>{throw Error(msg);}
+    );
+  }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp();}}
 
 
 function renderEDTF(r){
@@ -742,18 +783,44 @@ async function setIdCol(filename,sourceName){
 
 // === GPU ===
 async function chkGPU(){try{const d=await(await fetch('/api/gpu/status')).json();
+    // Update both header and KI tab status indicators
+    function setDot(cls,txt){
+      $('gd').className='dot '+cls;$('gl').textContent=txt;
+      if($('gd2'))$('gd2').className='dot '+cls;if($('gl2'))$('gl2').textContent=txt;
+    }
     if(!d.configured){
-      $('gd').className='dot mock';$('gl').textContent='Testdaten-Modus';
+      setDot('mock','Testdaten-Modus');
       $('gi').textContent='KI-Analyse verwendet Testdaten. F\u00fcr echte Ergebnisse: KWB_GPUSTACK_URL in .env konfigurieren.';
       if($('img-mock-hint'))$('img-mock-hint').style.display='block';
+      if($('model-cards'))$('model-cards').innerHTML='<p style="font-size:.73rem;color:#888">Keine Modelle verfügbar (Mock-Modus).</p>';
     }else if(d.available){
-      $('gd').className='dot on';$('gl').textContent='GPUStack: '+(d.models?.length||0)+' Modelle';
+      setDot('on','GPUStack: '+(d.models?.length||0)+' Modelle');
       gpuM=d.models||[];const cfg=d.config||{};
-      $('gi').innerHTML='<div style="font-size:.7rem;font-family:monospace">'+gpuM.map(m=>'<div>'+esc(m)+'</div>').join('')+'</div>';
-      for(const sid of['cfg-mt','cfg-mv']){$(sid).innerHTML=gpuM.map(m=>safeOpt(m,m)).join('')}
-      $('cfg-models').textContent='Text: '+(cfg.gpustack_model_text||'—')+' / Vision: '+(cfg.gpustack_model_vision||'—')
+      $('gi').innerHTML='<span style="color:var(--ok);font-weight:600">Verbunden</span> — '+(gpuM.length)+' Modelle verfügbar';
+      // Populate model dropdowns with type hints
+      const textModels=gpuM.filter(m=>{const h=getModelHint(m);return h.type==='text'||h.type==='unknown';});
+      const visionModels=gpuM.filter(m=>{const h=getModelHint(m);return h.type==='vision'||h.type==='unknown';});
+      $('cfg-mt').innerHTML=gpuM.map(m=>{const h=getModelHint(m);return '<option value="'+esc(m)+'">'+esc(m)+(h.type!=='unknown'?' ['+h.type.toUpperCase()+']':'')+'</option>';}).join('');
+      $('cfg-mv').innerHTML=gpuM.map(m=>{const h=getModelHint(m);return '<option value="'+esc(m)+'">'+esc(m)+(h.type!=='unknown'?' ['+h.type.toUpperCase()+']':'')+'</option>';}).join('');
+      // Pre-select configured models
+      if(cfg.gpustack_model_text)$('cfg-mt').value=cfg.gpustack_model_text;
+      if(cfg.gpustack_model_vision)$('cfg-mv').value=cfg.gpustack_model_vision;
+      $('cfg-models').textContent='Aktiv — Text: '+(cfg.gpustack_model_text||'—')+' / Vision: '+(cfg.gpustack_model_vision||'—');
+      // Render model cards
+      if($('model-cards')){
+        $('model-cards').innerHTML=gpuM.map(m=>{
+          const h=getModelHint(m);
+          return '<div class="model-card"><span class="mc-type mc-'+h.type+'">'+esc(h.type)+'</span><strong style="flex:1">'+esc(m)+'</strong><span style="color:#888;font-size:.68rem">'+esc(h.hint)+'</span></div>';
+        }).join('');
+      }
+      // Also populate image model dropdown
+      if($('img-model')){
+        $('img-model').innerHTML='<option value="">Standard (aus Konfiguration)</option>'+
+          visionModels.map(m=>safeOpt(m,m+' [VISION]')).join('')+
+          textModels.map(m=>safeOpt(m,m+' [TEXT]')).join('');
+      }
     }else{
-      $('gd').className='dot off';$('gl').textContent='GPUStack: nicht erreichbar';
+      setDot('off','GPUStack: nicht erreichbar');
       $('gi').textContent='Verbindung fehlgeschlagen. URL/Key in .env prüfen. '+(d.message||'');
     }
   }catch(e){$('gd').className='dot off';$('gl').textContent='Verbindungsfehler';}}
@@ -855,12 +922,16 @@ function renderImgGrid(){
   empty.style.display='none';
   empty.textContent='Noch keine Bilder hochgeladen.';
   grid.innerHTML = shown.map(function(img){
-    return '<div style="border:1px solid var(--brd);border-radius:4px;padding:.4rem;font-size:.72rem;background:#fafafa;display:flex;flex-direction:column;gap:.25rem">'
-      +'<img src="/api/images/'+esc(img.id)+'/data" alt="'+esc(img.filename)+'"'
+    const isTiff=(img.media_type||'').includes('tiff');
+    const thumb=isTiff
+      ?'<div style="height:140px;display:flex;align-items:center;justify-content:center;background:#eee;border-radius:3px;color:#888;font-size:.85rem;font-weight:600;cursor:pointer" onclick="openLightbox(\'/api/images/'+esc(img.id)+'/data\',\''+esc(img.filename)+'\')">TIFF</div>'
+      :'<img src="/api/images/'+esc(img.id)+'/data" alt="'+esc(img.filename)+'"'
       +' style="width:100%;height:140px;object-fit:contain;background:#eee;border-radius:3px;display:block;cursor:pointer"'
       +' onclick="openLightbox(\'/api/images/'+esc(img.id)+'/data\',\''+esc(img.filename)+' — '+(img.width||'?')+'x'+(img.height||'?')+'\')"'
       +' onerror="this.style.display=\'none\';this.nextElementSibling.style.display=\'flex\'">'
-      +'<div style="display:none;height:140px;align-items:center;justify-content:center;background:#eee;border-radius:3px;color:#aaa;font-size:.68rem">Vorschau n/v</div>'
+      +'<div style="display:none;height:140px;align-items:center;justify-content:center;background:#eee;border-radius:3px;color:#aaa;font-size:.68rem">Vorschau n/v</div>';
+    return '<div style="border:1px solid var(--brd);border-radius:4px;padding:.4rem;font-size:.72rem;background:#fafafa;display:flex;flex-direction:column;gap:.25rem">'
+      +thumb
       +'<div style="font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="'+esc(img.filename)+'">'+esc(img.filename)+'</div>'
       +'<div style="color:#888;font-size:.65rem">'+((img.size_bytes/1024).toFixed(1))+' KB &middot; '+esc(img.media_type||'')+'</div>'
       +'<div><span class="bg '+(img.analyzed?'ac':'no')+'">'+esc(img.analyzed?'analysiert':'ausstehend')+'</span></div>'
@@ -873,25 +944,22 @@ async function analyzeImages(){
   const sp_text = $('img-sp').value;
   const ids = uploadedImages.map(i=>i.id);
   sp('Bildanalyse läuft…', ids.length + ' Bild(er)');
+  const body={image_ids:ids, model:mod, system_prompt:sp_text, prompt_task:$('img-task').value};
   try{
-    const r = await fetch('/api/images/analyze',{
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({image_ids:ids, model:mod, system_prompt:sp_text, prompt_task:$('img-task').value})
-    });
-    const data = await r.json();
-    if(data.error){$('img-results-empty').textContent='Fehler: '+data.error;hp();return}
-    renderImgResults(data.results||[]);
-    hp();
-    // Persistence hint
-    if((data.results||[]).some(r=>r.result))$('img-results-empty').textContent='';
-    // Update analyzed flag
-    (data.results||[]).forEach(res=>{
-      const img = uploadedImages.find(i=>i.id===res.id);
-      if(img) img.analyzed = !!res.result;
-    });
-    renderImgGrid();
-  }catch(e){$('img-results-empty').textContent='Fehler: '+e;hp();}
+    await fetchSSE('/api/images/analyze/stream',body,
+      evt=>{spUp(evt.current,evt.total,esc(evt.filename||''));},
+      result=>{
+        renderImgResults(result.results||[]);
+        if((result.results||[]).some(r=>r.result))$('img-results-empty').textContent='';
+        (result.results||[]).forEach(res=>{
+          const img=uploadedImages.find(i=>i.id===res.id);
+          if(img)img.analyzed=!!res.result;
+        });
+        renderImgGrid();
+      },
+      msg=>{$('img-results-empty').textContent='Fehler: '+msg;}
+    );
+  }catch(e){if(e.name!=='AbortError')$('img-results-empty').textContent='Fehler: '+e;}finally{hp();}
 }
 
 function renderImgResults(results){
@@ -1036,9 +1104,11 @@ async function runOCR(){
   const mod=$('img-model').value;
   const ids=uploadedImages.map(i=>i.id);
   sp('OCR läuft…',ids.length+' Bild(er)');
+  _abortCtrl=new AbortController();
   try{
     const r=await fetch('/api/images/ocr',{
       method:'POST',headers:{'Content-Type':'application/json'},
+      signal:_abortCtrl.signal,
       body:JSON.stringify({image_ids:ids,model:mod,system_prompt:$('ocr-sp').value||''})
     });
     const data=await r.json();
@@ -1273,10 +1343,12 @@ function exportDictTyped(){window.open('/api/dictionary/export-typed','_blank')}
 async function runMdsValidation(){
   const ds=$('mds-ds').value;if(!ds){alert('Datensatz wählen');return}
   sp('MDS validieren …','');
+  _abortCtrl=new AbortController();
   try{const r=await(await fetch('/api/mds/validate',{method:'POST',headers:{'Content-Type':'application/json'},
+    signal:_abortCtrl.signal,
     body:JSON.stringify({dataset:ds,include_custom:$('mds-custom').checked})})).json();
     if(r.error){alert(r.error);return}renderMdsResults(r);
-  }catch(e){alert(e.message)}finally{hp()}
+  }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp()}
 }
 function renderMdsResults(r){
   $('mds-empty').style.display='none';$('mds-results').style.display='block';
@@ -1359,8 +1431,59 @@ async function delCustomMdsField(idx){
 function renderCatalog(){$('cat-body').innerHTML=CATALOG.map(c=>'<tr><td style="font-size:.62rem">'+esc(c.id)+'</td><td style="font-weight:600">'+esc(c.name)+'</td><td style="font-size:.68rem">'+esc(c.module)+'</td><td><span class="bg '+(c.status==='done'?'ac':c.status==='partial'?'pl':'no')+'">'+esc(c.status)+'</span></td><td style="font-size:.68rem">'+esc(c.tests||'—')+'</td><td style="font-size:.7rem;color:#666">'+esc(c.note||'')+'</td></tr>').join('')}
 
 // === PROGRESS ===
-function sp(t,x){$('pt').textContent=t;$('pp').textContent=x||'';$('po').classList.add('a')}
-function hp(){$('po').classList.remove('a')}
+function sp(t,x){
+  _opCancelled=false;
+  $('pt').textContent=t;$('pp').textContent=x||'';$('pct').textContent='';
+  const pf=$('pf');pf.style.width='0';pf.classList.add('ind');
+  $('po').classList.add('a');
+}
+function spUp(current,total,detail){
+  const pf=$('pf');pf.classList.remove('ind');
+  const pct=total>0?Math.round((current/total)*100):0;
+  pf.style.width=pct+'%';
+  $('pct').textContent=current+' / '+total+' ('+pct+'%)';
+  if(detail)$('pp').textContent=detail;
+}
+function hp(){$('po').classList.remove('a');_abortCtrl=null;}
+function cancelOp(){
+  _opCancelled=true;
+  if(_abortCtrl){_abortCtrl.abort();_abortCtrl=null;}
+  hp();
+}
+// ESC handler
+document.addEventListener('keydown',function(e){
+  if(e.key==='Escape'){
+    if($('lightbox').classList.contains('a')){closeLightbox();return;}
+    if($('po').classList.contains('a')){cancelOp();return;}
+  }
+});
+
+// === SSE READER ===
+async function fetchSSE(url,body,onProgress,onDone,onError){
+  _abortCtrl=new AbortController();
+  const resp=await fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify(body),signal:_abortCtrl.signal});
+  if(!resp.ok){const e=await resp.json().catch(()=>({error:resp.statusText}));throw Error(e.error||resp.statusText);}
+  const reader=resp.body.getReader();
+  const decoder=new TextDecoder();
+  let buf='';
+  while(true){
+    const{done,value}=await reader.read();
+    if(done)break;
+    buf+=decoder.decode(value,{stream:true});
+    const lines=buf.split('\n');
+    buf=lines.pop()||'';
+    for(const line of lines){
+      if(!line.startsWith('data: '))continue;
+      try{
+        const evt=JSON.parse(line.slice(6));
+        if(evt.type==='progress'&&onProgress)onProgress(evt);
+        else if(evt.type==='done'&&onDone)onDone(evt.result);
+        else if(evt.type==='error'&&onError)onError(evt.message);
+      }catch(parseErr){console.warn('SSE parse error',parseErr);}
+    }
+  }
+}
 
 // === INIT ===
 function showInitError(label){const b=document.createElement('div');b.style.cssText='position:fixed;bottom:0;left:0;right:0;z-index:9999;background:#fee2e2;color:#991b1b;padding:.4rem 1rem;font-size:.78rem;border-top:2px solid #f87171';b.textContent='⚠ UI-Initialisierung fehlgeschlagen'+(label?': '+label:'')+' – bitte Konsole prüfen';document.body.appendChild(b)}

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -14,9 +14,11 @@ import base64
 import tempfile as _tempfile
 from pathlib import Path
 
+import json
+
 try:
     from fastapi import APIRouter, File, UploadFile
-    from fastapi.responses import JSONResponse, Response
+    from fastapi.responses import JSONResponse, Response, StreamingResponse
 except ImportError:
     raise ImportError("pip install fastapi uvicorn python-multipart")
 
@@ -38,6 +40,11 @@ from kwb.ai.prompts import (
 from kwb.ingest.image_loader import ingest_image
 
 router = APIRouter()
+
+
+def _sse_event(data: dict) -> str:
+    """Format a dict as an SSE data line."""
+    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
 def _parse_image_review_status(status_raw: str) -> ImageReviewStatus | None:
@@ -257,6 +264,11 @@ def _sync_index() -> None:
 
 _sync_index()
 
+# Remove stale entries whose files no longer exist on disk
+_stale = [k for k, v in _uploaded_images.items() if not Path(v["path"]).exists()]
+for _k in _stale:
+    del _uploaded_images[_k]
+
 def _vision_prompt_for_task(task: str, context: str = ""):
     if task == "person_face_visibility":
         return prompt_person_face_visibility(additional_context=context)
@@ -352,6 +364,10 @@ async def image_data(img_id: str):
 @router.get("/api/images")
 async def images_list():
     """List all uploaded images and their analysis status."""
+    # Filter out stale entries whose files no longer exist
+    stale_ids = [k for k, img in _uploaded_images.items() if not Path(img["path"]).exists()]
+    for sid in stale_ids:
+        del _uploaded_images[sid]
     return {
         "images": [
             {
@@ -481,6 +497,128 @@ async def images_analyze(request: dict):
             "task": task,
         },
     }
+
+
+@router.post("/api/images/analyze/stream")
+async def images_analyze_stream(request: dict):
+    """SSE streaming version of /api/images/analyze — yields progress per image."""
+    from datetime import datetime
+    from kwb.core.utils import try_parse_json
+
+    image_ids = request.get("image_ids", list(_uploaded_images.keys()))
+    image_record_map = request.get("image_record_map", {})
+    mod = request.get("model", "")
+    task = request.get("prompt_task", "image_description")
+    syp = request.get("system_prompt", "")
+
+    if not image_ids:
+        return JSONResponse({"error": "Keine Bilder hochgeladen"}, 400)
+
+    prov = get_provider(mod)
+    prompt_name, prompt_version = _prompt_meta(task)
+    total = len(image_ids)
+
+    async def generate():
+        results = []
+        for idx, img_id in enumerate(image_ids, 1):
+            img = _uploaded_images.get(img_id)
+            if not img:
+                results.append({"id": img_id, "error": "Nicht gefunden"})
+                yield _sse_event({
+                    "type": "progress", "current": idx, "total": total,
+                    "filename": img_id,
+                })
+                continue
+
+            try:
+                b64 = base64.b64encode(
+                    Path(img["path"]).read_bytes()
+                ).decode("ascii")
+                data_url = f"data:{img['media_type']};base64,{b64}"
+                ctx = request.get("additional_context", "") or img["filename"]
+                prompt_msgs = _vision_prompt_for_task(task, context=ctx)
+                if syp:
+                    prompt_msgs[0] = AIMessage.system(syp)
+                prompt_msgs[1] = AIMessage.user([
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                    {"type": "text", "text": prompt_msgs[1].content},
+                ])
+
+                resp = prov.complete(prompt_msgs, model=mod or None, max_tokens=900)
+                parsed = try_parse_json(resp.content) or {
+                    "description": resp.content, "uncertain": True,
+                }
+                img["analyzed"] = True
+                img["result"] = parsed
+                img["record_id"] = image_record_map.get(
+                    img_id, img.get("record_id", ""),
+                )
+                results.append({
+                    "id": img_id, "filename": img["filename"],
+                    "record_id": img.get("record_id", ""),
+                    "review_status": img.get("review_status", "pending"),
+                    "result": parsed,
+                })
+
+                ws = get_workspace()
+                ws.save_image_analysis(ImageAnalysisResult(
+                    image_id=img_id,
+                    filename=img["filename"],
+                    media_type=img["media_type"],
+                    size_bytes=img.get("size_bytes", 0),
+                    width=img.get("width"),
+                    height=img.get("height"),
+                    hash_sha256=img.get("hash_sha256", ""),
+                    exif_subset=img.get("exif_subset", {}),
+                    analyzed=True,
+                    result=parsed,
+                    model=mod or "default",
+                    analyzed_at=datetime.utcnow().isoformat(),
+                    record_id=img.get("record_id", ""),
+                    review_status=ImageReviewStatus(
+                        img.get("review_status", "pending")
+                    ),
+                    review_comment=img.get("review_comment", ""),
+                    reviewer=img.get("reviewer", ""),
+                    reviewed_at=img.get("reviewed_at", ""),
+                    prompt_name=prompt_name,
+                    prompt_version=prompt_version,
+                ))
+                ws.save(workspace_dir() / safe_filename(ws.name))
+
+            except Exception as e:
+                results.append({"id": img_id, "error": str(e)})
+
+            yield _sse_event({
+                "type": "progress", "current": idx, "total": total,
+                "filename": img.get("filename", img_id) if img else img_id,
+            })
+
+        ws = get_workspace()
+        ws.log_ai_run(
+            "image_analysis", mod or "vision", len(results),
+            len([r for r in results if "result" in r]),
+            prompt_name=prompt_name, prompt_version=prompt_version,
+        )
+        yield _sse_event({
+            "type": "done",
+            "result": {
+                "total": total,
+                "analyzed": len([r for r in results if "result" in r]),
+                "model": mod or "default",
+                "prompt_name": prompt_name,
+                "prompt_version": prompt_version,
+                "results": results,
+                "ai_provenance": {
+                    "model": mod or "default",
+                    "prompt_name": prompt_name,
+                    "prompt_version": prompt_version,
+                    "task": task,
+                },
+            },
+        })
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
 
 
 @router.post("/api/images/{img_id}/review")

--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -19,7 +19,7 @@ import pandas as pd
 
 try:
     from fastapi import APIRouter, File, UploadFile
-    from fastapi.responses import JSONResponse
+    from fastapi.responses import JSONResponse, StreamingResponse
 except ImportError:
     raise ImportError("pip install fastapi uvicorn python-multipart")
 
@@ -35,6 +35,11 @@ from kwb.report.markdown import render_report
 from kwb.ai.prompts import PROMPT_VERSIONS
 
 router = APIRouter()
+
+
+def _sse_event(data: dict) -> str:
+    """Format a dict as an SSE data line."""
+    return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
 
 
 def _apply_filters(df: pd.DataFrame, filters: dict | None) -> pd.DataFrame:
@@ -427,6 +432,129 @@ async def api_ner(request: dict):
 
 
 # ---------------------------------------------------------------------------
+# NER — SSE streaming
+# ---------------------------------------------------------------------------
+
+@router.post("/api/ner/stream")
+async def api_ner_stream(request: dict):
+    """SSE streaming version of /api/ner — yields progress per chunk."""
+    dsn = request.get("dataset", "")
+    ds = get_datasets().get(dsn)
+    if not ds:
+        return JSONResponse({"error": "Datensatz nicht geladen"}, 400)
+    df, profile = ds
+    cols = request.get("columns", [])
+    if not cols:
+        cols = [c for c in df.columns if df[c].dtype == object]
+    method = request.get("method", "llm")
+    ss = min(int(request.get("sample_size", 10) or 10), max(len(df), 1))
+    chunk_size = max(1, min(int(request.get("chunk_size", 200) or 200), 1000))
+    syp = request.get("system_prompt", "")
+    mod = request.get("model", "")
+    prov = get_provider(mod)
+    ws = get_workspace()
+    entity_types = request.get("entity_types", [])
+    working, sampling = _build_sampling_plan(df, request, profile.id_column, ss)
+
+    total_chunks = max(1, -(-len(working) // chunk_size))  # ceil division
+
+    async def generate():
+        started = time.perf_counter()
+        all_entities = []
+        errors = 0
+        chunk_reports = []
+        for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
+            try:
+                chunk_result = ner_hybrid(
+                    chunk_df, cols,
+                    provider=prov if method != "spacy" else None,
+                    id_column=profile.id_column,
+                    sample_size=None,
+                    model=mod or None,
+                    system_prompt=syp,
+                    use_spacy=(method in ("spacy", "hybrid")),
+                    use_llm=(method in ("llm", "hybrid")),
+                    entity_types=entity_types or None,
+                )
+                new_ents = chunk_result.to_dict_list(deduplicated=False)
+                all_entities.extend(new_ents)
+                chunk_reports.append({
+                    "chunk": chunk_no, "rows": len(chunk_df),
+                    "entities": len(chunk_result.entities),
+                })
+            except Exception:
+                errors += len(chunk_df)
+                chunk_reports.append({
+                    "chunk": chunk_no, "rows": len(chunk_df), "error": True,
+                })
+
+            yield _sse_event({
+                "type": "progress", "chunk": chunk_no,
+                "total_chunks": total_chunks,
+                "entities_so_far": len(all_entities),
+            })
+
+        # Deduplicate + build final result (same logic as api_ner)
+        if entity_types:
+            all_entities = [e for e in all_entities if e.get("type") in entity_types]
+        dedup = {}
+        for e in all_entities:
+            key = f"{str(e.get('text','')).strip().lower()}||{e.get('type','CON')}"
+            if key not in dedup or float(e.get("confidence", 0)) > float(
+                dedup[key].get("confidence", 0)
+            ):
+                dedup[key] = e
+        ents = list(dedup.values())
+        by_type = {}
+        for e in ents:
+            etype = e.get("type", "CON")
+            by_type[etype] = by_type.get(etype, 0) + 1
+        ws.add_entities(ents, replace=True)
+
+        model_name = mod or method
+        prompt_name = "entity_extraction_normdata"
+        prompt_version = PROMPT_VERSIONS.get("entity_extraction_normdata", "1.0.0")
+        ws.log_ai_run(
+            "ner_extract", model_name, len(ents),
+            len([e for e in ents if e.get("confidence", 0) > 0.5]),
+            prompt_name=prompt_name, prompt_version=prompt_version,
+        )
+
+        elapsed = max(time.perf_counter() - started, 0.001)
+        metrics = {
+            "processed_rows": len(working), "total_rows": len(df),
+            "error_rows": errors,
+            "error_rate": round(errors / len(working), 4) if len(working) else 0,
+            "elapsed_seconds": round(elapsed, 2),
+            "eta_seconds": _estimate_eta(len(working), len(df), elapsed),
+            "chunk_count": len(chunk_reports), "chunks": chunk_reports,
+            "sampling": sampling,
+        }
+        _persist_chunk_run(ws, "ner", dsn, {
+            "run_id": str(uuid.uuid4()), **metrics,
+        })
+        ai_provenance = {
+            "model": model_name, "prompt_name": prompt_name,
+            "prompt_version": prompt_version,
+            "entity_types_requested": entity_types or "all",
+        }
+        yield _sse_event({
+            "type": "done",
+            "result": {
+                "task_name": "NER", "total": len(ents),
+                "prompt_name": prompt_name, "prompt_version": prompt_version,
+                "succeeded": len([e for e in ents if e.get("confidence", 0) > 0.3]),
+                "model": model_name,
+                "entities": ents[:500], "by_type": by_type,
+                "run_metrics": metrics, "ai_provenance": ai_provenance,
+                "workspace": ws.to_summary(),
+            },
+        })
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+# ---------------------------------------------------------------------------
 # Scan (problematic terms)
 # ---------------------------------------------------------------------------
 
@@ -477,6 +605,83 @@ async def api_scan(request: dict):
         "issues": issues[:200],
         "run_metrics": metrics,
     }
+
+
+# ---------------------------------------------------------------------------
+# Scan — SSE streaming
+# ---------------------------------------------------------------------------
+
+@router.post("/api/scan/stream")
+async def api_scan_stream(request: dict):
+    """SSE streaming version of /api/scan — yields progress per chunk."""
+    dsn = request.get("dataset", "")
+    ds = get_datasets().get(dsn)
+    if not ds:
+        return JSONResponse({"error": "Datensatz nicht geladen"}, 400)
+    df, profile = ds
+    ss = min(int(request.get("sample_size", 20) or 20), max(len(df), 1))
+    chunk_size = max(1, min(int(request.get("chunk_size", 200) or 200), 1000))
+    syp = request.get("system_prompt", "")
+    mod = request.get("model", "")
+    prov = get_provider(mod)
+    working, sampling = _build_sampling_plan(df, request, profile.id_column, ss)
+
+    total_chunks = max(1, -(-len(working) // chunk_size))
+
+    async def generate():
+        started = time.perf_counter()
+        issues, errors, batches = [], 0, []
+        for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
+            try:
+                i2, batch = scan_problematic_terms(
+                    chunk_df, prov,
+                    id_column=profile.id_column,
+                    sample_size=len(chunk_df),
+                    model=mod or None,
+                    system_prompt=syp,
+                )
+                issues.extend(i2)
+                batches.append({
+                    "chunk": chunk_no, "rows": len(chunk_df),
+                    "issues": len(i2), "succeeded": batch.succeeded,
+                })
+            except Exception:
+                errors += len(chunk_df)
+                batches.append({
+                    "chunk": chunk_no, "rows": len(chunk_df), "error": True,
+                })
+
+            yield _sse_event({
+                "type": "progress", "chunk": chunk_no,
+                "total_chunks": total_chunks,
+                "issues_so_far": len(issues),
+            })
+
+        elapsed = max(time.perf_counter() - started, 0.001)
+        metrics = {
+            "processed_rows": len(working), "total_rows": len(df),
+            "error_rows": errors,
+            "error_rate": round(errors / len(working), 4) if len(working) else 0,
+            "elapsed_seconds": round(elapsed, 2),
+            "eta_seconds": _estimate_eta(len(working), len(df), elapsed),
+            "chunk_count": len(batches), "chunks": batches,
+            "sampling": sampling,
+        }
+        ws = get_workspace()
+        _persist_chunk_run(ws, "scan", dsn, {
+            "run_id": str(uuid.uuid4()), **metrics,
+        })
+        succeeded = sum(b.get("succeeded", 0) for b in batches)
+        yield _sse_event({
+            "type": "done",
+            "result": {
+                "task_name": "Scan", "total": len(working),
+                "succeeded": succeeded, "model": mod or "default",
+                "issues": issues[:200], "run_metrics": metrics,
+            },
+        })
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +764,116 @@ async def api_edtf(request: dict):
             for r in results
         ],
     }
+
+
+# ---------------------------------------------------------------------------
+# EDTF — SSE streaming
+# ---------------------------------------------------------------------------
+
+@router.post("/api/edtf/stream")
+async def api_edtf_stream(request: dict):
+    """SSE streaming version of /api/edtf — yields progress per chunk."""
+    dsn = request.get("dataset", "")
+    ds = get_datasets().get(dsn)
+    if not ds:
+        return JSONResponse({"error": "Datensatz nicht geladen"}, 400)
+    df, profile = ds
+    col = request.get("column", "")
+    if not col:
+        return JSONResponse({"error": "Spalte wählen"}, 400)
+    if col not in df.columns:
+        return JSONResponse({"error": f"Spalte '{col}' nicht vorhanden"}, 400)
+
+    ss = int(request.get("sample_size", 0) or 0)
+    chunk_size = max(1, min(int(request.get("chunk_size", 200) or 200), 1000))
+    use_llm = request.get("use_llm", False)
+    syp = request.get("system_prompt", "")
+    mod = request.get("model", "")
+    ws = get_workspace()
+
+    mask = df[col].replace("", pd.NA).notna()
+    source_df = df[mask]
+    working, sampling = _build_sampling_plan(source_df, request, profile.id_column, ss)
+    prov = get_provider(mod) if use_llm else None
+
+    total_chunks = max(1, -(-len(working) // chunk_size))
+
+    async def generate():
+        started = time.perf_counter()
+        all_results = []
+        chunk_reports = []
+        errors = 0
+        for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
+            items = [
+                {
+                    "record_id": (
+                        str(row.get(profile.id_column, "")) if profile.id_column else ""
+                    ),
+                    "text": str(row[col]).strip(),
+                }
+                for _, row in chunk_df.iterrows()
+                if str(row[col]).strip()
+            ]
+            try:
+                results, _batch = normalize_dates(
+                    items, provider=prov, model=mod or None, system_prompt=syp,
+                )
+                all_results.extend(results)
+                chunk_reports.append({
+                    "chunk": chunk_no, "rows": len(chunk_df),
+                    "results": len(results),
+                })
+            except Exception:
+                errors += len(chunk_df)
+                chunk_reports.append({
+                    "chunk": chunk_no, "rows": len(chunk_df), "error": True,
+                })
+
+            yield _sse_event({
+                "type": "progress", "chunk": chunk_no,
+                "total_chunks": total_chunks,
+                "results_so_far": len(all_results),
+            })
+
+        results = all_results
+        ws.add_dates([
+            {"original": r.original, "edtf": r.edtf, "confidence": r.confidence,
+             "method": r.method, "record_id": r.record_id, "column": col}
+            for r in results
+        ], replace=True)
+
+        converted = len([r for r in results if r.edtf])
+        undated = len([r for r in results if not r.edtf and "undatiert" in r.note])
+        failed = len(results) - converted - undated
+        elapsed = max(time.perf_counter() - started, 0.001)
+        metrics = {
+            "processed_rows": len(working), "total_rows": len(source_df),
+            "error_rows": errors,
+            "error_rate": round(errors / len(working), 4) if len(working) else 0,
+            "elapsed_seconds": round(elapsed, 2),
+            "eta_seconds": _estimate_eta(len(working), len(source_df), elapsed),
+            "chunk_count": len(chunk_reports), "chunks": chunk_reports,
+            "sampling": sampling,
+        }
+        _persist_chunk_run(ws, "edtf", dsn, {
+            "run_id": str(uuid.uuid4()), **metrics,
+        })
+        yield _sse_event({
+            "type": "done",
+            "result": {
+                "task_name": "EDTF", "total": len(results),
+                "converted": converted, "failed": failed, "undated": undated,
+                "model": mod or "rule", "run_metrics": metrics,
+                "results": [
+                    {"record_id": r.record_id, "original": r.original,
+                     "edtf": r.edtf, "confidence": round(r.confidence, 3),
+                     "method": r.method, "note": r.note}
+                    for r in results
+                ],
+            },
+        })
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds Server-Sent Events (SSE) streaming support for long-running AI analysis operations (NER, Scan, EDTF, and Image Analysis), enabling real-time progress updates to the client instead of waiting for the entire operation to complete.

## Key Changes

### Backend (Python/FastAPI)
- **New SSE helper function**: Added `_sse_event()` utility in both `analyze.py` and `ai.py` to format progress events as SSE data lines
- **Streaming endpoints**: Added four new `/stream` variants:
  - `/api/ner/stream` - NER with per-chunk progress and entity count updates
  - `/api/scan/stream` - Problematic terms scanning with per-chunk progress
  - `/api/edtf/stream` - Date normalization with per-chunk progress
  - `/api/images/analyze/stream` - Image analysis with per-image progress
- **Progress tracking**: Each streaming endpoint yields progress events during processing and a final `done` event with complete results
- **Image cleanup**: Added stale file detection in image listing to remove entries whose files no longer exist on disk
- **Imports**: Added `StreamingResponse` from FastAPI and `json` module for SSE formatting

### Frontend (JavaScript)
- **SSE client handler**: Implemented `fetchSSE()` function to consume streaming responses with callbacks for progress and completion
- **Abort control**: Added `_abortCtrl` and `_opCancelled` variables to support cancellation of long-running operations
- **Updated task runners**: Modified `runNER()`, `runScan()`, `runEDTF()`, and `analyzeImages()` to use SSE streaming instead of single-request pattern
- **Progress UI**: Added `spUp()` calls to update progress bar with chunk/image counts during streaming
- **Error handling**: Updated error handling to distinguish between `AbortError` and actual failures
- **GPU status improvements**: Enhanced `chkGPU()` to display model type hints, populate dropdowns with model metadata, and render model cards
- **Image grid**: Added TIFF file handling with placeholder display and improved image preview rendering

## Implementation Details

- SSE events use JSON format with `type` field (`progress` or `done`) for client-side routing
- Streaming endpoints maintain the same request/response structure as their non-streaming counterparts for consistency
- Progress events include chunk numbers, totals, and running counts (entities, issues, results)
- Final `done` events include complete results, metrics, and AI provenance information
- All streaming operations support cancellation via `AbortController`
- Model hints provide type information (text, vision, audio, etc.) to guide user selection

https://claude.ai/code/session_012be37g7iHHLoYxPuwBNoqZ