### PR TITLE
Fix file lookup to use uploadName property instead of object keys

### DIFF
--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -960,7 +960,7 @@ async function createArbeitspaket(){
   const d=ds[0];
   const dsName=d.source_name;
   const idCol=d.id_column||d.columns?.[0]?.name||'';
-  const fullName=Object.keys(ufiles).find(n=>n===dsName||n.startsWith(dsName+'.'))||Object.keys(ufiles).find(n=>n.includes(dsName))||Object.keys(ufiles)[0]||'';
+  const fullName=(Object.values(ufiles).find(f=>f.uploadName===dsName||f.uploadName.startsWith(dsName+'.'))||Object.values(ufiles).find(f=>f.uploadName.includes(dsName))||Object.values(ufiles)[0]||{uploadName:''}).uploadName;
   if(!fullName){alert('Datensatz nicht mehr verfügbar. Bitte Seite neu laden.');return;}
   sp('Arbeitspaket wird erstellt…','CSV Export');
   try{
@@ -1000,7 +1000,7 @@ function showIdColBar(reportData){
   cont.innerHTML=ds.map(d=>{
     const cols=d.columns||[];
     const detected=d.id_column||'';
-    const fname=Object.keys(ufiles).find(n=>n===d.source_name||n.startsWith(d.source_name+'.'))||Object.keys(ufiles).find(n=>n.includes(d.source_name))||'';
+    const fname=(Object.values(ufiles).find(f=>f.uploadName===d.source_name||f.uploadName.startsWith(d.source_name+'.'))||Object.values(ufiles).find(f=>f.uploadName.includes(d.source_name))||{uploadName:''}).uploadName;
     return '<div class="id-col-row">'+
       '<strong style="min-width:140px;font-size:.75rem">'+esc(d.source_name)+':</strong>'+
       '<select id="idcol-'+esc(d.source_name)+'" style="min-width:200px">'+


### PR DESCRIPTION
## Summary
Updated file lookup logic in the dashboard to access the `uploadName` property of file objects instead of relying on object keys, ensuring consistent and reliable file identification.

## Key Changes
- Modified `createArbeitspaket()` function to search through `Object.values(ufiles)` and access the `uploadName` property instead of using `Object.keys(ufiles)`
- Modified `showIdColBar()` function with the same file lookup pattern for consistency
- Both changes follow the same pattern: find file by `uploadName` match, with fallback to empty object with `uploadName` property to prevent errors

## Implementation Details
The changes replace direct key matching with property-based matching on file objects:
- **Before**: `Object.keys(ufiles).find(n=>n===dsName||...)` 
- **After**: `Object.values(ufiles).find(f=>f.uploadName===dsName||...).uploadName`

This approach is more robust as it:
- Directly accesses the intended `uploadName` property rather than relying on object key structure
- Provides a consistent fallback with `{uploadName:''}` to safely handle cases where no file is found
- Ensures the code works correctly regardless of how the `ufiles` object is structured internally

https://claude.ai/code/session_01UJKSJr14FvbvxFDNyNQ9ND