### PR TITLE
Separate image and document file handling in structural analysis

### DIFF
--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -453,12 +453,33 @@ async function saveFM(){
 }
 
 // === STRUCTURAL ANALYSIS ===
+const _IMAGE_EXTS = new Set(['.jpg','.jpeg','.png','.tif','.tiff','.webp','.img']);
+function _fileExt(name){const i=(name||'').lastIndexOf('.');return i>=0?name.slice(i).toLowerCase():'';}
+
 async function runStruct(){
   const sel=[...document.querySelectorAll('.fcb:checked')].map(c=>c.value);
   if(!sel.length){alert('Mindestens eine Datei auswählen.');return}
   sp('Strukturelle Analyse …',sel.length+' Datei(en)');
   _abortCtrl=new AbortController();
-  const fd=new FormData();for(const id of sel){const it=ufiles[id];if(it)fd.append('files',it.file,it.uploadName)}
+
+  const imgFiles=[], docFiles=[];
+  for(const id of sel){const it=ufiles[id];if(!it)continue;(_IMAGE_EXTS.has(_fileExt(it.uploadName))?imgFiles:docFiles).push(it);}
+
+  // Route image files to the image upload endpoint
+  if(imgFiles.length){
+    const fd=new FormData();for(const it of imgFiles)fd.append('files',it.file,it.uploadName);
+    try{
+      const r=await(await fetch('/api/images/upload',{method:'POST',body:fd,signal:_abortCtrl.signal})).json();
+      if(r.error)throw Error(r.error);
+      uploadedImages=(uploadedImages||[]).concat(r.images||[]);
+      renderImgGrid&&renderImgGrid();
+      if($('img-upload-status'))$('img-upload-status').textContent=(r.uploaded||imgFiles.length)+' Bild(er) hochgeladen.';
+    }catch(e){if(e.name!=='AbortError'){hp();alert(e.message);return;}}
+  }
+
+  if(!docFiles.length){hp();return;}
+
+  const fd=new FormData();for(const it of docFiles)fd.append('files',it.file,it.uploadName);
   try{const r=await(await fetch('/api/analyze',{method:'POST',body:fd,signal:_abortCtrl.signal})).json();
     if(r.error)throw Error(r.error);curRep=r;rrep(r);populateDS();updWS();
     // Show ID column bar for step 1c


### PR DESCRIPTION
## Summary
Modified the structural analysis feature to handle image files and document files through separate upload endpoints, enabling better file type-specific processing.

## Key Changes
- Added image file extension detection with a new `_IMAGE_EXTS` set containing common image formats (.jpg, .jpeg, .png, .tif, .tiff, .webp, .img)
- Introduced `_fileExt()` helper function to extract and normalize file extensions
- Split file selection logic to categorize files into `imgFiles` and `docFiles` arrays based on their extension
- Image files are now routed to `/api/images/upload` endpoint with dedicated handling:
  - Uploads images separately before document analysis
  - Updates `uploadedImages` array with response data
  - Triggers image grid re-rendering via `renderImgGrid()`
  - Displays upload status message in the UI
- Document files continue to use the existing `/api/analyze` endpoint
- Added early return if no document files are present after image upload
- Improved error handling with abort signal support for both upload paths

## Implementation Details
- File categorization happens before any uploads, allowing parallel processing potential
- Image upload errors are caught and displayed to the user without proceeding to document analysis
- The solution maintains backward compatibility for document-only workflows

https://claude.ai/code/session_01WsDpMkm1bL7r8neH561AJN