### PR TITLE
Add provider override mechanism and fix AI response handling

### DIFF
--- a/src/kwb/api/deps.py
+++ b/src/kwb/api/deps.py
@@ -107,8 +107,21 @@ def set_config(cfg) -> None:
 # ---------------------------------------------------------------------------
 # Provider factory
 # ---------------------------------------------------------------------------
+
+# Test-override: set this module-level variable to inject a mock provider.
+# Tests do:  deps._prov_override = MockProvider.with_defaults()
+_prov_override = None
+
+
 def get_provider(model: str = ""):
-    """Build AI provider: GPUStack if configured, else MockProvider."""
+    """Build AI provider: GPUStack if configured, else MockProvider.
+
+    When _prov_override is set (e.g. in tests), it is returned directly.
+    """
+    global _prov_override
+    if _prov_override is not None:
+        return _prov_override
+
     from kwb.ai.gpustack import GPUStackProvider
     from kwb.ai.mock import MockProvider
 

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -178,7 +178,7 @@ async def ai_describe_columns(request: dict | None = None):
         if br.parsed:
             descriptions[col] = br.parsed
         else:
-            descriptions[col] = {"column": col, "description": br.raw or "", "data_type": "unbekannt"}
+            descriptions[col] = {"column": col, "description": br.response.content if br.response else "", "data_type": "unbekannt"}
 
     col_list = []
     for c in profile.columns:


### PR DESCRIPTION
## Summary
This PR improves testability of the dependency injection system and fixes a bug in AI response handling.

## Key Changes
- **Provider Override for Testing**: Added `_prov_override` module-level variable in `deps.py` to allow tests to inject mock providers without modifying configuration. The `get_provider()` function now checks this override first before building the default provider.
- **Fix AI Response Handling**: Corrected the column description extraction in `routes/ai.py` to use `br.response.content` instead of `br.raw`, ensuring the actual AI response content is captured when available.

## Implementation Details
- The provider override mechanism is intentionally simple and module-level, allowing tests to set `deps._prov_override = MockProvider.with_defaults()` for isolated testing
- The AI response fix handles the case where `br.response` may be `None` by falling back to an empty string
- Both changes maintain backward compatibility with existing code

https://claude.ai/code/session_016hZN3cPutQf94HkRhBzTXS