### PR TITLE
Add GPUStack model configuration display to status endpoint

### DIFF
--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -864,6 +864,8 @@ async function loadGPUConfig(){
     if($('cfg-key'))$('cfg-key').placeholder=d.gpustack_key_masked
       ?'Aktuell: '+d.gpustack_key_masked+' (leer = unverändert)'
       :'sk-… (leer lassen = unverändert)';
+    if(d.gpustack_model_text&&$('cfg-mt'))$('cfg-mt').value=d.gpustack_model_text;
+    if(d.gpustack_model_vision&&$('cfg-mv'))$('cfg-mv').value=d.gpustack_model_vision;
   }catch(e){console.error('loadGPUConfig',e)}}
 
 function toggleKeyVis(){const inp=$('cfg-key');inp.type=inp.type==='password'?'text':'password';}

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -68,8 +68,9 @@ async def gpu_status():
         prov = GPUStackProvider(c.to_provider_config())
         available = prov.is_available()
         models = prov.list_models() if available else []
+        config = {"gpustack_model_text": c.gpustack_model_text, "gpustack_model_vision": c.gpustack_model_vision}
         return {"status": "ok" if available else "error",
-                "configured": True, "available": available, "models": models}
+                "configured": True, "available": available, "models": models, "config": config}
     except Exception as e:
         return {"status": "error", "configured": True, "message": str(e)}
 


### PR DESCRIPTION
## Summary
This PR adds support for displaying the configured GPUStack text and vision models in the GPU status endpoint and updates the dashboard to populate these values in the configuration UI.

## Key Changes
- **Backend (ai.py)**: Extended the `/gpu_status` endpoint to include a `config` object containing `gpustack_model_text` and `gpustack_model_vision` from the provider configuration
- **Frontend (dashboard.js)**: Updated `loadGPUConfig()` to populate the model configuration fields (`cfg-mt` and `cfg-mv`) with the values returned from the status endpoint

## Implementation Details
- The configuration values are extracted from the GPUStackProvider configuration object and returned alongside existing status information
- The frontend conditionally sets the input field values only if the configuration values exist, preventing overwriting with empty values
- This allows users to see their current model selections in the dashboard configuration interface

https://claude.ai/code/session_01C42QgVQksbQXQrxGHW6ges