### PR TITLE
Add source_path to dataset metadata and normalize upload filenames

### DIFF
--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -960,7 +960,7 @@ async function createArbeitspaket(){
   const d=ds[0];
   const dsName=d.source_name;
   const idCol=d.id_column||d.columns?.[0]?.name||'';
-  const fullName=(Object.values(ufiles).find(f=>f.uploadName===dsName||f.uploadName.startsWith(dsName+'.'))||Object.values(ufiles).find(f=>f.uploadName.includes(dsName))||Object.values(ufiles)[0]||{uploadName:''}).uploadName;
+  const fullName=d.source_path||(Object.values(ufiles).find(f=>f.uploadName===dsName||f.uploadName.startsWith(dsName+'.'))||Object.values(ufiles).find(f=>f.uploadName.includes(dsName))||Object.values(ufiles)[0]||{uploadName:''}).uploadName;
   if(!fullName){alert('Datensatz nicht mehr verfügbar. Bitte Seite neu laden.');return;}
   sp('Arbeitspaket wird erstellt…','CSV Export');
   try{
@@ -1000,7 +1000,7 @@ function showIdColBar(reportData){
   cont.innerHTML=ds.map(d=>{
     const cols=d.columns||[];
     const detected=d.id_column||'';
-    const fname=(Object.values(ufiles).find(f=>f.uploadName===d.source_name||f.uploadName.startsWith(d.source_name+'.'))||Object.values(ufiles).find(f=>f.uploadName.includes(d.source_name))||{uploadName:''}).uploadName;
+    const fname=d.source_path||(Object.values(ufiles).find(f=>f.uploadName===d.source_name||f.uploadName.startsWith(d.source_name+'.'))||Object.values(ufiles).find(f=>f.uploadName.includes(d.source_name))||{uploadName:''}).uploadName;
     return '<div class="id-col-row">'+
       '<strong style="min-width:140px;font-size:.75rem">'+esc(d.source_name)+':</strong>'+
       '<select id="idcol-'+esc(d.source_name)+'" style="min-width:200px">'+

--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -155,6 +155,7 @@ def _report_json(report, markdown: str) -> dict:
     datasets = [
         {
             "source_name": dp.source_name,
+            "source_path": dp.source_path,
             "row_count": dp.row_count,
             "column_count": dp.column_count,
             "id_column": dp.id_column,
@@ -195,6 +196,27 @@ def _report_json(report, markdown: str) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+_COMPOSITE_KEY_RE = _re.compile(r"__\d+__\d+$")
+
+
+def _normalize_upload_filename(filename: str) -> str:
+    """Strip composite frontend key suffix (``__size__lastModified``) if present.
+
+    The JS upload UI keys files internally as ``name__bytesize__lastModified``
+    (e.g. ``data.csv__11565356__1768907749964``).  In normal operation the
+    third argument of ``FormData.append`` ensures only the plain name reaches
+    the server, but as a defensive measure we strip any such suffix here so
+    that dataset lookups work regardless.
+    """
+    return _COMPOSITE_KEY_RE.sub("", filename)
+
+
+# ---------------------------------------------------------------------------
 # CSV Upload + Analyse
 # ---------------------------------------------------------------------------
 
@@ -211,12 +233,13 @@ async def analyze(files: list[UploadFile] = File(...)):
     datasets = []
 
     for u in files:
-        suffix = Path(u.filename or "").suffix.lower()
+        fname = _normalize_upload_filename(u.filename or "")
+        suffix = Path(fname).suffix.lower()
         if suffix not in ALLOWED_EXTENSIONS:
-            return JSONResponse({"error": f"'{u.filename}': Nur {', '.join(ALLOWED_EXTENSIONS)} erlaubt"}, 400)
+            return JSONResponse({"error": f"'{fname}': Nur {', '.join(ALLOWED_EXTENSIONS)} erlaubt"}, 400)
         content = await u.read()
         if len(content) > MAX_FILE_BYTES:
-            return JSONResponse({"error": f"'{u.filename}': Max {MAX_FILE_BYTES // (1024 * 1024)} MB"}, 400)
+            return JSONResponse({"error": f"'{fname}': Max {MAX_FILE_BYTES // (1024 * 1024)} MB"}, 400)
 
         with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
             tmp.write(content)
@@ -229,16 +252,16 @@ async def analyze(files: list[UploadFile] = File(...)):
             else:
                 df, pr = ingest_csv(tp)
             if len(df) > MAX_CSV_ROWS:
-                return JSONResponse({"error": f"'{u.filename}': Max {MAX_CSV_ROWS:,} Zeilen"}, 400)
+                return JSONResponse({"error": f"'{fname}': Max {MAX_CSV_ROWS:,} Zeilen"}, 400)
             if len(df.columns) > MAX_CSV_COLS:
-                return JSONResponse({"error": f"'{u.filename}': Max {MAX_CSV_COLS} Spalten"}, 400)
-            pr.source_name = Path(u.filename).stem
-            pr.source_path = u.filename
+                return JSONResponse({"error": f"'{fname}': Max {MAX_CSV_COLS} Spalten"}, 400)
+            pr.source_name = Path(fname).stem
+            pr.source_path = fname
             datasets.append((df, pr))
-            state["datasets"][u.filename] = (df, pr)
-            ws.source_files.append(u.filename)
+            state["datasets"][fname] = (df, pr)
+            ws.source_files.append(fname)
         except Exception as e:
-            return JSONResponse({"error": f"{u.filename}: {e}"}, 400)
+            return JSONResponse({"error": f"{fname}: {e}"}, 400)
         finally:
             tp.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary
This PR improves handling of uploaded file metadata by adding the `source_path` field to dataset reports and implementing defensive filename normalization to handle composite keys from the frontend upload UI.

## Key Changes

- **Added `source_path` to dataset metadata**: The `source_path` field is now included in the JSON report output, allowing the frontend to reliably access the original uploaded filename without needing to perform complex lookups.

- **Implemented filename normalization**: Added `_normalize_upload_filename()` helper function that strips composite key suffixes (format: `__size__lastModified`) that the JavaScript upload UI may append to filenames. This ensures dataset lookups work correctly regardless of how the filename is formatted.

- **Updated file validation and processing**: All file validation error messages and dataset storage now use the normalized filename (`fname`) instead of the raw `u.filename`, ensuring consistency throughout the upload pipeline.

- **Simplified frontend logic**: Updated JavaScript code in `dashboard.js` to use `d.source_path` directly instead of performing complex filename matching heuristics, making the code more maintainable and reliable.

## Implementation Details

- The regex pattern `__\d+__\d+$` matches the composite key suffix format used by the frontend
- Normalization is applied early in the upload handler before any file operations
- The `source_path` is stored in the dataset metadata and propagated through the report JSON
- Frontend fallback logic is preserved for backward compatibility with older report formats

https://claude.ai/code/session_01B5Sgb2g4P8zjkwpUKAy66m