### PR TITLE
fix: Codex-Review P1-Punkte adressieren (#87)

### DIFF
--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 656/788 Tests bestanden, 0 fehlgeschlagen, 132 übersprungen
+**Gesamtstatus:** 665/797 Tests bestanden, 0 fehlgeschlagen, 132 übersprungen
 
 ---
 
@@ -260,7 +260,7 @@
 | test_pdf_loader.py | 3/3 | 0 | 0 | ✅ |
 | test_pipeline.py | 18/18 | 0 | 0 | ✅ |
 | test_pipeline_steps.py | 10/10 | 0 | 0 | ✅ |
-| test_quality_analysis_report.py | 43/43 | 0 | 0 | ✅ |
+| test_quality_analysis_report.py | 52/52 | 0 | 0 | ✅ |
 | test_quality_measures.py | 55/55 | 0 | 0 | ✅ |
 | test_roadmap.py | 8/8 | 0 | 0 | ✅ |
 | test_services.py | 20/20 | 0 | 0 | ✅ |
@@ -269,7 +269,7 @@
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 8/8 | 0 | 0 | ✅ |
-| **Gesamt** | **656/788** | **0** | **132** | **✅** |
+| **Gesamt** | **665/797** | **0** | **132** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/analyze/quality_report.py
+++ b/src/kwb/analyze/quality_report.py
@@ -58,9 +58,41 @@ _CATEGORY_ACTION_TEMPLATES: dict[FindingCategory, str] = {
     FindingCategory.FIELD_MISUSE: "Fehlplatzierte Werte in korrekte Felder verschieben",
 }
 
+# Evidence keys that hold explicit record/row counts per finding category.
+# Using these avoids relying on capped record_ids samples for cluster sizing.
+_COUNT_EVIDENCE_KEYS = (
+    "missing_count",
+    "duplicate_row_count",
+    "orphan_count",
+    "near_duplicate_count",
+    "affected_count",
+    "no_match_count",
+)
+
 
 def _highest_severity(severities: list[Severity]) -> Severity:
     return min(severities, key=lambda s: _SEVERITY_ORDER[s], default=Severity.INFO)
+
+
+def _estimate_affected_count(findings: list) -> int:
+    """Return the best available count of affected records for a group of findings.
+
+    Prefers explicit count evidence fields over ``len(record_ids)`` because
+    ``Finding.record_ids`` may be a capped sample and would systematically
+    undercount larger issues.
+    """
+    total = 0
+    has_explicit = False
+    for f in findings:
+        for key in _COUNT_EVIDENCE_KEYS:
+            if key in f.evidence:
+                total += int(f.evidence[key])
+                has_explicit = True
+                break
+    if has_explicit:
+        return total
+    # Fallback: deduplicated record_ids (may be a sample)
+    return len({rid for f in findings for rid in f.record_ids})
 
 
 # ---------------------------------------------------------------------------
@@ -69,32 +101,39 @@ def _highest_severity(severities: list[Severity]) -> Severity:
 
 
 def _build_column_reports(report: AnalysisReport) -> list[ColumnQualityReport]:
-    """Build per-column quality reports from findings and dataset profiles."""
-    # Collect column metadata from dataset profiles
-    col_meta: dict[str, dict] = {}
+    """Build per-column quality reports from findings and dataset profiles.
+
+    Columns are keyed by ``(source_name, col_name)`` so that identically-named
+    columns from different datasets get distinct reports.  Finding-only columns
+    (present in findings but absent from any profile) are stored under
+    ``source=""`` to avoid conflating them with profile-derived entries.
+    """
+    # Collect column metadata keyed by (source_name, col_name)
+    col_meta: dict[tuple[str, str], dict] = {}
     for ds in report.datasets:
         for col in ds.columns:
-            col_meta[col.name] = {
+            col_meta[(ds.source_name, col.name)] = {
                 "fill_rate": col.fill_rate,
                 "unique_count": col.unique_count,
                 "dtype": col.dtype,
             }
 
-    # Group findings by column
+    # Group findings by column name
     findings_by_col: dict[str, list] = {}
     for f in report.findings:
         if f.column:
             findings_by_col.setdefault(f.column, []).append(f)
 
-    # Also include columns from metadata that have no findings
-    all_columns = set(col_meta.keys()) | set(findings_by_col.keys())
+    # Column names that appear in at least one dataset profile
+    profile_col_names = {col_name for _, col_name in col_meta}
+    # Finding-only columns: present in findings but absent from all profiles
+    finding_only_cols = {
+        col_name for col_name in findings_by_col if col_name not in profile_col_names
+    }
 
     column_reports: list[ColumnQualityReport] = []
-    for col_name in sorted(all_columns):
-        col_findings = findings_by_col.get(col_name, [])
-        meta = col_meta.get(col_name, {})
 
-        # Derive measure summaries from findings for this column
+    def _make_report(col_name: str, source: str, meta: dict, col_findings: list) -> ColumnQualityReport:
         measure_summary: dict[str, MeasureSummaryEntry] = {}
 
         completeness_score: int | None = None
@@ -105,7 +144,6 @@ def _build_column_reports(report: AnalysisReport) -> list[ColumnQualityReport]:
             confidence=None,
             reasoning="",
         )
-
         # semantic_correctness placeholder — will be enriched in Phase 2
         measure_summary["semantic_correctness"] = MeasureSummaryEntry(
             score=None,
@@ -121,33 +159,40 @@ def _build_column_reports(report: AnalysisReport) -> list[ColumnQualityReport]:
         if "dtype" in meta:
             evidence["dtype"] = meta["dtype"]
 
-        # Determine suggested_action and review_required from findings
         suggested_action: str | None = None
         review_required = False
         if col_findings:
             severities = [f.severity for f in col_findings]
             if _highest_severity(severities) in (Severity.CRITICAL, Severity.WARNING):
                 review_required = True
-            # Pick suggestion from the most severe finding
             for f in sorted(col_findings, key=lambda x: _SEVERITY_ORDER[x.severity]):
                 if f.suggestion:
                     suggested_action = f.suggestion
                     break
-                # Fall back to category template
                 template = _CATEGORY_ACTION_TEMPLATES.get(f.category)
                 if template:
                     suggested_action = template
                     break
 
-        column_reports.append(
-            ColumnQualityReport(
-                column=col_name,
-                measure_summary=measure_summary,
-                evidence=evidence,
-                suggested_action=suggested_action,
-                review_required=review_required,
-            )
+        return ColumnQualityReport(
+            column=col_name,
+            source=source,
+            measure_summary=measure_summary,
+            evidence=evidence,
+            suggested_action=suggested_action,
+            review_required=review_required,
         )
+
+    # Profile-derived columns — one entry per (source_name, col_name)
+    for source_name, col_name in sorted(col_meta):
+        col_findings = findings_by_col.get(col_name, [])
+        column_reports.append(
+            _make_report(col_name, source_name, col_meta[(source_name, col_name)], col_findings)
+        )
+
+    # Finding-only columns — source stays empty
+    for col_name in sorted(finding_only_cols):
+        column_reports.append(_make_report(col_name, "", {}, findings_by_col[col_name]))
 
     return column_reports
 
@@ -158,7 +203,13 @@ def _build_column_reports(report: AnalysisReport) -> list[ColumnQualityReport]:
 
 
 def _build_record_reports(report: AnalysisReport) -> list[RecordQualityReport]:
-    """Derive per-record quality reports from findings that reference record IDs."""
+    """Derive per-record quality reports from findings that reference record IDs.
+
+    Records are keyed by ``record_id`` only in Phase 1 because ``Finding``
+    objects do not carry dataset-source context.  The ``source`` field on
+    ``RecordQualityReport`` is left empty and will be populated in Phase 2
+    once findings carry explicit source attribution.
+    """
     record_findings: dict[str, list] = {}
     for f in report.findings:
         for rid in f.record_ids:
@@ -173,6 +224,7 @@ def _build_record_reports(report: AnalysisReport) -> list[RecordQualityReport]:
         record_reports.append(
             RecordQualityReport(
                 record_id=record_id,
+                source="",  # Phase 1: Finding has no source attribution
                 severity=severity,
                 issues=issues,
                 confidence=None,
@@ -220,18 +272,30 @@ def _build_cell_findings(report: AnalysisReport) -> list[CellFinding]:
 
 
 def _build_issue_clusters(report: AnalysisReport) -> list[IssueCluster]:
-    """Group related findings by category into issue clusters."""
+    """Group related findings by category into issue clusters.
+
+    ``affected_records_count`` is derived from explicit evidence count fields
+    (e.g. ``missing_count``, ``duplicate_row_count``) when available, falling
+    back to ``len(record_ids)`` only when no explicit count exists.  This
+    avoids systematic undercounting caused by capped ``record_ids`` samples.
+    """
     by_cat: dict[FindingCategory, list] = {}
     for f in report.findings:
         by_cat.setdefault(f.category, []).append(f)
 
     clusters: list[IssueCluster] = []
     for idx, (cat, findings) in enumerate(
-        sorted(by_cat.items(), key=lambda x: (_SEVERITY_ORDER[_highest_severity([f.severity for f in x[1]])], x[0].value))
+        sorted(
+            by_cat.items(),
+            key=lambda x: (
+                _SEVERITY_ORDER[_highest_severity([f.severity for f in x[1]])],
+                x[0].value,
+            ),
+        )
     ):
         cols = sorted({f.column for f in findings if f.column})
-        record_ids = {rid for f in findings for rid in f.record_ids}
         severity = _highest_severity([f.severity for f in findings])
+        affected_count = _estimate_affected_count(findings)
 
         clusters.append(
             IssueCluster(
@@ -239,7 +303,7 @@ def _build_issue_clusters(report: AnalysisReport) -> list[IssueCluster]:
                 label=cat.value.replace("_", " ").title(),
                 category=cat,
                 affected_columns=cols,
-                affected_records_count=len(record_ids),
+                affected_records_count=affected_count,
                 severity=severity,
                 suggested_action=_CATEGORY_ACTION_TEMPLATES.get(cat),
             )
@@ -305,8 +369,8 @@ def build_quality_analysis_report(report: AnalysisReport) -> QualityAnalysisRepo
     Existing rule-based findings are mapped onto the hierarchical structure.
     In Phase 2, LLM-based checks will enrich the same structure.
     """
-    # dataset_profile: use first dataset
-    dataset_profile = report.datasets[0] if report.datasets else None
+    # dataset_profiles: preserve *all* analysed datasets (not just the first)
+    dataset_profiles = list(report.datasets)
 
     # quality_measures: transform QualityMeasureReport into plain dicts
     quality_measures: list[dict] = []
@@ -333,14 +397,15 @@ def build_quality_analysis_report(report: AnalysisReport) -> QualityAnalysisRepo
     issue_clusters = _build_issue_clusters(report)
     work_package_candidates = _build_work_packages(issue_clusters, report)
 
+    source_names = ", ".join(ds.source_name for ds in dataset_profiles) if dataset_profiles else ""
     provenance = AnalysisProvenance(
         analyzed_at=datetime.now(timezone.utc).isoformat(),
-        source_name=dataset_profile.source_name if dataset_profile else "",
+        source_name=source_names,
         analysis_mode="rule_based",
     )
 
     return QualityAnalysisReport(
-        dataset_profile=dataset_profile,
+        dataset_profiles=dataset_profiles,
         quality_measures=quality_measures,
         column_reports=column_reports,
         record_reports=record_reports,

--- a/src/kwb/core/models.py
+++ b/src/kwb/core/models.py
@@ -192,9 +192,14 @@ class MeasureSummaryEntry:
 
 @dataclass
 class ColumnQualityReport:
-    """Quality report for a single dataset column."""
+    """Quality report for a single dataset column.
+
+    ``source`` identifies which dataset this column belongs to, enabling
+    distinct reports for same-named columns from different datasets.
+    """
 
     column: str
+    source: str = ""
     measure_summary: dict[str, MeasureSummaryEntry] = field(default_factory=dict)
     evidence: dict[str, Any] = field(default_factory=dict)
     suggested_action: str | None = None
@@ -203,6 +208,7 @@ class ColumnQualityReport:
     def to_dict(self) -> dict[str, Any]:
         return {
             "column": self.column,
+            "source": self.source,
             "measure_summary": {k: v.to_dict() for k, v in self.measure_summary.items()},
             "evidence": self.evidence,
             "suggested_action": self.suggested_action,
@@ -212,9 +218,14 @@ class ColumnQualityReport:
 
 @dataclass
 class RecordQualityReport:
-    """Quality report for a single dataset record."""
+    """Quality report for a single dataset record.
+
+    ``source`` identifies which dataset this record belongs to, preventing
+    same-ID records from different datasets from being conflated.
+    """
 
     record_id: str
+    source: str = ""
     severity: Severity | None = None
     issues: list[str] = field(default_factory=list)
     confidence: float | None = None
@@ -224,6 +235,7 @@ class RecordQualityReport:
     def to_dict(self) -> dict[str, Any]:
         return {
             "record_id": self.record_id,
+            "source": self.source,
             "severity": self.severity.value if self.severity else None,
             "issues": self.issues,
             "confidence": self.confidence,
@@ -337,9 +349,13 @@ class QualityAnalysisReport:
     the single source of truth for all downstream rendering (Markdown, GUI,
     JSON export).  Markdown and other output formats are derived from this
     structure rather than the other way around.
+
+    ``dataset_profiles`` holds metadata for *all* analysed datasets so that
+    multi-file analyses (cross-file linkage, orphan checks) are fully
+    represented without silently dropping files after the first one.
     """
 
-    dataset_profile: DatasetProfile | None = None
+    dataset_profiles: list[DatasetProfile] = field(default_factory=list)
     quality_measures: list[dict[str, Any]] = field(default_factory=list)
     column_reports: list[ColumnQualityReport] = field(default_factory=list)
     record_reports: list[RecordQualityReport] = field(default_factory=list)
@@ -349,15 +365,15 @@ class QualityAnalysisReport:
     analysis_provenance: AnalysisProvenance | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        ds = self.dataset_profile
         return {
-            "dataset_profile": {
-                "source_name": ds.source_name,
-                "row_count": ds.row_count,
-                "column_count": ds.column_count,
-            }
-            if ds
-            else None,
+            "dataset_profiles": [
+                {
+                    "source_name": ds.source_name,
+                    "row_count": ds.row_count,
+                    "column_count": ds.column_count,
+                }
+                for ds in self.dataset_profiles
+            ],
             "quality_measures": self.quality_measures,
             "column_reports": [r.to_dict() for r in self.column_reports],
             "record_reports": [r.to_dict() for r in self.record_reports],

--- a/src/kwb/report/markdown.py
+++ b/src/kwb/report/markdown.py
@@ -240,16 +240,14 @@ def render_quality_analysis_report(report: QualityAnalysisReport) -> str:
     sections.append(f"*Erstellt: {now}*")
     sections.append("")
 
-    # Dataset summary
-    ds = report.dataset_profile
-    if ds:
+    # Dataset summary (all analysed datasets)
+    if report.dataset_profiles:
         sections.append("## Datensatz-Zusammenfassung")
         sections.append("")
-        sections.append("| Eigenschaft | Wert |")
-        sections.append("|---|---|")
-        sections.append(f"| Datei | `{ds.source_name}` |")
-        sections.append(f"| Zeilen | {ds.row_count:,} |")
-        sections.append(f"| Spalten | {ds.column_count} |")
+        sections.append("| Datei | Zeilen | Spalten |")
+        sections.append("|---|---|---|")
+        for ds in report.dataset_profiles:
+            sections.append(f"| `{ds.source_name}` | {ds.row_count:,} | {ds.column_count} |")
         sections.append("")
 
     # Quality measures

--- a/tests/test_quality_analysis_report.py
+++ b/tests/test_quality_analysis_report.py
@@ -82,6 +82,7 @@ class TestColumnQualityReport(unittest.TestCase):
     def test_to_dict_structure(self):
         cr = ColumnQualityReport(
             column="title",
+            source="ds1.csv",
             measure_summary={
                 "completeness": MeasureSummaryEntry(score=80, confidence=None, reasoning="")
             },
@@ -91,16 +92,23 @@ class TestColumnQualityReport(unittest.TestCase):
         )
         d = cr.to_dict()
         self.assertEqual(d["column"], "title")
+        self.assertEqual(d["source"], "ds1.csv")
         self.assertIn("completeness", d["measure_summary"])
         self.assertEqual(d["measure_summary"]["completeness"]["score"], 80)
         self.assertEqual(d["evidence"]["fill_rate"], 0.8)
         self.assertTrue(d["review_required"])
+
+    def test_source_defaults_to_empty_string(self):
+        cr = ColumnQualityReport(column="title")
+        self.assertEqual(cr.source, "")
+        self.assertEqual(cr.to_dict()["source"], "")
 
 
 class TestRecordQualityReport(unittest.TestCase):
     def test_to_dict_with_severity(self):
         rr = RecordQualityReport(
             record_id="rec_001",
+            source="ds1.csv",
             severity=Severity.WARNING,
             issues=["Missing title"],
             confidence=0.85,
@@ -109,6 +117,7 @@ class TestRecordQualityReport(unittest.TestCase):
         )
         d = rr.to_dict()
         self.assertEqual(d["record_id"], "rec_001")
+        self.assertEqual(d["source"], "ds1.csv")
         self.assertEqual(d["severity"], "warning")
         self.assertEqual(d["issues"], ["Missing title"])
         self.assertTrue(d["review_required"])
@@ -117,6 +126,11 @@ class TestRecordQualityReport(unittest.TestCase):
         rr = RecordQualityReport(record_id="rec_002")
         d = rr.to_dict()
         self.assertIsNone(d["severity"])
+
+    def test_source_defaults_to_empty_string(self):
+        rr = RecordQualityReport(record_id="rec_003")
+        self.assertEqual(rr.source, "")
+        self.assertEqual(rr.to_dict()["source"], "")
 
 
 class TestCellFinding(unittest.TestCase):
@@ -194,7 +208,7 @@ class TestQualityAnalysisReport(unittest.TestCase):
     def test_to_dict_empty(self):
         qar = QualityAnalysisReport()
         d = qar.to_dict()
-        self.assertIsNone(d["dataset_profile"])
+        self.assertEqual(d["dataset_profiles"], [])
         self.assertEqual(d["quality_measures"], [])
         self.assertEqual(d["column_reports"], [])
         self.assertEqual(d["record_reports"], [])
@@ -203,20 +217,30 @@ class TestQualityAnalysisReport(unittest.TestCase):
         self.assertEqual(d["work_package_candidates"], [])
         self.assertIsNone(d["analysis_provenance"])
 
-    def test_to_dict_with_profile(self):
+    def test_to_dict_with_single_profile(self):
         ds = _make_profile("demo.csv", rows=500, cols=10)
-        qar = QualityAnalysisReport(dataset_profile=ds)
+        qar = QualityAnalysisReport(dataset_profiles=[ds])
         d = qar.to_dict()
-        self.assertIsNotNone(d["dataset_profile"])
-        self.assertEqual(d["dataset_profile"]["source_name"], "demo.csv")
-        self.assertEqual(d["dataset_profile"]["row_count"], 500)
+        self.assertEqual(len(d["dataset_profiles"]), 1)
+        self.assertEqual(d["dataset_profiles"][0]["source_name"], "demo.csv")
+        self.assertEqual(d["dataset_profiles"][0]["row_count"], 500)
+
+    def test_to_dict_with_multiple_profiles(self):
+        ds1 = _make_profile("a.csv", rows=100, cols=3)
+        ds2 = _make_profile("b.csv", rows=200, cols=5)
+        qar = QualityAnalysisReport(dataset_profiles=[ds1, ds2])
+        d = qar.to_dict()
+        self.assertEqual(len(d["dataset_profiles"]), 2)
+        names = [p["source_name"] for p in d["dataset_profiles"]]
+        self.assertIn("a.csv", names)
+        self.assertIn("b.csv", names)
 
     def test_all_levels_present_in_schema(self):
         """The schema must have all required top-level keys."""
         qar = QualityAnalysisReport()
         d = qar.to_dict()
         required_keys = [
-            "dataset_profile",
+            "dataset_profiles",
             "quality_measures",
             "column_reports",
             "record_reports",
@@ -277,18 +301,31 @@ class TestBuildQualityAnalysisReport(unittest.TestCase):
         qar = build_quality_analysis_report(report)
         self.assertIsInstance(qar, QualityAnalysisReport)
 
-    def test_dataset_profile_mapped(self):
+    def test_all_dataset_profiles_preserved(self):
+        """All datasets must be retained — not just the first one."""
+        report = _make_report()
+        report.datasets = [
+            _make_profile("a.csv", rows=100),
+            _make_profile("b.csv", rows=200),
+        ]
+        qar = build_quality_analysis_report(report)
+        self.assertEqual(len(qar.dataset_profiles), 2)
+        names = {ds.source_name for ds in qar.dataset_profiles}
+        self.assertIn("a.csv", names)
+        self.assertIn("b.csv", names)
+
+    def test_single_dataset_profile_mapped(self):
         report = _make_report()
         profile = _make_profile("mydata.csv", rows=300)
         report.datasets = [profile]
         qar = build_quality_analysis_report(report)
-        self.assertIsNotNone(qar.dataset_profile)
-        self.assertEqual(qar.dataset_profile.source_name, "mydata.csv")
+        self.assertEqual(len(qar.dataset_profiles), 1)
+        self.assertEqual(qar.dataset_profiles[0].source_name, "mydata.csv")
 
-    def test_no_datasets_profile_is_none(self):
+    def test_no_datasets_profiles_empty(self):
         report = _make_report()
         qar = build_quality_analysis_report(report)
-        self.assertIsNone(qar.dataset_profile)
+        self.assertEqual(qar.dataset_profiles, [])
 
     def test_quality_measures_populated_from_report(self):
         report = self._make_full_report()
@@ -395,7 +432,14 @@ class TestBuildQualityAnalysisReport(unittest.TestCase):
         qar = build_quality_analysis_report(report)
         self.assertIsNotNone(qar.analysis_provenance)
         self.assertEqual(qar.analysis_provenance.analysis_mode, "rule_based")
-        self.assertEqual(qar.analysis_provenance.source_name, "sample.csv")
+        self.assertIn("sample.csv", qar.analysis_provenance.source_name)
+
+    def test_provenance_source_name_includes_all_datasets(self):
+        report = _make_report()
+        report.datasets = [_make_profile("a.csv"), _make_profile("b.csv")]
+        qar = build_quality_analysis_report(report)
+        self.assertIn("a.csv", qar.analysis_provenance.source_name)
+        self.assertIn("b.csv", qar.analysis_provenance.source_name)
 
     def test_to_dict_is_json_compatible(self):
         import json
@@ -405,6 +449,60 @@ class TestBuildQualityAnalysisReport(unittest.TestCase):
         # Should not raise
         serialized = json.dumps(d)
         self.assertIsInstance(serialized, str)
+
+    def test_column_reports_distinct_per_dataset_for_same_column_name(self):
+        """Same-named columns from different datasets must produce separate reports."""
+        from kwb.ingest.csv_loader import profile_column
+        import pandas as pd
+
+        def make_ds_with_col(source_name, col_name, values):
+            s = pd.Series(values, name=col_name)
+            col = profile_column(s)
+            ds = _make_profile(source_name)
+            ds.columns = [col]
+            return ds
+
+        report = _make_report()
+        report.datasets = [
+            make_ds_with_col("ds1.csv", "title", ["A", "B", "C"]),
+            make_ds_with_col("ds2.csv", "title", ["X", None, "Z"]),
+        ]
+        qar = build_quality_analysis_report(report)
+        title_reports = [cr for cr in qar.column_reports if cr.column == "title"]
+        # There must be one report per dataset, not one merged entry
+        self.assertEqual(len(title_reports), 2)
+        sources = {cr.source for cr in title_reports}
+        self.assertIn("ds1.csv", sources)
+        self.assertIn("ds2.csv", sources)
+
+    def test_issue_cluster_uses_evidence_count_over_record_ids(self):
+        """affected_records_count must use evidence fields, not capped record_ids."""
+        # Finding has only 2 record_ids in the sample but evidence says 500
+        finding = Finding(
+            category=FindingCategory.MISSING_VALUES,
+            severity=Severity.WARNING,
+            message="Viele fehlende Werte",
+            column="description",
+            record_ids=["r001", "r002"],  # capped sample
+            evidence={"missing_count": 500},  # true count
+        )
+        report = _make_report(finding, rows=1000)
+        qar = build_quality_analysis_report(report)
+        cluster = next(cl for cl in qar.issue_clusters if cl.category == FindingCategory.MISSING_VALUES)
+        self.assertEqual(cluster.affected_records_count, 500)
+
+    def test_issue_cluster_falls_back_to_record_ids_when_no_evidence_count(self):
+        finding = Finding(
+            category=FindingCategory.TERM_VARIANTS,
+            severity=Severity.INFO,
+            message="Term-Varianten",
+            record_ids=["r001", "r002", "r003"],
+            evidence={},  # no count fields
+        )
+        report = _make_report(finding)
+        qar = build_quality_analysis_report(report)
+        cluster = next(cl for cl in qar.issue_clusters if cl.category == FindingCategory.TERM_VARIANTS)
+        self.assertEqual(cluster.affected_records_count, 3)
 
     def test_empty_report_does_not_crash(self):
         report = AnalysisReport()
@@ -493,6 +591,14 @@ class TestRenderQualityAnalysisReport(unittest.TestCase):
         qar = self._build_qar()
         md = render_quality_analysis_report(qar)
         self.assertIn("rule_based", md)
+
+    def test_dataset_summary_shows_all_datasets(self):
+        ds1 = _make_profile("file1.csv", rows=100)
+        ds2 = _make_profile("file2.csv", rows=200)
+        qar = QualityAnalysisReport(dataset_profiles=[ds1, ds2])
+        md = render_quality_analysis_report(qar)
+        self.assertIn("file1.csv", md)
+        self.assertIn("file2.csv", md)
 
     def test_no_cell_findings_section_when_empty(self):
         qar = QualityAnalysisReport()


### PR DESCRIPTION
Behebt alle vier P1-Findings aus dem automatischen Codex-Review:

1. Alle Dataset-Profile erhalten (nicht nur das erste)
   - QualityAnalysisReport.dataset_profile → dataset_profiles: list[DatasetProfile]
   - build_quality_analysis_report() übergibt report.datasets komplett
   - render_quality_analysis_report() rendert alle Datasets als Tabelle
   - AnalysisProvenance.source_name enthält alle Dataset-Namen

2. Spalten verschiedener Datasets werden separat gehalten
   - _build_column_reports() schlüsselt nach (source_name, col_name)
   - ColumnQualityReport erhält neues Feld source: str
   - Gleichnamige Spalten aus verschiedenen Datasets erzeugen separate Reports

3. Records erhalten source-Feld für spätere Disambiguierung
   - RecordQualityReport erhält neues Feld source: str
   - In Phase 1 bleibt source="" (Finding trägt noch keine Quell-Attribution)
   - Vorbereitung für Phase 2, wenn Findings source-Kontext tragen

4. affected_records_count nutzt evidence-Felder statt gekappter record_ids
   - _estimate_affected_count() bevorzugt missing_count, duplicate_row_count, orphan_count, near_duplicate_count, affected_count, no_match_count
   - Fallback auf len(record_ids) nur wenn kein explizites Zählfeld vorhanden
   - Verhindert systematisches Undercounting bei großen Datensätzen

Tests: 43 → 52 (9 neue Tests für alle Fixes, inkl. Multi-Dataset-Szenarien)
Testkatalog: 656/788 → 665/797

https://claude.ai/code/session_01J7P9dgYg27Nvz6QvR4Tmd9

## Summary
Briefly describe what this PR changes.

## Problem
What was broken, missing, or suboptimal?

## Root cause
What caused the issue?

## Solution
What did you change to address it?

## Files changed
List the most important files or modules changed.

## Tests
- [ ] `ruff check .`
- [ ] `pytest`
- [ ] added or updated automated tests
- [ ] manual verification on localhost performed
- [ ] no relevant manual verification needed

Describe the tests or checks you performed.

## Screenshots / UI notes
Add screenshots or short notes if the UI changed.

## Risks / follow-up
What remains risky, incomplete, or worth addressing later?