### PR TITLE
Add end-to-end OCR → NER → Dictionary pipeline with 3 review gates

### DIFF
--- a/src/kwb/api/app.py
+++ b/src/kwb/api/app.py
@@ -178,8 +178,14 @@ CATALOG = [
     {"id": "R-02", "name": "OCR/HTR",             "module": "Analyse",   "status": "planned", "note": ""},
     {"id": "R-03", "name": "Goobi Viewer API",    "module": "Export",    "status": "done",    "note": "REST Push via /api/goobi/*"},
     {"id": "R-04", "name": "METS/MODS Export",    "module": "Export",    "status": "planned", "note": ""},
-    {"id": "R-05", "name": "GeoNames Lookup",     "module": "Enrich",    "status": "planned", "note": ""},
+    {"id": "R-05", "name": "GeoNames Lookup",     "module": "Enrich",    "status": "done",    "note": "GeoNames JSON API"},
     {"id": "R-06", "name": "XML/PDF Ingest",      "module": "Ingest",    "status": "planned", "note": ""},
+    # Pipeline Review Gates
+    {"id": "P-02", "name": "OCR Review-Gate",      "module": "Pipeline",  "status": "done",    "note": "Stichprobe, Auto-Accept, nur akzeptierte OCR → NER"},
+    {"id": "P-03", "name": "NER Review-Gate",      "module": "Pipeline",  "status": "done",    "note": "Stichprobe, Auto-Accept, nur akzeptierte → Dictionary"},
+    {"id": "P-04", "name": "Authority Review-Gate", "module": "Pipeline", "status": "done",    "note": "GND/Wikidata/GeoNames Kandidaten prüfen → Dictionary"},
+    {"id": "P-05", "name": "Pipeline-Status",      "module": "Pipeline",  "status": "done",    "note": "GET /api/pipeline/status"},
+    {"id": "P-06", "name": "Zielformat-Export",    "module": "Export",    "status": "done",    "note": "GET /api/dictionary/export-target"},
 ]
 
 

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -23,6 +23,9 @@
 <span class="wsi">Wörterbuch: <strong id="ws-dict">0</strong></span>
 <span style="margin-left:auto"><button class="btn sm" onclick="saveWS()">💾 Speichern</button></span>
 </div>
+<div class="ws-bar" id="pipeline-bar" style="background:#f0f7ff;border-color:#d0e3ff;font-size:.72rem">
+<span id="pipeline-status" style="display:flex;gap:.6rem;flex-wrap:wrap">Pipeline: wird geladen…</span>
+</div>
 <div class="nav">
 <div class="nt a" data-p="data">① Daten</div>
 <div class="nt" data-p="ner">② NER</div>
@@ -98,6 +101,14 @@
 <div style="display:flex;gap:.4rem;flex-wrap:wrap">
 <button class="btn" onclick="runPilot('ner')">🧪 Pilotlauf auf 2%</button>
 <button class="btn s" onclick="runNER()">▶️ Gesamtlauf fortsetzen</button>
+</div>
+<div style="margin-top:.6rem;padding:.4rem;background:#f0f7ff;border:1px solid #d0e3ff;border-radius:4px">
+<strong style="font-size:.73rem">Review-Gate</strong>
+<div style="display:flex;gap:.3rem;flex-wrap:wrap;margin-top:.3rem">
+<button class="btn sm" onclick="nerSpotCheck()">🔍 Stichprobe</button>
+<button class="btn sm" onclick="nerAutoAccept()">✓ Auto-Accept</button>
+<button class="btn sm" style="background:var(--info)" onclick="nerToDict()">→ Wörterbuch</button>
+</div>
 </div>
 </div>
 <div class="c"><h2>Problematische Begriffe</h2>
@@ -290,6 +301,14 @@
 <label class="lbl" style="margin-top:.5rem">OCR Prompt-Preset</label><select id="ocr-preset" class="sel" style="width:100%" onchange="applyActionPreset('ocr')"><option value="vision_de">Vision/OCR</option><option value="custom">Eigen</option></select>
 <textarea id="ocr-sp" class="ta" style="height:3.5rem;margin-top:.3rem"></textarea>
 <button class="btn f" style="margin-top:.3rem;background:var(--info)" onclick="runOCR()">📖 Text erkennen (OCR)</button>
+<div style="margin-top:.6rem;padding:.4rem;background:#f0f7ff;border:1px solid #d0e3ff;border-radius:4px">
+<strong style="font-size:.73rem">Review-Gate</strong>
+<div style="display:flex;gap:.3rem;flex-wrap:wrap;margin-top:.3rem">
+<button class="btn sm" onclick="ocrSpotCheck()">🔍 Stichprobe</button>
+<button class="btn sm" onclick="ocrAutoAccept()">✓ Auto-Accept</button>
+<button class="btn sm" style="background:var(--info)" onclick="ocrToDict()">→ NER auf akzeptierte OCR</button>
+</div>
+</div>
 </div>
 
 <div>
@@ -361,8 +380,15 @@
 <h3 style="font-size:.82rem">Aus NER übernehmen</h3>
 <button class="btn f" onclick="nerToDict()">🔗 Akzeptierte Entities → Wörterbuch</button>
 
-<h3 style="font-size:.82rem;margin-top:.5rem">Aus OCR → NER → Wörterbuch</h3>
-<button class="btn f s" onclick="ocrToDict()">📖 OCR-Texte → NER → Wörterbuch</button>
+<h3 style="font-size:.82rem;margin-top:.5rem">Aus OCR → NER → Review</h3>
+<button class="btn f s" onclick="ocrToDict()">📖 OCR-Texte → NER (Review-Queue)</button>
+
+<hr style="border:none;border-top:1px solid var(--brd);margin:.6rem 0">
+<h3 style="font-size:.82rem">Normdaten-Kandidaten</h3>
+<p style="font-size:.72rem;color:#666;margin-bottom:.3rem">GND/Wikidata/GeoNames Treffer prüfen und übernehmen.</p>
+<div id="authority-candidates" style="max-height:200px;overflow-y:auto;font-size:.75rem"><em>Keine Kandidaten.</em></div>
+<button class="btn f" style="margin-top:.3rem" onclick="commitAuthority()">✓ Akzeptierte übernehmen</button>
+<button class="btn sm s" style="margin-top:.3rem" onclick="loadAuthorityCandidates()">🔄 Aktualisieren</button>
 </div>
 
 <div>
@@ -371,6 +397,7 @@
 <div style="display:flex;gap:.5rem;margin-bottom:.5rem;flex-wrap:wrap">
 <button class="btn sm" onclick="exportDict('')">⬇️ Alle exportieren (JSON)</button>
 <button class="btn sm s" onclick="exportDictTyped()">⬇️ Nach Typ exportieren</button>
+<button class="btn sm" style="background:var(--info)" onclick="exportDictTarget()">⬇️ Zielformat exportieren</button>
 </div>
 <div id="dict-list-empty" class="em" style="font-size:.75rem;padding:1rem">Noch keine Einträge.</div>
 <div id="dict-list" class="scroll-box" style="max-height:500px"></div>

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -75,7 +75,7 @@ function dl(name,content,type){const b=new Blob([content],{type});const a=docume
 
 // === NAV ===
 function bindTabs(el){const ps=[];let s=el.nextElementSibling;while(s&&s.classList.contains('tp')){ps.push(s);s=s.nextElementSibling}el.onclick=e=>{if(!e.target.classList.contains('tab'))return;const t=e.target.dataset.t;el.querySelectorAll('.tab').forEach(x=>x.classList.toggle('a',x.dataset.t===t));ps.forEach(x=>x.classList.toggle('a',x.dataset.t===t))}}
-function initNav(){try{const nav=document.querySelector('.nav');if(!nav)return;nav.onclick=e=>{if(!e.target.classList.contains('nt'))return;const p=e.target.dataset.p;document.querySelectorAll('.nt').forEach(t=>t.classList.toggle('a',t.dataset.p===p));document.querySelectorAll('.pg').forEach(x=>x.classList.toggle('a',x.dataset.p===p));if(p==='config'){loadGPUConfig();chkGPU();}if(p==='mapping')loadFMCols();if(p==='mds'){loadCustomMdsFields();loadTasks();}if(p==='dict'){loadDictEntries();loadDictTypes();}if(p==='catalog')renderCatalog();if(p==='images')loadImages();}}catch(err){console.error('[initNav]',err)}}
+function initNav(){try{const nav=document.querySelector('.nav');if(!nav)return;nav.onclick=e=>{if(!e.target.classList.contains('nt'))return;const p=e.target.dataset.p;document.querySelectorAll('.nt').forEach(t=>t.classList.toggle('a',t.dataset.p===p));document.querySelectorAll('.pg').forEach(x=>x.classList.toggle('a',x.dataset.p===p));if(p==='config'){loadGPUConfig();chkGPU();}if(p==='mapping')loadFMCols();if(p==='mds'){loadCustomMdsFields();loadTasks();}if(p==='dict'){loadDictEntries();loadDictTypes();loadAuthorityCandidates();}if(p==='catalog')renderCatalog();if(p==='images')loadImages();}}catch(err){console.error('[initNav]',err)}}
 function initTabs(){try{document.querySelectorAll('.tabs').forEach(bindTabs)}catch(err){console.error('[initTabs]',err)}}
 initNav();initTabs();
 
@@ -1269,10 +1269,12 @@ async function nerToDict(){
   }catch(e){alert(e.message)}finally{hp()}
 }
 async function ocrToDict(){
-  sp('OCR → NER → Wörterbuch …','');
+  sp('OCR → NER (Review-Queue) …','');
   try{const r=await(await fetch('/api/dictionary/from-ocr',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({model:$('cfg-mt').value||''})})).json();
-    if(r.error){alert(r.error);return}loadDictEntries();loadDictTypes();updWS();
-    alert('OCR: '+r.ocr_texts_processed+' Texte → '+r.entities_found+' Entities → '+r.dictionary_added+' neue Wörterbuch-Einträge');
+    if(r.error){alert(r.error);return}loadDictEntries();loadDictTypes();updWS();loadPipelineStatus();
+    alert('OCR: '+r.ocr_texts_processed+' Texte → '+r.entities_found+' Entities in Review-Queue.'
+      +(r.skipped_pending?' ('+r.skipped_pending+' ungeprüft übersprungen)':'')
+      +'\nNächster Schritt: Entities im NER-Tab prüfen, dann "NER → Wörterbuch".');
   }catch(e){alert(e.message)}finally{hp()}
 }
 async function showDictDetail(entryId){
@@ -1338,6 +1340,102 @@ function exportDict(entityType){
   window.open('/api/dictionary/export'+(entityType?'?entity_type='+encodeURIComponent(entityType):''),'_blank');
 }
 function exportDictTyped(){window.open('/api/dictionary/export-typed','_blank')}
+function exportDictTarget(){window.open('/api/dictionary/export-target','_blank')}
+
+// === PIPELINE STATUS ===
+async function loadPipelineStatus(){
+  try{
+    const r=await(await fetch('/api/pipeline/status')).json();
+    const el=$('pipeline-status');if(!el)return;
+    const s=r;
+    function bar(label,done,total){
+      const pct=total?Math.round(done/total*100):0;
+      return '<span class="wsi" title="'+label+': '+done+'/'+total+'">'
+        +label+': <strong>'+done+'/'+total+'</strong>'
+        +'<span style="display:inline-block;width:40px;height:6px;background:#e0e0e0;border-radius:3px;vertical-align:middle;margin-left:.3rem">'
+        +'<span style="display:block;height:100%;width:'+pct+'%;background:var(--pri);border-radius:3px"></span></span></span>';
+    }
+    el.innerHTML=bar('OCR',s.phase1_ocr.accepted,s.phase1_ocr.total)
+      +bar('NER',s.phase2_ner.accepted,s.phase2_ner.total)
+      +bar('Authority',s.phase3_authority.accepted,s.phase3_authority.total)
+      +'<span class="wsi">Dict: <strong>'+s.dictionary.enriched+'/'+s.dictionary.total+' angereichert</strong></span>';
+  }catch(e){console.error('[pipeline-status]',e)}
+}
+
+// === OCR REVIEW GATE ===
+async function ocrSpotCheck(){
+  sp('Stichprobe laden …','');
+  try{
+    const r=await(await fetch('/api/images/review/sample',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({sample_size:10,strategy:'low_confidence'})})).json();
+    alert('Stichprobe: '+r.sample_size+' von '+r.total_pending+' ausstehend. Prüfen Sie die Ergebnisse im Bilder-Tab.');
+    loadImages();
+  }catch(e){alert(e.message)}finally{hp()}
+}
+async function ocrAutoAccept(){
+  const conf=parseFloat(prompt('Minimale Konfidenz (0.0-1.0):','0.85'));
+  if(isNaN(conf))return;
+  sp('Auto-Accept …','');
+  try{
+    const r=await(await fetch('/api/images/review/auto-accept',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({min_confidence:conf})})).json();
+    alert(r.auto_accepted+' akzeptiert, '+r.remaining_pending+' noch ausstehend.');
+    loadImages();loadPipelineStatus();
+  }catch(e){alert(e.message)}finally{hp()}
+}
+
+// === NER REVIEW GATE ===
+async function nerSpotCheck(){
+  sp('NER-Stichprobe …','');
+  try{
+    const r=await(await fetch('/api/ner/review/sample',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({sample_size:20,strategy:'low_confidence'})})).json();
+    alert('Stichprobe: '+r.sample_size+' von '+r.total_pending+' ausstehend.');
+  }catch(e){alert(e.message)}finally{hp()}
+}
+async function nerAutoAccept(){
+  const conf=parseFloat(prompt('Minimale Konfidenz (0.0-1.0):','0.8'));
+  if(isNaN(conf))return;
+  sp('NER Auto-Accept …','');
+  try{
+    const r=await(await fetch('/api/ner/review/auto-accept',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({min_confidence:conf})})).json();
+    alert(r.auto_accepted+' akzeptiert, '+r.remaining_pending+' noch ausstehend.');
+    loadPipelineStatus();
+  }catch(e){alert(e.message)}finally{hp()}
+}
+
+// === AUTHORITY REVIEW ===
+async function loadAuthorityCandidates(){
+  try{
+    const r=await(await fetch('/api/authority/candidates?status=pending')).json();
+    const el=$('authority-candidates');if(!el)return;
+    const cands=r.candidates||[];
+    if(!cands.length){el.innerHTML='<em>Keine ausstehenden Kandidaten.</em>';return}
+    el.innerHTML=cands.slice(0,100).map(c=>
+      '<div style="padding:.3rem;border-bottom:1px solid var(--brd);font-size:.75rem;display:flex;align-items:center;gap:.3rem">'
+      +'<span class="dict-type dict-type-'+(c.authority_type||'other')+'">'+esc(c.source)+'</span>'
+      +'<span>'+esc(c.preferred_name)+' ('+esc(c.authority_id)+')</span>'
+      +'<span style="color:#888">Score: '+(c.score*100).toFixed(0)+'%</span>'
+      +'<button class="btn sm" onclick="reviewAuthCandidate(\''+esc(c.candidate_id)+'\',\'accepted\')">✓</button>'
+      +'<button class="btn sm s" onclick="reviewAuthCandidate(\''+esc(c.candidate_id)+'\',\'rejected\')">✗</button>'
+      +'</div>'
+    ).join('')+'<div style="margin-top:.3rem;font-size:.72rem;color:#888">'+r.total+' Kandidaten gesamt</div>';
+  }catch(e){console.error(e)}
+}
+async function reviewAuthCandidate(candidateId,status){
+  try{await fetch('/api/authority/candidates/'+candidateId+'/review',{method:'POST',headers:{'Content-Type':'application/json'},
+    body:JSON.stringify({status})});loadAuthorityCandidates();loadPipelineStatus();
+  }catch(e){alert(e.message)}
+}
+async function commitAuthority(){
+  sp('Normdaten übernehmen …','');
+  try{
+    const r=await(await fetch('/api/authority/commit',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'})).json();
+    alert(r.committed+' Normdaten in Wörterbuch übernommen.');
+    loadDictEntries();loadDictTypes();loadAuthorityCandidates();loadPipelineStatus();updWS();
+  }catch(e){alert(e.message)}finally{hp()}
+}
 
 // === MDS VALIDATION (Feature 4) ===
 async function runMdsValidation(){
@@ -1503,6 +1601,7 @@ function showInitError(label){const b=document.createElement('div');b.style.cssT
   try{loadGPUConfig()}catch(err){console.error('[init] loadGPUConfig',err);failed.push('loadGPUConfig')}
   try{checkAuth()}catch(err){console.error('[init] checkAuth',err);failed.push('checkAuth')}
   try{loadDictEntries();loadDictTypes()}catch(err){console.error('[init] dict',err);failed.push('dict')}
+  try{loadPipelineStatus()}catch(err){console.error('[init] pipeline',err);failed.push('pipeline')}
   try{loadTasks()}catch(err){console.error('[init] tasks',err);failed.push('tasks')}
   try{loadCustomMdsFields()}catch(err){console.error('[init] mdsFields',err);failed.push('mdsFields')}
   if(failed.length)showInitError(failed.join(', '));

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -740,6 +740,73 @@ async def image_review_batch(request: dict):
     ws.save(workspace_dir() / safe_filename(ws.name))
     return {"updated": updated, "status": status.value}
 
+@router.post("/api/images/review/sample")
+async def image_review_sample(request: dict):
+    """Return a spot-check sample of pending OCR results for review."""
+    ws = get_workspace()
+    sample_size = min(request.get("sample_size", 10), 100)
+    strategy = request.get("strategy", "random")
+
+    pending = [
+        r for r in ws.image_analyses
+        if r.review_status == ImageReviewStatus.PENDING and r.analyzed
+    ]
+    total_pending = len(pending)
+
+    if strategy == "low_confidence":
+        pending.sort(key=lambda r: r.confidence)
+    else:
+        import random
+        random.shuffle(pending)
+
+    sample = pending[:sample_size]
+    return {
+        "sample": [r.to_dict() for r in sample],
+        "total_pending": total_pending,
+        "sample_size": len(sample),
+        "strategy": strategy,
+    }
+
+
+@router.post("/api/images/review/auto-accept")
+async def image_review_auto_accept(request: dict):
+    """Auto-accept all OCR results with confidence >= min_confidence."""
+    ws = get_workspace()
+    min_confidence = float(request.get("min_confidence", 0.85))
+
+    auto_accepted = 0
+    for analysis in ws.image_analyses:
+        if analysis.review_status != ImageReviewStatus.PENDING:
+            continue
+        if not analysis.analyzed:
+            continue
+        if analysis.confidence >= min_confidence:
+            analysis.update_review(
+                status=ImageReviewStatus.ACCEPTED,
+                comment=f"Auto-accepted (confidence {analysis.confidence:.2f} >= {min_confidence})",
+                reviewer="auto",
+            )
+            # Also update in-memory image index
+            img = _uploaded_images.get(analysis.image_id)
+            if img:
+                img["review_status"] = "accepted"
+                img["review_comment"] = analysis.review_comment
+                img["reviewed_at"] = analysis.reviewed_at
+            auto_accepted += 1
+
+    remaining = sum(
+        1 for r in ws.image_analyses
+        if r.review_status == ImageReviewStatus.PENDING
+    )
+
+    ws.save(workspace_dir() / safe_filename(ws.name))
+    return {
+        "auto_accepted": auto_accepted,
+        "remaining_pending": remaining,
+        "min_confidence": min_confidence,
+    }
+
+
 @router.delete("/api/images")
 async def images_clear():
     """Clear all uploaded images from memory and disk."""

--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -1099,3 +1099,88 @@ async def dict_scan(request: dict):
         "matches": matches[:2000],
         "dataset": dsn,
     }
+
+
+# ---------------------------------------------------------------------------
+# NER Review Gate — spot-check, auto-accept, single review
+# ---------------------------------------------------------------------------
+
+@router.post("/api/ner/review/sample")
+async def ner_review_sample(request: dict):
+    """Return a spot-check sample of pending NER entities for review."""
+    from kwb.core.workspace import ReviewStatus
+    ws = get_workspace()
+    sample_size = min(request.get("sample_size", 20), 200)
+    strategy = request.get("strategy", "random")
+    entity_type = request.get("entity_type", "")
+
+    pending = [
+        (i, e) for i, e in enumerate(ws.entity_reviews)
+        if e.status == ReviewStatus.PENDING
+        and (not entity_type or e.entity_type == entity_type)
+    ]
+    total_pending = len(pending)
+
+    if strategy == "low_confidence":
+        pending.sort(key=lambda t: t[1].confidence)
+    elif strategy == "by_type":
+        pending.sort(key=lambda t: t[1].entity_type)
+    else:
+        import random
+        random.shuffle(pending)
+
+    sample = pending[:sample_size]
+    return {
+        "sample": [
+            {"index": i, **e.to_dict()} for i, e in sample
+        ],
+        "total_pending": total_pending,
+        "sample_size": len(sample),
+        "strategy": strategy,
+    }
+
+
+@router.post("/api/ner/review/auto-accept")
+async def ner_review_auto_accept(request: dict):
+    """Auto-accept all NER entities with confidence >= min_confidence."""
+    from kwb.core.workspace import ReviewStatus
+    ws = get_workspace()
+    min_confidence = float(request.get("min_confidence", 0.8))
+    entity_types = request.get("entity_types", [])
+
+    auto_accepted = 0
+    for er in ws.entity_reviews:
+        if er.status != ReviewStatus.PENDING:
+            continue
+        if entity_types and er.entity_type not in entity_types:
+            continue
+        if er.confidence >= min_confidence:
+            er.accept(
+                note=f"Auto-accepted (confidence {er.confidence:.2f} >= {min_confidence})",
+            )
+            auto_accepted += 1
+
+    remaining = sum(
+        1 for e in ws.entity_reviews if e.status == ReviewStatus.PENDING
+    )
+    return {
+        "auto_accepted": auto_accepted,
+        "remaining_pending": remaining,
+        "min_confidence": min_confidence,
+    }
+
+
+@router.post("/api/ner/review/{index}")
+async def ner_review_single(index: int, request: dict):
+    """Review a single NER entity by index."""
+    ws = get_workspace()
+    if index < 0 or index >= len(ws.entity_reviews):
+        return JSONResponse({"error": "Index ungültig"}, 400)
+
+    updates = {}
+    for key in ("status", "entity_type", "text", "reviewer_note", "editor_note"):
+        if key in request:
+            updates[key] = request[key]
+
+    ws.update_entity(index, updates)
+    return {"ok": True, "entity": ws.entity_reviews[index].to_dict()}

--- a/src/kwb/api/routes/dictionary.py
+++ b/src/kwb/api/routes/dictionary.py
@@ -86,6 +86,97 @@ async def export_typed_dictionaries():
     )
 
 
+@router.get("/api/dictionary/export-target")
+async def export_dictionary_target(entity_type: str = ""):
+    """Export dictionary in the target JSON format for downstream systems.
+
+    Target format per entry:
+    {
+        "id": "entry_id",
+        "category": "person",
+        "term_source": "Joh. Seb. Bach",
+        "term_normalized": "Johann Sebastian Bach",
+        "source": "ocr",
+        "authority": {
+            "wikidata_qid": "Q1339",
+            "gnd_id": "11850529X",
+            "geonames_id": null
+        },
+        "occurrences": [{"record_id": "rec_001"}]
+    }
+    """
+    ws = get_workspace()
+    if entity_type:
+        entries = ws.dictionary_by_type(entity_type)
+    else:
+        entries = list(ws.dictionary)
+
+    def _to_target(entry):
+        return {
+            "id": entry.entry_id,
+            "category": entry.entity_type,
+            "term_source": entry.term,
+            "term_normalized": entry.term_normalized or entry.preferred_name or entry.term,
+            "source": entry.term_source or entry.source,
+            "authority": {
+                "wikidata_qid": entry.wikidata_id or None,
+                "gnd_id": entry.gnd_id or None,
+                "geonames_id": entry.geonames_id or None,
+            },
+            "occurrences": [{"record_id": rid} for rid in entry.record_ids],
+        }
+
+    data = json.dumps(
+        [_to_target(e) for e in entries], ensure_ascii=False, indent=2,
+    )
+    filename = f"dictionary_target_{entity_type}.json" if entity_type else "dictionary_target.json"
+    return Response(
+        content=data.encode("utf-8"),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/api/pipeline/status")
+async def pipeline_status():
+    """Return pipeline progress across all three review gates."""
+    ws = get_workspace()
+
+    # Phase 1: OCR
+    ocr_stats = {"total": 0, "pending": 0, "accepted": 0, "rejected": 0}
+    for r in ws.image_analyses:
+        ocr_stats["total"] += 1
+        ocr_stats[r.review_status.value] = ocr_stats.get(r.review_status.value, 0) + 1
+
+    # Phase 2: NER
+    ner_stats = {"total": 0, "pending": 0, "accepted": 0, "rejected": 0}
+    for e in ws.entity_reviews:
+        ner_stats["total"] += 1
+        ner_stats[e.status.value] = ner_stats.get(e.status.value, 0) + 1
+
+    # Phase 3: Authority
+    auth_stats = {"total": 0, "pending": 0, "accepted": 0, "rejected": 0}
+    for c in ws.authority_candidates:
+        auth_stats["total"] += 1
+        auth_stats[c.status.value] = auth_stats.get(c.status.value, 0) + 1
+
+    # Dictionary
+    dict_total = len(ws.dictionary)
+    enriched = sum(1 for e in ws.dictionary if e.has_authority)
+    dict_stats = {
+        "total": dict_total,
+        "enriched": enriched,
+        "unenriched": dict_total - enriched,
+    }
+
+    return {
+        "phase1_ocr": ocr_stats,
+        "phase2_ner": ner_stats,
+        "phase3_authority": auth_stats,
+        "dictionary": dict_stats,
+    }
+
+
 @router.post("/api/dictionary/entry")
 async def add_or_update_entry(request: dict):
     """Add or update a single dictionary entry."""
@@ -228,18 +319,32 @@ async def ner_to_dictionary(request: dict):
 
 @router.post("/api/dictionary/from-ocr")
 async def ocr_to_dictionary(request: dict):
-    """Run NER on OCR text results and add entities to dictionary.
+    """Run NER on accepted OCR text results and add entities to review queue.
 
-    This is the OCR → NER → Dictionary pipeline (Feature 11).
-    Requires OCR results in workspace image_analyses.
+    REVIEW GATE: Only OCR results with review_status == ACCEPTED are processed.
+    Entities are added to entity_reviews (not directly to dictionary).
+    Use POST /api/dictionary/from-ner to transfer accepted entities to dictionary.
+
+    Set include_pending=true to also process pending OCR results (legacy mode).
     """
     ws = get_workspace()
+    include_pending = request.get("include_pending", False)
 
-    # Collect OCR texts from image analyses
+    # Collect OCR texts — GATE: only accepted OCR results
     ocr_texts: list[dict] = []
+    skipped_pending = 0
     for analysis in ws.image_analyses:
         if not analysis.result:
             continue
+        if analysis.review_status.value == "accepted":
+            pass  # always include accepted
+        elif include_pending and analysis.review_status.value == "pending":
+            pass  # include pending only in legacy mode
+        else:
+            if analysis.review_status.value == "pending":
+                skipped_pending += 1
+            continue
+
         text = (analysis.result.get("transcription") or
                 analysis.result.get("text") or "")
         if not text.strip():
@@ -251,9 +356,15 @@ async def ocr_to_dictionary(request: dict):
         })
 
     if not ocr_texts:
-        return JSONResponse(
-            {"error": "Keine OCR-Ergebnisse vorhanden. Bitte zuerst OCR durchführen."}, 400,
-        )
+        msg = "Keine akzeptierten OCR-Ergebnisse vorhanden."
+        if skipped_pending > 0:
+            msg += (
+                f" {skipped_pending} Ergebnisse warten auf Review."
+                " Bitte zuerst OCR-Ergebnisse prüfen (Tab Bilder)."
+            )
+        else:
+            msg += " Bitte zuerst OCR durchführen."
+        return JSONResponse({"error": msg}, 400)
 
     # Run NER on OCR texts
     entity_types = request.get("entity_types", ["PER", "ORG", "LOC", "GPE"])
@@ -265,19 +376,11 @@ async def ocr_to_dictionary(request: dict):
     provider = get_provider(model)
     llm_entities, batch = ner_llm(ocr_texts, provider, model=model or None)
 
-    # Filter by requested entity types and add to dictionary
-    entries_to_add: list[dict] = []
+    # Filter by requested entity types
     entities_added = []
     for entity in llm_entities:
         if entity_types and entity.entity_type.value not in entity_types:
             continue
-        dict_type = DictionaryType.from_entity_type(entity.entity_type.value).value
-        entries_to_add.append({
-            "term": entity.text,
-            "entity_type": dict_type,
-            "record_id": entity.record_id,
-            "source": "ocr",
-        })
         entities_added.append({
             "text": entity.text,
             "type": entity.entity_type.value,
@@ -285,7 +388,7 @@ async def ocr_to_dictionary(request: dict):
             "record_id": entity.record_id,
         })
 
-    # Also add to entity_reviews for review
+    # Add to entity_reviews for review (NOT directly to dictionary)
     ws.add_entities([
         {
             "text": e.text,
@@ -298,12 +401,11 @@ async def ocr_to_dictionary(request: dict):
         for e in llm_entities
     ])
 
-    added = ws.add_to_dictionary(entries_to_add)
     return {
         "ocr_texts_processed": len(ocr_texts),
+        "skipped_pending": skipped_pending,
         "entities_found": len(llm_entities),
-        "entities_filtered": len(entries_to_add),
-        "dictionary_added": added,
-        "dictionary_total": len(ws.dictionary),
+        "entities_filtered": len(entities_added),
+        "entities_in_review": len(ws.entity_reviews),
         "entities": entities_added[:200],
     }

--- a/src/kwb/api/routes/enrich.py
+++ b/src/kwb/api/routes/enrich.py
@@ -1,5 +1,6 @@
 """
-Enrichment routes: GND search, GND batch lookup, Wikidata SPARQL.
+Enrichment routes: GND search, GND batch, Wikidata SPARQL, GeoNames,
+and authority candidate review.
 
 Router prefix: /api
 """
@@ -11,8 +12,9 @@ try:
 except ImportError:
     raise ImportError("pip install fastapi")
 
-from kwb.api.deps import get_workspace
+from kwb.api.deps import get_workspace, get_config
 from kwb.enrich.gnd import gnd_search, gnd_batch_search
+from kwb.core.workspace import AuthorityCandidate, ReviewStatus
 
 router = APIRouter()
 
@@ -29,9 +31,11 @@ async def gnd_search_api(q: str = "", type: str = "", size: int = 5):
 @router.post("/api/gnd/batch")
 async def gnd_batch_api(request: dict):
     """
-    Batch GND enrichment for all unique entities in the current workspace.
+    Batch GND enrichment — creates AuthorityCandidates for review.
 
-    Matches are written back into entity_reviews and the workspace dictionary.
+    Matches are NOT written directly into the dictionary. Instead they
+    become AuthorityCandidate records with status=pending.
+    Use POST /api/authority/commit to write accepted candidates to dictionary.
     """
     ws = get_workspace()
     unique = ws.unique_entities()
@@ -48,21 +52,39 @@ async def gnd_batch_api(request: dict):
     for gr in results:
         if gr.get("top_match"):
             tm = gr["top_match"]
+            # Ensure dictionary entry exists for the term
+            entry = ws.lookup(gr["text"])
+            if not entry:
+                ws.add_to_dictionary([{
+                    "term": gr["text"],
+                    "category": gr["type"],
+                    "source": "gnd-api",
+                }])
+                entry = ws.lookup(gr["text"])
+
+            if entry:
+                ws.add_authority_candidate(AuthorityCandidate(
+                    entry_id=entry.entry_id,
+                    source="gnd",
+                    authority_id=tm["gnd_id"],
+                    preferred_name=tm["preferred_name"],
+                    authority_type=tm.get("gnd_type", ""),
+                    uri=f"https://d-nb.info/gnd/{tm['gnd_id']}",
+                    score=tm.get("confidence", 0.8),
+                ))
+
+            # Still update entity_reviews for backward compat
             for i, e in enumerate(ws.entities):
                 if e.text == gr["text"] and e.entity_type == gr["type"]:
                     ws.update_entity(i, {
                         "gnd_id": tm["gnd_id"],
                         "gnd_preferred": tm["preferred_name"],
                     })
-            ws.add_to_dictionary([{
-                "term": gr["text"], "gnd_id": tm["gnd_id"],
-                "gnd_preferred": tm["preferred_name"],
-                "category": gr["type"], "source": "gnd-api",
-            }])
             matched += 1
 
     return {
         "total": len(terms), "matched": matched,
+        "candidates_created": matched,
         "results": results,
     }
 
@@ -72,16 +94,10 @@ async def gnd_batch_api(request: dict):
 # ---------------------------------------------------------------------------
 
 @router.get("/api/wikidata/search")
-async def wikidata_search_api(q: str = "", type: str = "", lang: str = "de", size: int = 5):
-    """
-    Live Wikidata entity lookup via SPARQL.
-
-    Parameters:
-        q:    Search term
-        type: Entity type filter: PER, LOC, GPE, ORG or empty for all
-        lang: Language for labels (default "de")
-        size: Max results (default 5)
-    """
+async def wikidata_search_api(
+    q: str = "", type: str = "", lang: str = "de", size: int = 5,
+):
+    """Live Wikidata entity lookup via SPARQL."""
     if not q:
         return {"results": []}
     try:
@@ -95,7 +111,7 @@ async def wikidata_search_api(q: str = "", type: str = "", lang: str = "de", siz
 @router.post("/api/wikidata/batch")
 async def wikidata_batch_api(request: dict):
     """
-    Batch Wikidata enrichment for all unique entities in the current workspace.
+    Batch Wikidata enrichment — creates AuthorityCandidates for review.
 
     Request body:
         limit: int   -- max entities to process (default 30, max 100)
@@ -125,25 +141,234 @@ async def wikidata_batch_api(request: dict):
         if wr.get("top_match"):
             tm = wr["top_match"]
             qid = tm.get("qid", "")
+            # Ensure dictionary entry exists
             entry = ws.lookup(wr["text"])
-            if entry:
-                entry.wikidata_id = qid
-                if not entry.gnd_id and tm.get("gnd_id"):
-                    entry.gnd_id = tm["gnd_id"]
-            else:
+            if not entry:
                 ws.add_to_dictionary([{
                     "term": wr["text"],
-                    "gnd_id": tm.get("gnd_id", ""),
                     "category": wr.get("type", ""),
                     "source": "wikidata",
                 }])
-                fresh = ws.lookup(wr["text"])
-                if fresh:
-                    fresh.wikidata_id = qid
+                entry = ws.lookup(wr["text"])
+
+            if entry:
+                ws.add_authority_candidate(AuthorityCandidate(
+                    entry_id=entry.entry_id,
+                    source="wikidata",
+                    authority_id=qid,
+                    preferred_name=tm.get("label", ""),
+                    authority_type=wr.get("type", ""),
+                    uri=f"https://www.wikidata.org/wiki/{qid}" if qid else "",
+                    score=float(tm.get("confidence", 0.8)),
+                    extra={"gnd_id": tm.get("gnd_id", "")},
+                ))
             matched += 1
 
     return {
         "total": len(terms),
         "matched": matched,
+        "candidates_created": matched,
         "results": results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# GeoNames Enrichment
+# ---------------------------------------------------------------------------
+
+@router.get("/api/geonames/search")
+async def geonames_search_api(q: str = "", size: int = 5):
+    """Live GeoNames term lookup."""
+    if not q:
+        return {"results": []}
+    try:
+        from kwb.enrich.geonames import geonames_search
+        cfg = get_config()
+        username = cfg.geonames_username or "demo"
+        results = geonames_search(q, username=username, max_rows=size)
+        return {"results": [r.to_dict() for r in results]}
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, 500)
+
+
+@router.post("/api/geonames/batch")
+async def geonames_batch_api(request: dict):
+    """
+    Batch GeoNames enrichment — creates AuthorityCandidates for review.
+
+    Request body:
+        limit: int   -- max entities to process (default 30, max 100)
+        entity_types: list[str] -- filter by NER types (default ["LOC", "GPE"])
+    """
+    ws = get_workspace()
+    unique = ws.unique_entities()
+    if not unique:
+        return JSONResponse({"error": "Erst NER ausfuehren"}, 400)
+
+    limit = min(request.get("limit", 30), 100)
+    entity_types = request.get("entity_types", ["LOC", "GPE"])
+
+    filtered = [e for e in unique if e.entity_type in entity_types] if entity_types else unique
+    terms = [
+        {"text": e.text, "type": e.entity_type, "record_id": e.record_id}
+        for e in filtered[:limit]
+    ]
+
+    try:
+        from kwb.enrich.geonames import geonames_batch_search
+        cfg = get_config()
+        username = cfg.geonames_username or "demo"
+        results = geonames_batch_search(terms, username=username, delay=1.0)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, 500)
+
+    matched = 0
+    for gr in results:
+        if gr.get("top_match"):
+            tm = gr["top_match"]
+            entry = ws.lookup(gr["text"])
+            if not entry:
+                ws.add_to_dictionary([{
+                    "term": gr["text"],
+                    "category": "place",
+                    "source": "geonames",
+                }])
+                entry = ws.lookup(gr["text"])
+
+            if entry:
+                ws.add_authority_candidate(AuthorityCandidate(
+                    entry_id=entry.entry_id,
+                    source="geonames",
+                    authority_id=tm["geonames_id"],
+                    preferred_name=tm["name"],
+                    authority_type="PlaceOrGeographicName",
+                    uri=tm.get("uri", ""),
+                    score=0.8,
+                    extra={
+                        "country": tm.get("country", ""),
+                        "lat": tm.get("lat", 0),
+                        "lng": tm.get("lng", 0),
+                    },
+                ))
+            matched += 1
+
+    return {
+        "total": len(terms),
+        "matched": matched,
+        "candidates_created": matched,
+        "results": results,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Authority Candidate Review
+# ---------------------------------------------------------------------------
+
+@router.get("/api/authority/candidates")
+async def authority_candidates_list(
+    entry_id: str = "", status: str = "", source: str = "",
+):
+    """List authority candidates, optionally filtered."""
+    ws = get_workspace()
+    candidates = ws.authority_candidates
+
+    if entry_id:
+        candidates = [c for c in candidates if c.entry_id == entry_id]
+    if status:
+        candidates = [c for c in candidates if c.status.value == status]
+    if source:
+        candidates = [c for c in candidates if c.source == source]
+
+    return {
+        "candidates": [c.to_dict() for c in candidates],
+        "total": len(candidates),
+        "stats": ws.authority_review_stats(),
+    }
+
+
+@router.post("/api/authority/candidates/{candidate_id}/review")
+async def authority_candidate_review(candidate_id: str, request: dict):
+    """Accept or reject a single authority candidate."""
+    ws = get_workspace()
+    target = None
+    for c in ws.authority_candidates:
+        if c.candidate_id == candidate_id:
+            target = c
+            break
+    if not target:
+        return JSONResponse({"error": "Kandidat nicht gefunden"}, 404)
+
+    new_status = request.get("status", "")
+    note = request.get("note", "")
+
+    if new_status == "accepted":
+        target.accept(note=note)
+    elif new_status == "rejected":
+        target.reject(note=note)
+    else:
+        return JSONResponse({"error": "Status muss 'accepted' oder 'rejected' sein"}, 400)
+
+    return {"ok": True, "candidate": target.to_dict()}
+
+
+@router.post("/api/authority/candidates/batch-review")
+async def authority_candidates_batch_review(request: dict):
+    """Batch accept/reject authority candidates."""
+    ws = get_workspace()
+    candidate_ids = request.get("candidate_ids", [])
+    new_status = request.get("status", "")
+    note = request.get("note", "")
+
+    if new_status not in ("accepted", "rejected"):
+        return JSONResponse({"error": "Status muss 'accepted' oder 'rejected' sein"}, 400)
+
+    updated = 0
+    id_set = set(candidate_ids)
+    for c in ws.authority_candidates:
+        if c.candidate_id in id_set:
+            if new_status == "accepted":
+                c.accept(note=note)
+            else:
+                c.reject(note=note)
+            updated += 1
+
+    return {"updated": updated, "status": new_status}
+
+
+@router.post("/api/authority/commit")
+async def authority_commit(request: dict = {}):
+    """Write all accepted authority candidates into their DictionaryEntry fields."""
+    ws = get_workspace()
+    committed = 0
+
+    for candidate in ws.authority_candidates:
+        if candidate.status != ReviewStatus.ACCEPTED:
+            continue
+
+        entry = ws.lookup_by_id(candidate.entry_id)
+        if not entry:
+            continue
+
+        if candidate.source == "gnd":
+            entry.gnd_id = candidate.authority_id
+            entry.gnd_preferred = candidate.preferred_name
+            entry.gnd_type = candidate.authority_type
+            entry.gnd_uri = candidate.uri
+        elif candidate.source == "wikidata":
+            entry.wikidata_id = candidate.authority_id
+            if not entry.gnd_id and candidate.extra.get("gnd_id"):
+                entry.gnd_id = candidate.extra["gnd_id"]
+        elif candidate.source == "geonames":
+            entry.geonames_id = candidate.authority_id
+
+        if candidate.preferred_name and not entry.preferred_name:
+            entry.preferred_name = candidate.preferred_name
+
+        committed += 1
+
+    ws._touch()
+    return {
+        "committed": committed,
+        "dictionary_total": len(ws.dictionary),
+        "stats": ws.authority_review_stats(),
     }

--- a/src/kwb/core/config.py
+++ b/src/kwb/core/config.py
@@ -35,6 +35,7 @@ class KWBConfig:
     goobi_api_url: str = ""
     goobi_api_key: str = ""
     goobi_project: str = ""
+    geonames_username: str = ""
     batch_size: int = 50
     batch_delay_seconds: float = 0.1
     max_retries: int = 3
@@ -118,6 +119,7 @@ def load_config(dotenv_path=None):
         gpustack_key=_get("KWB_GPUSTACK_KEY", dotenv),
         gpustack_model_text=_get("KWB_GPUSTACK_MODEL_TEXT", dotenv),
         gpustack_model_vision=_get("KWB_GPUSTACK_MODEL_VISION", dotenv),
+        geonames_username=_get("KWB_GEONAMES_USERNAME", dotenv),
         goobi_api_url=_get("KWB_GOOBI_API_URL", dotenv),
         goobi_api_key=_get("KWB_GOOBI_API_KEY", dotenv),
         goobi_project=_get("KWB_GOOBI_PROJECT", dotenv),

--- a/src/kwb/core/normalize.py
+++ b/src/kwb/core/normalize.py
@@ -1,0 +1,15 @@
+"""Text normalization utilities for dictionary terms."""
+from __future__ import annotations
+
+import unicodedata
+
+
+def normalize_term(text: str) -> str:
+    """NFC normalize, collapse whitespace, trim.
+
+    >>> normalize_term("  Johann   Sebastian   Bach  ")
+    'Johann Sebastian Bach'
+    """
+    text = unicodedata.normalize("NFC", text)
+    text = " ".join(text.split())
+    return text.strip()

--- a/src/kwb/core/workspace.py
+++ b/src/kwb/core/workspace.py
@@ -147,6 +147,8 @@ class DictionaryEntry:
     confidence: float = 1.0
     source: str = "manual"            # "manual" | "api" | "llm" | "ner" | "ocr"
     note: str = ""
+    term_normalized: str = ""          # NFC + whitespace-collapsed form
+    term_source: str = ""              # "ocr" | "metadata" | "manual"
 
     def __post_init__(self):
         if not self.entry_id:
@@ -183,6 +185,8 @@ class DictionaryEntry:
             "confidence": self.confidence,
             "source": self.source,
             "note": self.note,
+            "term_normalized": self.term_normalized,
+            "term_source": self.term_source,
         }
 
     @staticmethod
@@ -211,6 +215,70 @@ class ImageReviewStatus(str, Enum):
     PENDING = "pending"
     ACCEPTED = "accepted"
     REJECTED = "rejected"
+
+
+@dataclass
+class AuthorityCandidate:
+    """An authority-match candidate pending human review."""
+    entry_id: str                       # Target DictionaryEntry.entry_id
+    candidate_id: str = ""              # Auto UUID
+    source: str = ""                    # "gnd" | "wikidata" | "geonames"
+    authority_id: str = ""              # GND ID, QID, or GeoNames ID
+    preferred_name: str = ""
+    authority_type: str = ""            # "Person", "PlaceOrGeographicName", etc.
+    uri: str = ""
+    score: float = 0.0
+    extra: dict = field(default_factory=dict)
+    status: ReviewStatus = ReviewStatus.PENDING
+    reviewer_note: str = ""
+    reviewed_at: str = ""
+
+    def __post_init__(self):
+        if not self.candidate_id:
+            self.candidate_id = str(_uuid.uuid4())[:8]
+
+    def accept(self, note: str = "") -> None:
+        self.status = ReviewStatus.ACCEPTED
+        self.reviewer_note = note
+        self.reviewed_at = datetime.utcnow().isoformat()
+
+    def reject(self, note: str = "") -> None:
+        self.status = ReviewStatus.REJECTED
+        self.reviewer_note = note
+        self.reviewed_at = datetime.utcnow().isoformat()
+
+    def to_dict(self) -> dict:
+        return {
+            "entry_id": self.entry_id,
+            "candidate_id": self.candidate_id,
+            "source": self.source,
+            "authority_id": self.authority_id,
+            "preferred_name": self.preferred_name,
+            "authority_type": self.authority_type,
+            "uri": self.uri,
+            "score": self.score,
+            "extra": self.extra,
+            "status": self.status.value,
+            "reviewer_note": self.reviewer_note,
+            "reviewed_at": self.reviewed_at,
+        }
+
+    @staticmethod
+    def from_dict(d: dict) -> "AuthorityCandidate":
+        return AuthorityCandidate(
+            entry_id=d.get("entry_id", ""),
+            candidate_id=d.get("candidate_id", ""),
+            source=d.get("source", ""),
+            authority_id=d.get("authority_id", ""),
+            preferred_name=d.get("preferred_name", ""),
+            authority_type=d.get("authority_type", ""),
+            uri=d.get("uri", ""),
+            score=float(d.get("score", 0)),
+            extra=d.get("extra", {}),
+            status=ReviewStatus(d.get("status", "pending")),
+            reviewer_note=d.get("reviewer_note", ""),
+            reviewed_at=d.get("reviewed_at", ""),
+        )
 
 
 @dataclass
@@ -479,6 +547,7 @@ class Workspace:
         self.source_files: list[str] = []
         self.ai_runs: list[dict] = []
         self.image_analyses: list[ImageAnalysisResult] = []
+        self.authority_candidates: list[AuthorityCandidate] = []
 
     @property
     def field_mapping(self):
@@ -830,6 +899,34 @@ class Workspace:
         return [r for r in self.image_analyses if r.review_status == status]
 
     # ------------------------------------------------------------------
+    # Authority candidate helpers
+    # ------------------------------------------------------------------
+
+    def add_authority_candidate(self, candidate: AuthorityCandidate) -> None:
+        """Add an authority candidate for review."""
+        self.authority_candidates.append(candidate)
+        self._touch()
+
+    def authority_candidates_for_entry(self, entry_id: str) -> list[AuthorityCandidate]:
+        """Return all authority candidates for a given dictionary entry."""
+        return [c for c in self.authority_candidates if c.entry_id == entry_id]
+
+    def authority_review_stats(self) -> dict[str, int]:
+        """Return count of authority candidates per status."""
+        stats: dict[str, int] = {s.value: 0 for s in ReviewStatus}
+        for c in self.authority_candidates:
+            stats[c.status.value] += 1
+        stats["total"] = len(self.authority_candidates)
+        return stats
+
+    def accepted_ocr_analyses(self) -> list[ImageAnalysisResult]:
+        """Return only accepted OCR image analyses."""
+        return [
+            r for r in self.image_analyses
+            if r.review_status == ImageReviewStatus.ACCEPTED
+        ]
+
+    # ------------------------------------------------------------------
     # AI run logging
     # ------------------------------------------------------------------
 
@@ -877,6 +974,8 @@ class Workspace:
             "source_files": self.source_files,
             "image_analysis_count": len(self.image_analyses),
             "image_review_status": self.image_review_stats(),
+            "authority_candidates_count": len(self.authority_candidates),
+            "authority_review_status": self.authority_review_stats(),
         }
 
     # ------------------------------------------------------------------
@@ -909,6 +1008,7 @@ class Workspace:
             "custom_mds_fields": self.custom_mds_fields,
             "ai_runs": self.ai_runs,
             "image_analyses": [r.to_dict() for r in self.image_analyses],
+            "authority_candidates": [c.to_dict() for c in self.authority_candidates],
             "notes": self.notes,
             "model_text": self.model_text,
             "model_vision": self.model_vision,
@@ -954,6 +1054,10 @@ class Workspace:
         ws.ai_runs = d.get("ai_runs", [])
         ws.image_analyses = [
             ImageAnalysisResult.from_dict(r) for r in d.get("image_analyses", [])
+        ]
+        ws.authority_candidates = [
+            AuthorityCandidate.from_dict(c)
+            for c in d.get("authority_candidates", [])
         ]
         ws.source_files = d.get("source_files", [])
         ws.notes = d.get("notes", "")

--- a/src/kwb/enrich/geonames.py
+++ b/src/kwb/enrich/geonames.py
@@ -1,0 +1,143 @@
+"""
+GeoNames enrichment client.
+
+Queries the GeoNames JSON API (api.geonames.org/searchJSON) for geographic
+entities. Requires a free GeoNames username (env var KWB_GEONAMES_USERNAME).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import time as _time
+from dataclasses import dataclass
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+GEONAMES_BASE = "http://api.geonames.org/searchJSON"
+
+
+@dataclass
+class GeoNamesResult:
+    """One GeoNames search result."""
+    geonames_id: str
+    name: str
+    country: str = ""
+    country_code: str = ""
+    feature_class: str = ""
+    feature_code: str = ""
+    lat: float = 0.0
+    lng: float = 0.0
+    population: int = 0
+
+    @property
+    def uri(self) -> str:
+        return f"https://www.geonames.org/{self.geonames_id}" if self.geonames_id else ""
+
+    def to_dict(self) -> dict:
+        return {
+            "geonames_id": self.geonames_id,
+            "name": self.name,
+            "country": self.country,
+            "country_code": self.country_code,
+            "feature_class": self.feature_class,
+            "feature_code": self.feature_code,
+            "lat": self.lat,
+            "lng": self.lng,
+            "population": self.population,
+            "uri": self.uri,
+        }
+
+
+def geonames_search(
+    term: str,
+    username: str = "demo",
+    max_rows: int = 5,
+    lang: str = "de",
+    feature_class: str = "",
+    timeout: int = 10,
+) -> list[GeoNamesResult]:
+    """Search GeoNames for a geographic term.
+
+    Returns up to max_rows results. Returns [] on empty query or network error.
+    """
+    if not term or not term.strip():
+        return []
+    if not username:
+        logger.warning("GeoNames username not configured")
+        return []
+
+    params = {
+        "q": term,
+        "maxRows": str(min(max_rows, 20)),
+        "username": username,
+        "lang": lang,
+        "type": "json",
+    }
+    if feature_class:
+        params["featureClass"] = feature_class
+
+    url = f"{GEONAMES_BASE}?{urlencode(params)}"
+    try:
+        req = Request(url, headers={"Accept": "application/json"})
+        with urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read().decode("utf-8"))
+    except Exception as e:
+        logger.warning(f"GeoNames API unavailable for '{term}': {e}")
+        return []
+
+    results = []
+    for item in data.get("geonames", []):
+        results.append(GeoNamesResult(
+            geonames_id=str(item.get("geonameId", "")),
+            name=item.get("name", ""),
+            country=item.get("countryName", ""),
+            country_code=item.get("countryCode", ""),
+            feature_class=item.get("fcl", ""),
+            feature_code=item.get("fcode", ""),
+            lat=float(item.get("lat", 0) or 0),
+            lng=float(item.get("lng", 0) or 0),
+            population=int(item.get("population", 0) or 0),
+        ))
+
+    return results
+
+
+def geonames_batch_search(
+    terms: list[dict],
+    username: str = "demo",
+    delay: float = 1.0,
+    max_rows: int = 5,
+) -> list[dict]:
+    """Batch GeoNames search for a list of {text, type, record_id} dicts.
+
+    Returns a list of {text, record_id, results, top_match} dicts.
+    Rate-limits requests with a configurable delay.
+    """
+    if not terms:
+        return []
+
+    output = []
+    for i, item in enumerate(terms):
+        text = item.get("text", "")
+        record_id = item.get("record_id", "")
+
+        try:
+            results = geonames_search(text, username=username, max_rows=max_rows)
+        except Exception as e:
+            logger.warning(f"GeoNames batch search failed for '{text}': {e}")
+            results = []
+
+        top = results[0] if results else None
+        output.append({
+            "text": text,
+            "record_id": record_id,
+            "results": [r.to_dict() for r in results],
+            "top_match": top.to_dict() if top else None,
+        })
+
+        if delay > 0 and i < len(terms) - 1:
+            _time.sleep(delay)
+
+    return output

--- a/tests/test_authority_review.py
+++ b/tests/test_authority_review.py
@@ -1,0 +1,195 @@
+"""
+Tests for authority candidate CRUD, review, and commit-to-dictionary flow.
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import unittest
+
+from kwb.core.workspace import (
+    Workspace, DictionaryEntry, AuthorityCandidate, ReviewStatus,
+)
+
+
+class TestAuthorityCandidateCRUD(unittest.TestCase):
+
+    def test_add_candidate(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+            preferred_name="Berlin", score=0.85,
+        ))
+        self.assertEqual(len(ws.authority_candidates), 1)
+
+    def test_candidates_for_entry(self):
+        ws = Workspace.create("test")
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="1",
+        ))
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e2", source="gnd", authority_id="2",
+        ))
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e1", source="wikidata", authority_id="Q64",
+        ))
+        self.assertEqual(len(ws.authority_candidates_for_entry("e1")), 2)
+        self.assertEqual(len(ws.authority_candidates_for_entry("e2")), 1)
+        self.assertEqual(len(ws.authority_candidates_for_entry("e3")), 0)
+
+
+class TestAuthorityCandidateReview(unittest.TestCase):
+
+    def test_accept_and_reject(self):
+        ws = Workspace.create("test")
+        c1 = AuthorityCandidate(entry_id="e1", source="gnd")
+        c2 = AuthorityCandidate(entry_id="e2", source="gnd")
+        ws.add_authority_candidate(c1)
+        ws.add_authority_candidate(c2)
+
+        c1.accept(note="correct")
+        c2.reject(note="wrong match")
+
+        stats = ws.authority_review_stats()
+        self.assertEqual(stats["accepted"], 1)
+        self.assertEqual(stats["rejected"], 1)
+        self.assertEqual(stats["pending"], 0)
+
+    def test_review_stats_initial(self):
+        ws = Workspace.create("test")
+        ws.add_authority_candidate(AuthorityCandidate(entry_id="e1", source="gnd"))
+        ws.add_authority_candidate(AuthorityCandidate(entry_id="e2", source="gnd"))
+        stats = ws.authority_review_stats()
+        self.assertEqual(stats["pending"], 2)
+        self.assertEqual(stats["total"], 2)
+
+
+class TestAuthorityCommit(unittest.TestCase):
+
+    def test_commit_gnd(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+
+        c = AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+            preferred_name="Berlin", authority_type="PlaceOrGeographicName",
+            uri="https://d-nb.info/gnd/4005765-8",
+        )
+        c.accept()
+        ws.add_authority_candidate(c)
+
+        # Commit
+        for candidate in ws.authority_candidates:
+            if candidate.status != ReviewStatus.ACCEPTED:
+                continue
+            entry = ws.lookup_by_id(candidate.entry_id)
+            if entry and candidate.source == "gnd":
+                entry.gnd_id = candidate.authority_id
+                entry.gnd_preferred = candidate.preferred_name
+                entry.gnd_type = candidate.authority_type
+                entry.gnd_uri = candidate.uri
+
+        berlin = ws.lookup_by_id("e1")
+        self.assertEqual(berlin.gnd_id, "4005765-8")
+        self.assertEqual(berlin.gnd_uri, "https://d-nb.info/gnd/4005765-8")
+
+    def test_commit_wikidata(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+
+        c = AuthorityCandidate(
+            entry_id="e1", source="wikidata", authority_id="Q64",
+            extra={"gnd_id": "4005765-8"},
+        )
+        c.accept()
+        ws.add_authority_candidate(c)
+
+        for candidate in ws.authority_candidates:
+            if candidate.status != ReviewStatus.ACCEPTED:
+                continue
+            entry = ws.lookup_by_id(candidate.entry_id)
+            if entry and candidate.source == "wikidata":
+                entry.wikidata_id = candidate.authority_id
+                if not entry.gnd_id and candidate.extra.get("gnd_id"):
+                    entry.gnd_id = candidate.extra["gnd_id"]
+
+        berlin = ws.lookup_by_id("e1")
+        self.assertEqual(berlin.wikidata_id, "Q64")
+        self.assertEqual(berlin.gnd_id, "4005765-8")
+
+    def test_commit_geonames(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+
+        c = AuthorityCandidate(
+            entry_id="e1", source="geonames", authority_id="2950159",
+        )
+        c.accept()
+        ws.add_authority_candidate(c)
+
+        for candidate in ws.authority_candidates:
+            if candidate.status != ReviewStatus.ACCEPTED:
+                continue
+            entry = ws.lookup_by_id(candidate.entry_id)
+            if entry and candidate.source == "geonames":
+                entry.geonames_id = candidate.authority_id
+
+        berlin = ws.lookup_by_id("e1")
+        self.assertEqual(berlin.geonames_id, "2950159")
+
+    def test_pending_not_committed(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+
+        c = AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+        )
+        # NOT accepted
+        ws.add_authority_candidate(c)
+
+        committed = 0
+        for candidate in ws.authority_candidates:
+            if candidate.status != ReviewStatus.ACCEPTED:
+                continue
+            committed += 1
+
+        self.assertEqual(committed, 0)
+        berlin = ws.lookup_by_id("e1")
+        self.assertEqual(berlin.gnd_id, "")
+
+    def test_full_workspace_roundtrip(self):
+        """Full serialization roundtrip with authority candidates."""
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(
+            term="Berlin", entry_id="e1",
+            term_normalized="Berlin", term_source="metadata",
+        ))
+        c = AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+            preferred_name="Berlin",
+        )
+        c.accept()
+        ws.add_authority_candidate(c)
+
+        # Roundtrip
+        json_str = ws.to_json()
+        ws2 = Workspace.from_json(json_str)
+
+        self.assertEqual(len(ws2.authority_candidates), 1)
+        self.assertEqual(ws2.authority_candidates[0].status, ReviewStatus.ACCEPTED)
+        self.assertEqual(ws2.authority_candidates[0].authority_id, "4005765-8")
+
+        self.assertEqual(len(ws2.dictionary), 1)
+        self.assertEqual(ws2.dictionary[0].term_normalized, "Berlin")
+        self.assertEqual(ws2.dictionary[0].term_source, "metadata")
+
+        # Summary should include authority stats
+        summary = ws2.to_summary()
+        self.assertEqual(summary["authority_candidates_count"], 1)
+        self.assertEqual(summary["authority_review_status"]["accepted"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_geonames.py
+++ b/tests/test_geonames.py
@@ -1,0 +1,122 @@
+"""
+Tests for enrich/geonames.py.
+
+Uses mock HTTP responses to test GeoNames search and batch functions.
+"""
+
+import sys
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from kwb.enrich.geonames import (
+    GeoNamesResult, geonames_search, geonames_batch_search,
+)
+
+
+def _mock_geonames_response(geonames_list):
+    """Create a mock urllib response with GeoNames JSON."""
+    data = json.dumps({"geonames": geonames_list}).encode("utf-8")
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = data
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+class TestGeoNamesResult(unittest.TestCase):
+
+    def test_to_dict(self):
+        r = GeoNamesResult(
+            geonames_id="2950159",
+            name="Berlin",
+            country="Germany",
+            country_code="DE",
+            lat=52.52,
+            lng=13.405,
+            population=3748148,
+        )
+        d = r.to_dict()
+        self.assertEqual(d["geonames_id"], "2950159")
+        self.assertEqual(d["name"], "Berlin")
+        self.assertEqual(d["country"], "Germany")
+        self.assertIn("geonames.org", d["uri"])
+
+    def test_uri(self):
+        r = GeoNamesResult(geonames_id="12345", name="Test")
+        self.assertEqual(r.uri, "https://www.geonames.org/12345")
+
+    def test_empty_uri(self):
+        r = GeoNamesResult(geonames_id="", name="Test")
+        self.assertEqual(r.uri, "")
+
+
+class TestGeoNamesSearch(unittest.TestCase):
+
+    def test_empty_query(self):
+        results = geonames_search("", username="test")
+        self.assertEqual(results, [])
+
+    def test_no_username(self):
+        results = geonames_search("Berlin", username="")
+        self.assertEqual(results, [])
+
+    @patch("kwb.enrich.geonames.urlopen")
+    def test_successful_search(self, mock_urlopen):
+        mock_urlopen.return_value = _mock_geonames_response([
+            {
+                "geonameId": 2950159,
+                "name": "Berlin",
+                "countryName": "Germany",
+                "countryCode": "DE",
+                "fcl": "P",
+                "fcode": "PPLC",
+                "lat": "52.52437",
+                "lng": "13.41053",
+                "population": 3748148,
+            },
+        ])
+
+        results = geonames_search("Berlin", username="test")
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].geonames_id, "2950159")
+        self.assertEqual(results[0].name, "Berlin")
+        self.assertEqual(results[0].country, "Germany")
+
+    @patch("kwb.enrich.geonames.urlopen")
+    def test_network_error(self, mock_urlopen):
+        mock_urlopen.side_effect = Exception("Connection refused")
+        results = geonames_search("Berlin", username="test")
+        self.assertEqual(results, [])
+
+
+class TestGeoNamesBatchSearch(unittest.TestCase):
+
+    def test_empty_terms(self):
+        results = geonames_batch_search([])
+        self.assertEqual(results, [])
+
+    @patch("kwb.enrich.geonames.geonames_search")
+    def test_batch(self, mock_search):
+        mock_search.side_effect = [
+            [GeoNamesResult(geonames_id="2950159", name="Berlin")],
+            [],  # no results for second term
+        ]
+
+        terms = [
+            {"text": "Berlin", "record_id": "r1"},
+            {"text": "Atlantis", "record_id": "r2"},
+        ]
+        results = geonames_batch_search(terms, username="test", delay=0)
+
+        self.assertEqual(len(results), 2)
+        self.assertIsNotNone(results[0]["top_match"])
+        self.assertEqual(results[0]["top_match"]["geonames_id"], "2950159")
+        self.assertIsNone(results[1]["top_match"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,355 @@
+"""
+Tests for the OCR → NER → Dictionary pipeline with review gates.
+
+Covers:
+- AuthorityCandidate model: create, serialize, deserialize
+- OCR gating: only accepted OCR results produce NER entities
+- NER gating: only accepted entities transfer to dictionary
+- Authority gating: candidates must be accepted before commit
+- Dictionary target export format
+- Text normalization
+- Pipeline status
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+import unittest
+
+from kwb.core.workspace import (
+    Workspace, DictionaryEntry, ReviewStatus,
+    ImageAnalysisResult, ImageReviewStatus, AuthorityCandidate,
+)
+from kwb.core.normalize import normalize_term
+
+
+class TestAuthorityCandidateModel(unittest.TestCase):
+
+    def test_create_with_auto_id(self):
+        c = AuthorityCandidate(entry_id="e1", source="gnd", authority_id="123")
+        self.assertTrue(len(c.candidate_id) > 0)
+        self.assertEqual(c.status, ReviewStatus.PENDING)
+
+    def test_accept(self):
+        c = AuthorityCandidate(entry_id="e1", source="gnd")
+        c.accept(note="looks good")
+        self.assertEqual(c.status, ReviewStatus.ACCEPTED)
+        self.assertEqual(c.reviewer_note, "looks good")
+        self.assertTrue(len(c.reviewed_at) > 0)
+
+    def test_reject(self):
+        c = AuthorityCandidate(entry_id="e1", source="wikidata")
+        c.reject(note="wrong match")
+        self.assertEqual(c.status, ReviewStatus.REJECTED)
+
+    def test_roundtrip(self):
+        c = AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+            preferred_name="Berlin", authority_type="PlaceOrGeographicName",
+            uri="https://d-nb.info/gnd/4005765-8", score=0.85,
+            extra={"variants": ["Berlín"]},
+        )
+        d = c.to_dict()
+        c2 = AuthorityCandidate.from_dict(d)
+        self.assertEqual(c2.entry_id, "e1")
+        self.assertEqual(c2.authority_id, "4005765-8")
+        self.assertEqual(c2.score, 0.85)
+        self.assertEqual(c2.extra, {"variants": ["Berlín"]})
+        self.assertEqual(c2.status, ReviewStatus.PENDING)
+
+
+class TestWorkspaceAuthorityCandidates(unittest.TestCase):
+
+    def test_add_and_query(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+        ))
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e1", source="wikidata", authority_id="Q64",
+        ))
+        cands = ws.authority_candidates_for_entry("e1")
+        self.assertEqual(len(cands), 2)
+
+    def test_review_stats(self):
+        ws = Workspace.create("test")
+        c1 = AuthorityCandidate(entry_id="e1", source="gnd")
+        c2 = AuthorityCandidate(entry_id="e1", source="wikidata")
+        c2.accept()
+        ws.add_authority_candidate(c1)
+        ws.add_authority_candidate(c2)
+        stats = ws.authority_review_stats()
+        self.assertEqual(stats["pending"], 1)
+        self.assertEqual(stats["accepted"], 1)
+        self.assertEqual(stats["total"], 2)
+
+    def test_serialization_roundtrip(self):
+        ws = Workspace.create("test")
+        ws.add_authority_candidate(AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="123",
+        ))
+        d = ws.to_dict()
+        ws2 = Workspace.from_dict(d)
+        self.assertEqual(len(ws2.authority_candidates), 1)
+        self.assertEqual(ws2.authority_candidates[0].authority_id, "123")
+
+
+class TestOCRGating(unittest.TestCase):
+    """Verify that only accepted OCR results should feed NER."""
+
+    def test_accepted_ocr_analyses(self):
+        ws = Workspace.create("test")
+        # Add a pending OCR result
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img1", analyzed=True,
+            result={"transcription": "Hallo Welt"},
+            review_status=ImageReviewStatus.PENDING,
+        ))
+        # Add an accepted OCR result
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img2", analyzed=True,
+            result={"transcription": "Johann Bach"},
+            review_status=ImageReviewStatus.ACCEPTED,
+        ))
+        # Add a rejected OCR result
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img3", analyzed=True,
+            result={"transcription": "Noise"},
+            review_status=ImageReviewStatus.REJECTED,
+        ))
+
+        accepted = ws.accepted_ocr_analyses()
+        self.assertEqual(len(accepted), 1)
+        self.assertEqual(accepted[0].image_id, "img2")
+
+    def test_from_ocr_filter_logic(self):
+        """Simulate the from-ocr endpoint filtering logic."""
+        ws = Workspace.create("test")
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img1", analyzed=True,
+            result={"transcription": "Pending text"},
+            review_status=ImageReviewStatus.PENDING,
+        ))
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img2", analyzed=True,
+            result={"transcription": "Accepted text"},
+            review_status=ImageReviewStatus.ACCEPTED,
+        ))
+
+        # Only accepted should be collected
+        ocr_texts = []
+        for analysis in ws.image_analyses:
+            if analysis.review_status != ImageReviewStatus.ACCEPTED:
+                continue
+            text = analysis.result.get("transcription", "")
+            if text.strip():
+                ocr_texts.append(text)
+
+        self.assertEqual(len(ocr_texts), 1)
+        self.assertEqual(ocr_texts[0], "Accepted text")
+
+
+class TestNERGating(unittest.TestCase):
+    """Verify that only accepted entities transfer to dictionary."""
+
+    def test_only_accepted_to_dictionary(self):
+        ws = Workspace.create("test")
+        ws.add_entities([
+            {"text": "Berlin", "type": "LOC", "confidence": 0.9},
+            {"text": "Bach", "type": "PER", "confidence": 0.8},
+            {"text": "Noise", "type": "PER", "confidence": 0.3},
+        ])
+
+        # Accept Berlin and Bach, reject Noise
+        ws.entity_reviews[0].accept()
+        ws.entity_reviews[1].accept()
+        ws.entity_reviews[2].reject()
+
+        # Simulate from-ner logic: only accepted
+        entries_to_add = []
+        for er in ws.entity_reviews:
+            if er.status != ReviewStatus.ACCEPTED:
+                continue
+            entries_to_add.append({
+                "term": er.text,
+                "entity_type": er.entity_type,
+                "source": "ner",
+            })
+
+        added = ws.add_to_dictionary(entries_to_add)
+        self.assertEqual(added, 2)
+        self.assertEqual(len(ws.dictionary), 2)
+        terms = {e.term for e in ws.dictionary}
+        self.assertIn("Berlin", terms)
+        self.assertIn("Bach", terms)
+        self.assertNotIn("Noise", terms)
+
+
+class TestAuthorityGating(unittest.TestCase):
+    """Verify that authority candidates must be accepted before commit."""
+
+    def test_commit_only_accepted(self):
+        ws = Workspace.create("test")
+        ws.add_entry(DictionaryEntry(term="Berlin", entry_id="e1"))
+        ws.add_entry(DictionaryEntry(term="München", entry_id="e2"))
+
+        # GND candidate for Berlin - accepted
+        c1 = AuthorityCandidate(
+            entry_id="e1", source="gnd", authority_id="4005765-8",
+            preferred_name="Berlin", uri="https://d-nb.info/gnd/4005765-8",
+        )
+        c1.accept()
+
+        # GND candidate for München - still pending
+        c2 = AuthorityCandidate(
+            entry_id="e2", source="gnd", authority_id="4127793-4",
+            preferred_name="München",
+        )
+
+        ws.add_authority_candidate(c1)
+        ws.add_authority_candidate(c2)
+
+        # Simulate commit logic
+        committed = 0
+        for candidate in ws.authority_candidates:
+            if candidate.status != ReviewStatus.ACCEPTED:
+                continue
+            entry = ws.lookup_by_id(candidate.entry_id)
+            if entry and candidate.source == "gnd":
+                entry.gnd_id = candidate.authority_id
+                committed += 1
+
+        self.assertEqual(committed, 1)
+        berlin = ws.lookup_by_id("e1")
+        self.assertEqual(berlin.gnd_id, "4005765-8")
+        munich = ws.lookup_by_id("e2")
+        self.assertEqual(munich.gnd_id, "")
+
+
+class TestDictionaryExport(unittest.TestCase):
+    """Verify target JSON format output."""
+
+    def test_target_format(self):
+        entry = DictionaryEntry(
+            term="Joh. Seb. Bach",
+            entry_id="term_001",
+            entity_type="person",
+            preferred_name="Johann Sebastian Bach",
+            record_ids=["rec_001", "rec_002"],
+            gnd_id="11850529X",
+            wikidata_id="Q1339",
+            source="ocr",
+            term_normalized="Johann Sebastian Bach",
+            term_source="ocr",
+        )
+
+        target = {
+            "id": entry.entry_id,
+            "category": entry.entity_type,
+            "term_source": entry.term,
+            "term_normalized": entry.term_normalized or entry.preferred_name or entry.term,
+            "source": entry.term_source or entry.source,
+            "authority": {
+                "wikidata_qid": entry.wikidata_id or None,
+                "gnd_id": entry.gnd_id or None,
+                "geonames_id": entry.geonames_id or None,
+            },
+            "occurrences": [{"record_id": rid} for rid in entry.record_ids],
+        }
+
+        self.assertEqual(target["id"], "term_001")
+        self.assertEqual(target["category"], "person")
+        self.assertEqual(target["term_source"], "Joh. Seb. Bach")
+        self.assertEqual(target["term_normalized"], "Johann Sebastian Bach")
+        self.assertEqual(target["source"], "ocr")
+        self.assertEqual(target["authority"]["gnd_id"], "11850529X")
+        self.assertEqual(target["authority"]["wikidata_qid"], "Q1339")
+        self.assertIsNone(target["authority"]["geonames_id"])
+        self.assertEqual(len(target["occurrences"]), 2)
+
+    def test_new_fields_in_to_dict(self):
+        entry = DictionaryEntry(
+            term="Test",
+            term_normalized="test",
+            term_source="metadata",
+        )
+        d = entry.to_dict()
+        self.assertEqual(d["term_normalized"], "test")
+        self.assertEqual(d["term_source"], "metadata")
+
+        # Roundtrip
+        entry2 = DictionaryEntry.from_dict(d)
+        self.assertEqual(entry2.term_normalized, "test")
+        self.assertEqual(entry2.term_source, "metadata")
+
+
+class TestTextNormalization(unittest.TestCase):
+
+    def test_whitespace_collapse(self):
+        self.assertEqual(normalize_term("  Johann   Sebastian   Bach  "), "Johann Sebastian Bach")
+
+    def test_nfc_normalization(self):
+        # ä composed vs decomposed
+        composed = "Ä"  # U+00C4
+        decomposed = "A\u0308"  # A + combining diaeresis
+        self.assertEqual(normalize_term(composed), normalize_term(decomposed))
+
+    def test_empty(self):
+        self.assertEqual(normalize_term(""), "")
+        self.assertEqual(normalize_term("   "), "")
+
+    def test_tabs_and_newlines(self):
+        self.assertEqual(normalize_term("hello\t\tworld\n"), "hello world")
+
+
+class TestPipelineStatus(unittest.TestCase):
+
+    def test_counts(self):
+        ws = Workspace.create("test")
+        # Add some image analyses
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img1", review_status=ImageReviewStatus.ACCEPTED,
+        ))
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="img2", review_status=ImageReviewStatus.PENDING,
+        ))
+
+        # Add entities
+        ws.add_entities([
+            {"text": "Berlin", "type": "LOC"},
+            {"text": "Bach", "type": "PER"},
+        ])
+        ws.entity_reviews[0].accept()
+
+        # Add authority candidates
+        c = AuthorityCandidate(entry_id="e1", source="gnd")
+        c.accept()
+        ws.add_authority_candidate(c)
+        ws.add_authority_candidate(AuthorityCandidate(entry_id="e2", source="gnd"))
+
+        # Add dictionary entries
+        ws.add_entry(DictionaryEntry(term="Berlin", gnd_id="4005765-8"))
+        ws.add_entry(DictionaryEntry(term="Bach"))
+
+        # Check pipeline status
+        ocr_stats = ws.image_review_stats()
+        self.assertEqual(ocr_stats["total"], 2)
+
+        ner_stats = ws.review_stats()
+        self.assertEqual(ner_stats["total"], 2)
+        self.assertEqual(ner_stats["accepted"], 1)
+
+        auth_stats = ws.authority_review_stats()
+        self.assertEqual(auth_stats["total"], 2)
+        self.assertEqual(auth_stats["accepted"], 1)
+        self.assertEqual(auth_stats["pending"], 1)
+
+        dict_enriched = sum(1 for e in ws.dictionary if e.has_authority)
+        self.assertEqual(dict_enriched, 1)
+        self.assertEqual(len(ws.dictionary), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements a formal 3-phase pipeline with human review gates ensuring data
quality at each stage before promotion to the next:

Phase 1 - OCR Review Gate:
- POST /api/images/review/sample — spot-check sampling of pending OCR results
- POST /api/images/review/auto-accept — bulk accept above confidence threshold
- Modified POST /api/dictionary/from-ocr to only process ACCEPTED OCR results
  (entities go to review queue, not directly to dictionary)

Phase 2 - NER Review Gate:
- POST /api/ner/review/sample — spot-check sampling of pending entities
- POST /api/ner/review/auto-accept — bulk accept above confidence threshold
- POST /api/ner/review/{index} — single entity review endpoint

Phase 3 - Authority Review Gate:
- New AuthorityCandidate model for pending normdaten matches
- GND/Wikidata batch endpoints now create candidates instead of writing directly
- New GeoNames enrichment client (src/kwb/enrich/geonames.py)
- GET/POST /api/geonames/* — GeoNames search and batch enrichment
- GET /api/authority/candidates — list/filter authority candidates
- POST /api/authority/candidates/{id}/review — accept/reject single candidate
- POST /api/authority/candidates/batch-review — bulk review
- POST /api/authority/commit — write accepted candidates to dictionary entries

Additional features:
- GET /api/pipeline/status — pipeline progress across all 3 gates
- GET /api/dictionary/export-target — export in target JSON format
- Pipeline status bar in dashboard UI
- Review gate buttons (spot-check, auto-accept) in Bilder and NER tabs
- Authority candidates section in Wörterbücher tab

Model extensions:
- AuthorityCandidate dataclass with full lifecycle (PENDING→ACCEPTED/REJECTED)
- DictionaryEntry: new term_normalized and term_source fields
- Workspace: authority_candidates list with helpers
- Text normalization utility (NFC + whitespace collapse)
- Config: geonames_username field

Tests: 36 new tests covering all pipeline gates, models, and GeoNames client.

https://claude.ai/code/session_01EQ7Fyn8LhwAJsfTkUB59Ss