### PR TITLE
Add Phase 3: Review Queues, Work Packages & Remediation

### DIFF
--- a/src/kwb/api/app.py
+++ b/src/kwb/api/app.py
@@ -50,6 +50,7 @@ from kwb.api.routes.auth import router as auth_router
 from kwb.api.routes.pipeline import router as pipeline_router
 from kwb.api.routes.pdf import router as pdf_router
 from kwb.api.routes.llm_quality import router as llm_quality_router
+from kwb.api.routes.review import router as review_router
 
 # ---------------------------------------------------------------------------
 # FastAPI app
@@ -71,6 +72,7 @@ app.include_router(auth_router)
 app.include_router(pipeline_router)
 app.include_router(pdf_router)
 app.include_router(llm_quality_router)
+app.include_router(review_router)
 
 # ---------------------------------------------------------------------------
 # UI data injected into the dashboard HTML template
@@ -189,6 +191,21 @@ CATALOG = [
      "note": "POST /api/ai/quality-check; Zell-/Spalten-/Record-/Datensatz-Ebene; Modellwahl, Pilot/Vollanalyse, Scope; GUI: 1d + Tab KI-Qualitätsprüfung"},
     # Report
     {"id": "P-01", "name": "Markdown-Report",     "module": "Report",    "status": "done",    "note": ""},
+    # Phase 3 — Review Queues, Work Packages, Remediation
+    {"id": "V-01", "name": "Review-Queues (Phase 3)", "module": "Review", "status": "done",
+     "note": "GET /api/review/items; Filter: Severity, Spalte, Kategorie, Status, Confidence"},
+    {"id": "V-02", "name": "Review-Item-Status (Phase 3)", "module": "Review", "status": "done",
+     "note": "PATCH /api/review/items/{id}/status: pending|accepted|rejected|needs_expert_review|applied"},
+    {"id": "V-03", "name": "Work-Package-Generierung (Phase 3)", "module": "Review", "status": "done",
+     "note": "POST /api/review/work-packages/generate; Cluster → priorisierte Work Packages"},
+    {"id": "V-04", "name": "Bereinigungsvorschläge (Phase 3)", "module": "Review", "status": "done",
+     "note": "POST /api/review/suggestions; move_value_to_field, normalize_label, flag_for_authority_lookup etc."},
+    {"id": "V-05", "name": "Kontrollierte Anwendung (Phase 3)", "module": "Review", "status": "done",
+     "note": "POST /api/review/apply; nur ACCEPTED-Vorschläge, protokolliert in AppliedChangeLog"},
+    {"id": "V-06", "name": "Änderungsprotokoll (Phase 3)", "module": "Review", "status": "done",
+     "note": "GET /api/review/changelog; Originalwert, neuer Wert, Zeitstempel, Bearbeiter"},
+    {"id": "V-07", "name": "Review-Export (Phase 3)", "module": "Review", "status": "done",
+     "note": "GET /api/review/export; Review-Status + Work Packages + Changelog als JSON"},
     # Geplant
     {"id": "R-01", "name": "Wikidata",            "module": "Enrich",    "status": "planned", "note": "SPARQL"},
     {"id": "R-02", "name": "OCR/HTR",             "module": "Analyse",   "status": "planned", "note": ""},

--- a/src/kwb/api/deps.py
+++ b/src/kwb/api/deps.py
@@ -68,6 +68,11 @@ _state: dict[str, Any] = {
     "report": None,
     "config": None,
     "workspace": Workspace(name="default"),
+    # Phase 3 — Review
+    "review_queue": None,       # ReviewQueue | None
+    "work_packages": [],        # list[WorkPackage]
+    "changelog": [],            # list[AppliedChangeLog]
+    "suggestions": {},          # dict[suggestion_id, RemediationSuggestion]
 }
 
 

--- a/src/kwb/api/routes/review.py
+++ b/src/kwb/api/routes/review.py
@@ -1,0 +1,535 @@
+"""
+Phase 3 — Review Queues, Work Packages & Remediation — API Routes.
+
+Endpoints:
+
+  GET  /api/review/items                — list review items (filterable)
+  PATCH /api/review/items/{item_id}/status — update item status
+  GET  /api/review/items/summary        — queue summary statistics
+  GET  /api/review/work-packages        — list work packages
+  POST /api/review/work-packages/generate — generate from last quality analysis
+  GET  /api/review/suggestions          — list remediation suggestions
+  POST /api/review/suggestions          — add a remediation suggestion
+  PATCH /api/review/suggestions/{sid}/status — accept/reject a suggestion
+  POST /api/review/apply                — apply all ACCEPTED suggestions to dataset
+  GET  /api/review/changelog            — applied change log
+  GET  /api/review/export               — export review status + changelog as JSON
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+try:
+    from fastapi import APIRouter
+    from fastapi.responses import JSONResponse
+except ImportError:
+    raise ImportError("pip install fastapi uvicorn")
+
+from kwb.api.deps import get_datasets, get_state
+from kwb.core.models import (
+    AppliedChangeLog,
+    RemediationActionType,
+    RemediationSuggestion,
+    ReviewStatus,
+    WorkPackage,
+)
+from kwb.review.queue import ReviewQueue
+from kwb.review.remediation import apply_accepted_changes
+from kwb.review.work_packages import generate_work_packages
+
+router = APIRouter(prefix="/api/review", tags=["review"])
+
+_VALID_STATUSES = {s.value for s in ReviewStatus}
+_VALID_ACTIONS = {a.value for a in RemediationActionType}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_id() -> str:
+    return str(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# Helper: get or init review queue from state
+# ---------------------------------------------------------------------------
+
+def _get_queue(state: dict) -> ReviewQueue:
+    if state["review_queue"] is None:
+        state["review_queue"] = ReviewQueue()
+    return state["review_queue"]
+
+
+# ---------------------------------------------------------------------------
+# Review Items
+# ---------------------------------------------------------------------------
+
+@router.get("/items/summary")
+async def review_items_summary():
+    """Gibt Zusammenfassung der Review-Queue zurück (Anzahl nach Status, Severity, Kategorie)."""
+    state = get_state()
+    queue = _get_queue(state)
+    return {"status": "ok", "summary": queue.summary()}
+
+
+@router.get("/items")
+async def list_review_items(
+    severity: str | None = None,
+    column: str | None = None,
+    category: str | None = None,
+    status: str | None = None,
+    min_confidence: float | None = None,
+    max_confidence: float | None = None,
+    source: str | None = None,
+    is_ai_based: bool | None = None,
+    limit: int = 200,
+    offset: int = 0,
+):
+    """
+    Listet Review-Items gefiltert nach Severity, Spalte, Kategorie, Status oder Confidence.
+
+    Filter-Parameter (alle optional):
+      severity         — critical|warning|info
+      column           — Spaltenname
+      category         — FindingCategory-Wert (z. B. field_misuse)
+      status           — pending|accepted|rejected|needs_expert_review|applied
+      min_confidence   — Untergrenze Confidence (0.0–1.0)
+      max_confidence   — Obergrenze Confidence (0.0–1.0)
+      source           — Datensatzname
+      is_ai_based      — true|false
+      limit            — Maximalanzahl Ergebnisse (Standard: 200)
+      offset           — Seitenversatz
+    """
+    state = get_state()
+    queue = _get_queue(state)
+
+    items = queue.filter(
+        severity=severity,
+        column=column,
+        category=category,
+        status=status,
+        min_confidence=min_confidence,
+        max_confidence=max_confidence,
+        source=source,
+        is_ai_based=is_ai_based,
+    )
+    total = len(items)
+    page = items[offset: offset + limit]
+    return {
+        "status": "ok",
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "items": [i.to_dict() for i in page],
+    }
+
+
+@router.patch("/items/{item_id}/status")
+async def update_item_status(item_id: str, request: dict | None = None):
+    """
+    Aktualisiert den Bearbeitungsstatus eines Review-Items.
+
+    Request body:
+      status    — pending|accepted|rejected|needs_expert_review|applied (Pflicht)
+      reviewer  — Name/ID des Bearbeiters (optional)
+      note      — Notiz zur Entscheidung (optional)
+    """
+    request = request or {}
+    new_status_raw = request.get("status", "")
+    if new_status_raw not in _VALID_STATUSES:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "status": "error",
+                "message": f"Ungültiger Status '{new_status_raw}'. Erlaubt: {sorted(_VALID_STATUSES)}",
+            },
+        )
+
+    state = get_state()
+    queue = _get_queue(state)
+    item = queue.update_status(
+        item_id=item_id,
+        new_status=ReviewStatus(new_status_raw),
+        reviewer=request.get("reviewer"),
+        note=request.get("note"),
+    )
+    if item is None:
+        return JSONResponse(
+            status_code=404,
+            content={"status": "error", "message": f"Item '{item_id}' nicht gefunden."},
+        )
+    return {"status": "ok", "item": item.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# Work Packages
+# ---------------------------------------------------------------------------
+
+@router.get("/work-packages")
+async def list_work_packages(status: str | None = None):
+    """Gibt alle Work Packages zurück, optional gefiltert nach Status."""
+    state = get_state()
+    packages: list[WorkPackage] = state.get("work_packages", [])
+    if status is not None:
+        packages = [p for p in packages if p.status.value == status]
+    return {
+        "status": "ok",
+        "total": len(packages),
+        "work_packages": [p.to_dict() for p in packages],
+    }
+
+
+@router.post("/work-packages/generate")
+async def generate_packages(request: dict | None = None):
+    """
+    Generiert Work Packages aus dem letzten Qualitätsbericht.
+
+    Benötigt, dass zuvor eine Qualitätsanalyse durchgeführt wurde
+    (POST /api/analyze oder POST /api/ai/quality-check).
+
+    Request body (optional):
+      dataset_id  — Datensatz-ID (optional, verwendet letzten Bericht)
+    """
+    state = get_state()
+    report = state.get("report")
+    if report is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "status": "error",
+                "message": "Kein Qualitätsbericht vorhanden. Bitte zuerst Analyse durchführen.",
+            },
+        )
+
+    # report can be AnalysisReport or QualityAnalysisReport
+    from kwb.core.models import QualityAnalysisReport, AnalysisReport
+    from kwb.analyze.quality_report import build_quality_analysis_report
+
+    if isinstance(report, AnalysisReport):
+        quality_report = build_quality_analysis_report(report)
+    elif isinstance(report, QualityAnalysisReport):
+        quality_report = report
+    else:
+        return JSONResponse(
+            status_code=422,
+            content={"status": "error", "message": "Ungültiger Berichtstyp im Zustand."},
+        )
+
+    queue = _get_queue(state)
+    packages = generate_work_packages(quality_report, queue=queue)
+    state["work_packages"] = packages
+
+    return {
+        "status": "ok",
+        "total": len(packages),
+        "work_packages": [p.to_dict() for p in packages],
+    }
+
+
+@router.post("/queue/build")
+async def build_review_queue(request: dict | None = None):
+    """
+    Baut die Review-Queue aus dem letzten Qualitätsbericht auf.
+
+    Löscht ggf. bestehende Queue und erstellt sie neu.
+
+    Request body (optional):
+      is_ai_based  — bool, ob die Befunde KI-basiert sind (Standard: false)
+      source       — Datensatzname (optional)
+    """
+    request = request or {}
+    state = get_state()
+    report = state.get("report")
+    if report is None:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "status": "error",
+                "message": "Kein Qualitätsbericht vorhanden. Bitte zuerst Analyse durchführen.",
+            },
+        )
+
+    from kwb.core.models import QualityAnalysisReport, AnalysisReport
+    from kwb.analyze.quality_report import build_quality_analysis_report
+
+    if isinstance(report, AnalysisReport):
+        quality_report = build_quality_analysis_report(report)
+    elif isinstance(report, QualityAnalysisReport):
+        quality_report = report
+    else:
+        return JSONResponse(
+            status_code=422,
+            content={"status": "error", "message": "Ungültiger Berichtstyp im Zustand."},
+        )
+
+    is_ai_based: bool = bool(request.get("is_ai_based", False))
+    source: str = request.get("source", "")
+
+    queue = ReviewQueue.from_quality_report(quality_report, source=source, is_ai_based=is_ai_based)
+    state["review_queue"] = queue
+
+    return {
+        "status": "ok",
+        "summary": queue.summary(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Remediation Suggestions
+# ---------------------------------------------------------------------------
+
+@router.get("/suggestions")
+async def list_suggestions(item_id: str | None = None, package_id: str | None = None):
+    """Listet alle Bereinigungsvorschläge, optional gefiltert nach Item oder Package."""
+    state = get_state()
+    sugs: dict[str, RemediationSuggestion] = state.get("suggestions", {})
+    result = list(sugs.values())
+    if item_id is not None:
+        result = [s for s in result if s.item_id == item_id]
+    if package_id is not None:
+        result = [s for s in result if s.package_id == package_id]
+    return {
+        "status": "ok",
+        "total": len(result),
+        "suggestions": [s.to_dict() for s in result],
+    }
+
+
+@router.post("/suggestions")
+async def add_suggestion(request: dict | None = None):
+    """
+    Fügt einen neuen Bereinigungsvorschlag hinzu.
+
+    Request body:
+      action_type      — RemediationActionType-Wert (Pflicht)
+      original_value   — Originalwert (optional)
+      suggested_value  — Vorgeschlagener Wert (optional)
+      reasoning        — Begründung (Pflicht)
+      item_id          — Verknüpftes ReviewItem (optional)
+      package_id       — Verknüpftes WorkPackage (optional)
+      target_field     — Zielspalte (optional)
+      confidence       — Confidence 0.0–1.0 (optional)
+      is_ai_based      — bool (Standard: false)
+    """
+    request = request or {}
+    action_raw = request.get("action_type", "")
+    if action_raw not in _VALID_ACTIONS:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "status": "error",
+                "message": f"Ungültiger action_type '{action_raw}'. Erlaubt: {sorted(_VALID_ACTIONS)}",
+            },
+        )
+    reasoning = request.get("reasoning", "")
+    if not reasoning:
+        return JSONResponse(
+            status_code=422,
+            content={"status": "error", "message": "Feld 'reasoning' ist erforderlich."},
+        )
+
+    sug = RemediationSuggestion(
+        suggestion_id=_make_id(),
+        action_type=RemediationActionType(action_raw),
+        original_value=request.get("original_value"),
+        suggested_value=request.get("suggested_value"),
+        reasoning=reasoning,
+        item_id=request.get("item_id"),
+        package_id=request.get("package_id"),
+        target_field=request.get("target_field"),
+        confidence=request.get("confidence"),
+        is_ai_based=bool(request.get("is_ai_based", False)),
+    )
+    state = get_state()
+    state.setdefault("suggestions", {})[sug.suggestion_id] = sug
+    return {"status": "ok", "suggestion": sug.to_dict()}
+
+
+@router.patch("/suggestions/{suggestion_id}/status")
+async def update_suggestion_status(suggestion_id: str, request: dict | None = None):
+    """
+    Akzeptiert oder verwirft einen Bereinigungsvorschlag.
+
+    Request body:
+      status    — pending|accepted|rejected (Pflicht)
+      reviewer  — Name/ID des Bearbeiters (optional)
+    """
+    request = request or {}
+    new_status_raw = request.get("status", "")
+    allowed = {"pending", "accepted", "rejected"}
+    if new_status_raw not in allowed:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "status": "error",
+                "message": f"Ungültiger Status '{new_status_raw}'. Erlaubt: {sorted(allowed)}",
+            },
+        )
+
+    state = get_state()
+    sugs: dict = state.get("suggestions", {})
+    sug = sugs.get(suggestion_id)
+    if sug is None:
+        return JSONResponse(
+            status_code=404,
+            content={"status": "error", "message": f"Vorschlag '{suggestion_id}' nicht gefunden."},
+        )
+    sug.status = ReviewStatus(new_status_raw)
+    return {"status": "ok", "suggestion": sug.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# Apply accepted changes
+# ---------------------------------------------------------------------------
+
+@router.post("/apply")
+async def apply_changes(request: dict | None = None):
+    """
+    Wendet alle ACCEPTED Bereinigungsvorschläge auf einen Datensatz an.
+
+    Request body:
+      dataset_id  — ID des zu bereinigenden Datensatzes (Pflicht)
+      reviewer    — Name/ID des Bearbeiters (optional)
+      dry_run     — bool, wenn true: nur Vorschau, keine Änderung (Standard: false)
+    """
+    request = request or {}
+    dataset_id: str = request.get("dataset_id", "")
+    if not dataset_id:
+        return JSONResponse(
+            status_code=422,
+            content={"status": "error", "message": "Feld 'dataset_id' ist erforderlich."},
+        )
+
+    datasets = get_datasets()
+    if dataset_id not in datasets:
+        return JSONResponse(
+            status_code=404,
+            content={
+                "status": "error",
+                "message": f"Datensatz '{dataset_id}' nicht gefunden.",
+                "available_datasets": list(datasets.keys()),
+            },
+        )
+
+    state = get_state()
+    sugs: list[RemediationSuggestion] = list(state.get("suggestions", {}).values())
+    reviewer: str | None = request.get("reviewer")
+    dry_run: bool = bool(request.get("dry_run", False))
+
+    accepted = [s for s in sugs if s.status == ReviewStatus.ACCEPTED]
+    if not accepted:
+        return {
+            "status": "ok",
+            "message": "Keine akzeptierten Vorschläge zum Anwenden vorhanden.",
+            "applied_count": 0,
+            "changelog": [],
+        }
+
+    df, profile = datasets[dataset_id]
+    if dry_run:
+        return {
+            "status": "ok",
+            "dry_run": True,
+            "would_apply": len(accepted),
+            "suggestions": [s.to_dict() for s in accepted],
+        }
+
+    updated_df, changelog = apply_accepted_changes(
+        df=df,
+        suggestions=accepted,
+        dataset_id=dataset_id,
+        reviewer=reviewer,
+    )
+
+    # Update dataset in state
+    datasets[dataset_id] = (updated_df, profile)
+
+    # Append changelog
+    existing_log: list[AppliedChangeLog] = state.get("changelog", [])
+    existing_log.extend(changelog)
+    state["changelog"] = existing_log
+
+    # Mark applied suggestions
+    for sug in accepted:
+        sug.status = ReviewStatus.APPLIED
+
+    return {
+        "status": "ok",
+        "applied_count": len(changelog),
+        "changelog": [c.to_dict() for c in changelog],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Change Log
+# ---------------------------------------------------------------------------
+
+@router.get("/changelog")
+async def get_changelog(dataset_id: str | None = None, column: str | None = None):
+    """Gibt das Änderungsprotokoll zurück, optional gefiltert nach Datensatz oder Spalte."""
+    state = get_state()
+    log: list[AppliedChangeLog] = state.get("changelog", [])
+    if dataset_id is not None:
+        log = [e for e in log if e.dataset_id == dataset_id]
+    if column is not None:
+        log = [e for e in log if e.column == column]
+    return {
+        "status": "ok",
+        "total": len(log),
+        "changelog": [e.to_dict() for e in log],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+@router.get("/export")
+async def export_review_status():
+    """
+    Exportiert Review-Status, Work Packages und Änderungsprotokoll als JSON.
+
+    Eignet sich zum Archivieren oder Weitergeben des aktuellen Bearbeitungsstands.
+    """
+    state = get_state()
+    queue = _get_queue(state)
+    packages: list[WorkPackage] = state.get("work_packages", [])
+    log: list[AppliedChangeLog] = state.get("changelog", [])
+    sugs: dict = state.get("suggestions", {})
+
+    return {
+        "exported_at": _now_iso(),
+        "review_queue": queue.to_dict(),
+        "work_packages": [p.to_dict() for p in packages],
+        "suggestions": [s.to_dict() for s in sugs.values()],
+        "changelog": [e.to_dict() for e in log],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Schema
+# ---------------------------------------------------------------------------
+
+@router.get("/schema")
+async def review_schema():
+    """Gibt das Schema aller Review-Endpunkte und erlaubte Werte zurück."""
+    return {
+        "review_statuses": sorted(_VALID_STATUSES),
+        "remediation_action_types": sorted(_VALID_ACTIONS),
+        "endpoints": {
+            "GET /api/review/items": "Listet Review-Items (filterable)",
+            "GET /api/review/items/summary": "Queue-Zusammenfassung",
+            "PATCH /api/review/items/{item_id}/status": "Status eines Items aktualisieren",
+            "GET /api/review/work-packages": "Listet Work Packages",
+            "POST /api/review/work-packages/generate": "Generiert Work Packages aus Qualitätsbericht",
+            "POST /api/review/queue/build": "Baut Review-Queue aus Qualitätsbericht auf",
+            "GET /api/review/suggestions": "Listet Bereinigungsvorschläge",
+            "POST /api/review/suggestions": "Neuen Vorschlag hinzufügen",
+            "PATCH /api/review/suggestions/{sid}/status": "Vorschlag akzeptieren/verwerfen",
+            "POST /api/review/apply": "Akzeptierte Vorschläge auf Datensatz anwenden",
+            "GET /api/review/changelog": "Änderungsprotokoll abrufen",
+            "GET /api/review/export": "Kompletten Review-Status exportieren",
+        },
+    }

--- a/src/kwb/core/models.py
+++ b/src/kwb/core/models.py
@@ -340,6 +340,200 @@ class AnalysisProvenance:
         }
 
 
+# ---------------------------------------------------------------------------
+# Phase 3 — Review Queues, Work Packages, Remediation
+# ---------------------------------------------------------------------------
+
+
+class ReviewStatus(str, Enum):
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    NEEDS_EXPERT_REVIEW = "needs_expert_review"
+    APPLIED = "applied"
+
+
+class RemediationActionType(str, Enum):
+    MOVE_VALUE_TO_FIELD = "move_value_to_field"
+    SPLIT_MULTI_VALUE = "split_multi_value"
+    NORMALIZE_LABEL = "normalize_label"
+    FLAG_FOR_AUTHORITY_LOOKUP = "flag_for_authority_lookup"
+    LEAVE_UNCHANGED_MARK_UNCERTAIN = "leave_unchanged_mark_uncertain"
+    APPLY_SUGGESTED_VALUE = "apply_suggested_value"
+
+
+@dataclass
+class ReviewItem:
+    """A single quality finding ready for curatorial review."""
+
+    item_id: str
+    source: str
+    record_id: str | None
+    column: str | None
+    original_value: str | None
+    category: FindingCategory
+    severity: Severity
+    confidence: float | None
+    message: str
+    reasoning: str
+    suggested_action: str | None
+    status: ReviewStatus = ReviewStatus.PENDING
+    reviewer: str | None = None
+    reviewed_at: str | None = None
+    source_issue_ids: list[str] = field(default_factory=list)
+    is_ai_based: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "source": self.source,
+            "record_id": self.record_id,
+            "column": self.column,
+            "original_value": self.original_value,
+            "category": self.category.value,
+            "severity": self.severity.value,
+            "confidence": self.confidence,
+            "message": self.message,
+            "reasoning": self.reasoning,
+            "suggested_action": self.suggested_action,
+            "status": self.status.value,
+            "reviewer": self.reviewer,
+            "reviewed_at": self.reviewed_at,
+            "source_issue_ids": self.source_issue_ids,
+            "is_ai_based": self.is_ai_based,
+        }
+
+
+@dataclass
+class ReviewDecision:
+    """A curatorial decision on a ReviewItem."""
+
+    item_id: str
+    decision: ReviewStatus
+    reviewed_at: str
+    reviewer: str | None = None
+    note: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "item_id": self.item_id,
+            "decision": self.decision.value,
+            "reviewed_at": self.reviewed_at,
+            "reviewer": self.reviewer,
+            "note": self.note,
+        }
+
+
+@dataclass
+class WorkPackage:
+    """An actionable work package bundling related quality findings."""
+
+    package_id: str
+    title: str
+    description: str
+    scope: str
+    issue_family: str
+    priority: Severity
+    affected_columns: list[str]
+    estimated_records: int
+    action_type: str
+    automation_potential: str  # "high" | "medium" | "low"
+    recommended_strategy: str
+    source_cluster_ids: list[str] = field(default_factory=list)
+    item_ids: list[str] = field(default_factory=list)
+    status: ReviewStatus = ReviewStatus.PENDING
+    created_at: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "package_id": self.package_id,
+            "title": self.title,
+            "description": self.description,
+            "scope": self.scope,
+            "issue_family": self.issue_family,
+            "priority": self.priority.value,
+            "affected_columns": self.affected_columns,
+            "estimated_records": self.estimated_records,
+            "action_type": self.action_type,
+            "automation_potential": self.automation_potential,
+            "recommended_strategy": self.recommended_strategy,
+            "source_cluster_ids": self.source_cluster_ids,
+            "item_ids": self.item_ids,
+            "status": self.status.value,
+            "created_at": self.created_at,
+        }
+
+
+@dataclass
+class RemediationSuggestion:
+    """A structured suggestion for correcting a specific quality issue."""
+
+    suggestion_id: str
+    action_type: RemediationActionType
+    original_value: str | None
+    suggested_value: str | None
+    reasoning: str
+    item_id: str | None = None
+    package_id: str | None = None
+    target_field: str | None = None
+    confidence: float | None = None
+    status: ReviewStatus = ReviewStatus.PENDING
+    is_ai_based: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "suggestion_id": self.suggestion_id,
+            "action_type": self.action_type.value,
+            "original_value": self.original_value,
+            "suggested_value": self.suggested_value,
+            "reasoning": self.reasoning,
+            "item_id": self.item_id,
+            "package_id": self.package_id,
+            "target_field": self.target_field,
+            "confidence": self.confidence,
+            "status": self.status.value,
+            "is_ai_based": self.is_ai_based,
+        }
+
+
+@dataclass
+class AppliedChangeLog:
+    """An immutable log entry for a change applied to dataset metadata."""
+
+    change_id: str
+    dataset_id: str
+    record_id: str
+    column: str
+    original_value: str | None
+    new_value: str | None
+    action_type: RemediationActionType
+    applied_at: str
+    reviewer: str | None = None
+    suggestion_id: str | None = None
+    item_id: str | None = None
+    package_id: str | None = None
+    is_ai_based: bool = False
+    note: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "change_id": self.change_id,
+            "dataset_id": self.dataset_id,
+            "record_id": self.record_id,
+            "column": self.column,
+            "original_value": self.original_value,
+            "new_value": self.new_value,
+            "action_type": self.action_type.value,
+            "applied_at": self.applied_at,
+            "reviewer": self.reviewer,
+            "suggestion_id": self.suggestion_id,
+            "item_id": self.item_id,
+            "package_id": self.package_id,
+            "is_ai_based": self.is_ai_based,
+            "note": self.note,
+        }
+
+
 @dataclass
 class QualityAnalysisReport:
     """

--- a/src/kwb/review/__init__.py
+++ b/src/kwb/review/__init__.py
@@ -1,0 +1,13 @@
+"""
+Phase 3 — Review Queues, Work Packages, Remediation.
+
+Modules:
+  queue          — ReviewQueue: build, filter, update status
+  work_packages  — WorkPackage generation from IssueCluster
+  remediation    — Apply accepted changes to dataset DataFrames
+"""
+from kwb.review.queue import ReviewQueue
+from kwb.review.work_packages import generate_work_packages
+from kwb.review.remediation import apply_accepted_changes
+
+__all__ = ["ReviewQueue", "generate_work_packages", "apply_accepted_changes"]

--- a/src/kwb/review/queue.py
+++ b/src/kwb/review/queue.py
@@ -1,0 +1,228 @@
+"""
+ReviewQueue — build, filter and update curatorial review items.
+
+Entry point:
+    ReviewQueue.from_quality_report(report)  →  ReviewQueue
+
+The queue is built from a QualityAnalysisReport (Phase 1 + 2).  Each
+CellFinding, RecordQualityReport (if review_required) and IssueCluster
+becomes one or more ReviewItems.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from kwb.core.models import (
+    FindingCategory,
+    QualityAnalysisReport,
+    ReviewDecision,
+    ReviewItem,
+    ReviewStatus,
+    Severity,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_id() -> str:
+    return str(uuid.uuid4())
+
+
+class ReviewQueue:
+    """In-memory queue of ReviewItems derived from a QualityAnalysisReport."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, ReviewItem] = {}
+        self._decisions: list[ReviewDecision] = []
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_quality_report(
+        cls,
+        report: QualityAnalysisReport,
+        source: str = "",
+        is_ai_based: bool = False,
+    ) -> "ReviewQueue":
+        """Build a ReviewQueue from a QualityAnalysisReport.
+
+        Creates ReviewItems from:
+        - cell_findings (one item per cell finding)
+        - record_reports where review_required is True (one item per record)
+        - issue_clusters (one item per cluster, at dataset level)
+        """
+        queue = cls()
+
+        # Cell-level findings
+        for cf in report.cell_findings:
+            queue.add_item(
+                ReviewItem(
+                    item_id=_make_id(),
+                    source=source or (cf.evidence.get("source", "") if cf.evidence else ""),
+                    record_id=cf.record_id,
+                    column=cf.column,
+                    original_value=cf.value,
+                    category=cf.category,
+                    severity=cf.severity,
+                    confidence=cf.confidence,
+                    message=cf.message,
+                    reasoning=cf.reasoning,
+                    suggested_action=cf.suggested_action,
+                    is_ai_based=is_ai_based,
+                )
+            )
+
+        # Record-level findings that require review
+        for rr in report.record_reports:
+            if not rr.review_required:
+                continue
+            queue.add_item(
+                ReviewItem(
+                    item_id=_make_id(),
+                    source=source or rr.source,
+                    record_id=rr.record_id,
+                    column=None,
+                    original_value=None,
+                    category=FindingCategory.CROSS_FIELD_CONFLICT,
+                    severity=rr.severity or Severity.WARNING,
+                    confidence=rr.confidence,
+                    message="; ".join(rr.issues) if rr.issues else rr.reasoning,
+                    reasoning=rr.reasoning,
+                    suggested_action=None,
+                    is_ai_based=is_ai_based,
+                )
+            )
+
+        # Issue-cluster level (dataset/column scope)
+        for cluster in report.issue_clusters:
+            if cluster.severity == Severity.INFO:
+                continue  # skip info-only clusters from queue
+            queue.add_item(
+                ReviewItem(
+                    item_id=_make_id(),
+                    source=source,
+                    record_id=None,
+                    column=cluster.affected_columns[0] if cluster.affected_columns else None,
+                    original_value=None,
+                    category=cluster.category,
+                    severity=cluster.severity,
+                    confidence=None,
+                    message=cluster.label,
+                    reasoning=f"Cluster betrifft {cluster.affected_records_count} Datensätze "
+                    f"in Spalten: {', '.join(cluster.affected_columns)}",
+                    suggested_action=cluster.suggested_action,
+                    source_issue_ids=[cluster.cluster_id],
+                    is_ai_based=False,
+                )
+            )
+
+        return queue
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
+
+    def add_item(self, item: ReviewItem) -> None:
+        self._items[item.item_id] = item
+
+    def get_item(self, item_id: str) -> ReviewItem | None:
+        return self._items.get(item_id)
+
+    def all_items(self) -> list[ReviewItem]:
+        return list(self._items.values())
+
+    def update_status(
+        self,
+        item_id: str,
+        new_status: ReviewStatus,
+        reviewer: str | None = None,
+        note: str | None = None,
+    ) -> ReviewItem | None:
+        """Update the status of a ReviewItem and record the decision."""
+        item = self._items.get(item_id)
+        if item is None:
+            return None
+        item.status = new_status
+        item.reviewer = reviewer
+        item.reviewed_at = _now_iso()
+        decision = ReviewDecision(
+            item_id=item_id,
+            decision=new_status,
+            reviewed_at=item.reviewed_at,
+            reviewer=reviewer,
+            note=note,
+        )
+        self._decisions.append(decision)
+        return item
+
+    def decisions(self) -> list[ReviewDecision]:
+        return list(self._decisions)
+
+    # ------------------------------------------------------------------
+    # Filtering
+    # ------------------------------------------------------------------
+
+    def filter(
+        self,
+        *,
+        severity: str | None = None,
+        column: str | None = None,
+        category: str | None = None,
+        status: str | None = None,
+        min_confidence: float | None = None,
+        max_confidence: float | None = None,
+        source: str | None = None,
+        is_ai_based: bool | None = None,
+    ) -> list[ReviewItem]:
+        """Return items matching all provided filters."""
+        items = list(self._items.values())
+        if severity is not None:
+            items = [i for i in items if i.severity.value == severity]
+        if column is not None:
+            items = [i for i in items if i.column == column]
+        if category is not None:
+            items = [i for i in items if i.category.value == category]
+        if status is not None:
+            items = [i for i in items if i.status.value == status]
+        if min_confidence is not None:
+            items = [i for i in items if i.confidence is not None and i.confidence >= min_confidence]
+        if max_confidence is not None:
+            items = [i for i in items if i.confidence is not None and i.confidence <= max_confidence]
+        if source is not None:
+            items = [i for i in items if i.source == source]
+        if is_ai_based is not None:
+            items = [i for i in items if i.is_ai_based == is_ai_based]
+        return items
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+
+    def summary(self) -> dict[str, Any]:
+        items = list(self._items.values())
+        by_status: dict[str, int] = {}
+        by_severity: dict[str, int] = {}
+        by_category: dict[str, int] = {}
+        for item in items:
+            by_status[item.status.value] = by_status.get(item.status.value, 0) + 1
+            by_severity[item.severity.value] = by_severity.get(item.severity.value, 0) + 1
+            by_category[item.category.value] = by_category.get(item.category.value, 0) + 1
+        return {
+            "total": len(items),
+            "by_status": by_status,
+            "by_severity": by_severity,
+            "by_category": by_category,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "items": [i.to_dict() for i in self._items.values()],
+            "decisions": [d.to_dict() for d in self._decisions],
+            "summary": self.summary(),
+        }

--- a/src/kwb/review/remediation.py
+++ b/src/kwb/review/remediation.py
@@ -1,0 +1,242 @@
+"""
+Remediation — apply accepted RemediationSuggestions to a pandas DataFrame.
+
+Entry point:
+    apply_accepted_changes(df, suggestions, dataset_id, reviewer)
+        →  (updated_df, list[AppliedChangeLog])
+
+Only suggestions with status ACCEPTED are applied. Each accepted change
+is recorded in an AppliedChangeLog entry so the operation is fully
+traceable. The original DataFrame is not mutated; a copy is returned.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pandas as pd
+
+from kwb.core.models import (
+    AppliedChangeLog,
+    RemediationActionType,
+    RemediationSuggestion,
+    ReviewStatus,
+)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _make_id() -> str:
+    return str(uuid.uuid4())
+
+
+def apply_accepted_changes(
+    df: pd.DataFrame,
+    suggestions: list[RemediationSuggestion],
+    dataset_id: str,
+    reviewer: str | None = None,
+) -> tuple[pd.DataFrame, list[AppliedChangeLog]]:
+    """Apply all ACCEPTED RemediationSuggestions to *df* (copy).
+
+    Returns:
+        (updated DataFrame, list of AppliedChangeLog entries)
+    """
+    result = df.copy()
+    changelog: list[AppliedChangeLog] = []
+    now = _now_iso()
+
+    for sug in suggestions:
+        if sug.status != ReviewStatus.ACCEPTED:
+            continue
+        log = _apply_suggestion(result, sug, dataset_id, reviewer, now)
+        if log is not None:
+            changelog.append(log)
+
+    return result, changelog
+
+
+def _apply_suggestion(
+    df: pd.DataFrame,
+    sug: RemediationSuggestion,
+    dataset_id: str,
+    reviewer: str | None,
+    now: str,
+) -> AppliedChangeLog | None:
+    """Apply a single suggestion in-place on *df*. Returns a log entry or None."""
+
+    action = sug.action_type
+
+    if action == RemediationActionType.APPLY_SUGGESTED_VALUE:
+        return _apply_suggested_value(df, sug, dataset_id, reviewer, now)
+
+    if action == RemediationActionType.MOVE_VALUE_TO_FIELD:
+        return _move_value_to_field(df, sug, dataset_id, reviewer, now)
+
+    if action == RemediationActionType.NORMALIZE_LABEL:
+        return _normalize_label(df, sug, dataset_id, reviewer, now)
+
+    if action == RemediationActionType.SPLIT_MULTI_VALUE:
+        # Split is advisory only — not directly applicable to a single cell
+        # without knowing the delimiter and target columns.
+        return None
+
+    if action == RemediationActionType.FLAG_FOR_AUTHORITY_LOOKUP:
+        # Flagging doesn't change values; we just log the intent.
+        return AppliedChangeLog(
+            change_id=_make_id(),
+            dataset_id=dataset_id,
+            record_id=sug.item_id or "",
+            column=sug.target_field or "",
+            original_value=sug.original_value,
+            new_value=sug.original_value,  # unchanged
+            action_type=action,
+            applied_at=now,
+            reviewer=reviewer,
+            suggestion_id=sug.suggestion_id,
+            item_id=sug.item_id,
+            package_id=sug.package_id,
+            is_ai_based=sug.is_ai_based,
+            note="Flagged for authority lookup — value unchanged",
+        )
+
+    if action == RemediationActionType.LEAVE_UNCHANGED_MARK_UNCERTAIN:
+        return AppliedChangeLog(
+            change_id=_make_id(),
+            dataset_id=dataset_id,
+            record_id=sug.item_id or "",
+            column=sug.target_field or "",
+            original_value=sug.original_value,
+            new_value=sug.original_value,
+            action_type=action,
+            applied_at=now,
+            reviewer=reviewer,
+            suggestion_id=sug.suggestion_id,
+            item_id=sug.item_id,
+            package_id=sug.package_id,
+            is_ai_based=sug.is_ai_based,
+            note="Marked as uncertain — value unchanged",
+        )
+
+    return None
+
+
+def _find_rows(df: pd.DataFrame, record_id_hint: str | None) -> pd.Index:
+    """Return the index of rows matching the record_id hint."""
+    if record_id_hint is None:
+        return pd.Index([])
+    # Try common id columns
+    for id_col in ("record_id", "id", "identifier", "ID"):
+        if id_col in df.columns:
+            mask = df[id_col].astype(str) == str(record_id_hint)
+            if mask.any():
+                return df.index[mask]
+    return pd.Index([])
+
+
+def _apply_suggested_value(
+    df: pd.DataFrame,
+    sug: RemediationSuggestion,
+    dataset_id: str,
+    reviewer: str | None,
+    now: str,
+) -> AppliedChangeLog | None:
+    col = sug.target_field
+    if not col or col not in df.columns:
+        return None
+    rows = _find_rows(df, sug.item_id)
+    if rows.empty:
+        # Fall back: apply to all cells matching original_value
+        if sug.original_value is not None:
+            mask = df[col].astype(str) == str(sug.original_value)
+            rows = df.index[mask]
+    if rows.empty:
+        return None
+    original = df.at[rows[0], col]
+    df.loc[rows, col] = sug.suggested_value
+    return AppliedChangeLog(
+        change_id=_make_id(),
+        dataset_id=dataset_id,
+        record_id=str(sug.item_id or rows[0]),
+        column=col,
+        original_value=str(original) if original is not None else None,
+        new_value=sug.suggested_value,
+        action_type=sug.action_type,
+        applied_at=now,
+        reviewer=reviewer,
+        suggestion_id=sug.suggestion_id,
+        item_id=sug.item_id,
+        package_id=sug.package_id,
+        is_ai_based=sug.is_ai_based,
+    )
+
+
+def _move_value_to_field(
+    df: pd.DataFrame,
+    sug: RemediationSuggestion,
+    dataset_id: str,
+    reviewer: str | None,
+    now: str,
+) -> AppliedChangeLog | None:
+    """Move original_value from one column (item_id encodes source col) to target_field."""
+    target_col = sug.target_field
+    if not target_col:
+        return None
+    if target_col not in df.columns:
+        df[target_col] = ""
+    rows = _find_rows(df, sug.item_id)
+    if rows.empty:
+        return None
+    original = df.at[rows[0], target_col] if target_col in df.columns else None
+    df.loc[rows, target_col] = sug.suggested_value or sug.original_value
+    return AppliedChangeLog(
+        change_id=_make_id(),
+        dataset_id=dataset_id,
+        record_id=str(sug.item_id or rows[0]),
+        column=target_col,
+        original_value=str(original) if original is not None else None,
+        new_value=sug.suggested_value or sug.original_value,
+        action_type=sug.action_type,
+        applied_at=now,
+        reviewer=reviewer,
+        suggestion_id=sug.suggestion_id,
+        item_id=sug.item_id,
+        package_id=sug.package_id,
+        is_ai_based=sug.is_ai_based,
+    )
+
+
+def _normalize_label(
+    df: pd.DataFrame,
+    sug: RemediationSuggestion,
+    dataset_id: str,
+    reviewer: str | None,
+    now: str,
+) -> AppliedChangeLog | None:
+    col = sug.target_field
+    if not col or col not in df.columns:
+        return None
+    if sug.original_value is None or sug.suggested_value is None:
+        return None
+    mask = df[col].astype(str) == str(sug.original_value)
+    if not mask.any():
+        return None
+    df.loc[mask, col] = sug.suggested_value
+    count = int(mask.sum())
+    return AppliedChangeLog(
+        change_id=_make_id(),
+        dataset_id=dataset_id,
+        record_id="batch",
+        column=col,
+        original_value=sug.original_value,
+        new_value=sug.suggested_value,
+        action_type=sug.action_type,
+        applied_at=now,
+        reviewer=reviewer,
+        suggestion_id=sug.suggestion_id,
+        item_id=sug.item_id,
+        package_id=sug.package_id,
+        is_ai_based=sug.is_ai_based,
+        note=f"Batch normalization: {count} cells updated",
+    )

--- a/src/kwb/review/work_packages.py
+++ b/src/kwb/review/work_packages.py
@@ -1,0 +1,191 @@
+"""
+Work Package generation from IssueCluster and ReviewQueue.
+
+Entry point:
+    generate_work_packages(report, queue)  →  list[WorkPackage]
+
+Logic:
+  - Each IssueCluster with WARNING/CRITICAL severity becomes a WorkPackage candidate.
+  - Additional heuristics set automation_potential and recommended_strategy.
+  - ReviewItems belonging to the cluster are linked via item_ids.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from kwb.core.models import (
+    FindingCategory,
+    IssueCluster,
+    QualityAnalysisReport,
+    ReviewStatus,
+    Severity,
+    WorkPackage,
+)
+from kwb.review.queue import ReviewQueue
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Automation potential heuristics
+# ---------------------------------------------------------------------------
+
+_HIGH_AUTOMATION_CATEGORIES = {
+    FindingCategory.MISSING_VALUES,
+    FindingCategory.ENCODING_ISSUES,
+    FindingCategory.FORMAT_INCONSISTENCY,
+    FindingCategory.DUPLICATE_RECORDS,
+    FindingCategory.NEAR_DUPLICATE_RECORDS,
+}
+
+_MEDIUM_AUTOMATION_CATEGORIES = {
+    FindingCategory.TERM_VARIANTS,
+    FindingCategory.NORM_DATA_CANDIDATE,
+    FindingCategory.GND_MATCH_MISSING,
+    FindingCategory.GEO_ENRICHMENT_CANDIDATE,
+    FindingCategory.REMEDIATION_CANDIDATE,
+}
+
+_STRATEGY_MAP: dict[FindingCategory, str] = {
+    FindingCategory.MISSING_VALUES: "Fehlende Werte ergänzen oder Felder als optional markieren",
+    FindingCategory.DUPLICATE_RECORDS: "Duplikate zusammenführen oder löschen",
+    FindingCategory.NEAR_DUPLICATE_RECORDS: "Ähnliche Datensätze manuell prüfen und zusammenführen",
+    FindingCategory.ENCODING_ISSUES: "Encoding-Artefakte bereinigen (UTF-8 normalisieren)",
+    FindingCategory.FORMAT_INCONSISTENCY: "Einheitliches Format erzwingen (Trennzeichen, Leerzeichen)",
+    FindingCategory.TERM_VARIANTS: "Varianten auf Vorzugsbenennung normalisieren",
+    FindingCategory.FIELD_MISUSE: "Werte in korrekte Zielspalte verschieben",
+    FindingCategory.AMBIGUOUS_VALUE: "Ambige Werte einzeln prüfen und klären",
+    FindingCategory.CROSS_FIELD_CONFLICT: "Konfligierende Felder gemeinsam prüfen und abstimmen",
+    FindingCategory.PROVENANCE_GAP: "Fehlende Provenienzinformationen nacherfassen",
+    FindingCategory.GND_MATCH_MISSING: "GND-Normdaten zuordnen (lobid.org)",
+    FindingCategory.GEO_ENRICHMENT_CANDIDATE: "Geografische Anreicherung via GeoNames prüfen",
+    FindingCategory.NORM_DATA_CANDIDATE: "Normdaten-Kandidaten prüfen und verknüpfen",
+    FindingCategory.CLASSIFICATION_INCONSISTENCY: "Klassifikation vereinheitlichen",
+    FindingCategory.SCHEMA_MISMATCH: "Schema-Abweichungen bereinigen",
+    FindingCategory.LANGUAGE_MIXING: "Sprachmischungen prüfen und trennen",
+    FindingCategory.LOW_INFORMATION_VALUE: "Informationsarme Werte prüfen und ggf. löschen",
+    FindingCategory.CROSS_FILE_MISMATCH: "Datensatz-übergreifende Inkonsistenzen auflösen",
+    FindingCategory.ORPHAN_RECORDS: "Verwaiste Datensätze prüfen und verknüpfen oder löschen",
+    FindingCategory.REMEDIATION_CANDIDATE: "Bereinigungsvorschläge prüfen und anwenden",
+}
+
+_DEFAULT_STRATEGY = "Befunde manuell prüfen und bereinigen"
+
+_ACTION_TYPE_MAP: dict[FindingCategory, str] = {
+    FindingCategory.MISSING_VALUES: "fill_missing",
+    FindingCategory.DUPLICATE_RECORDS: "deduplicate",
+    FindingCategory.NEAR_DUPLICATE_RECORDS: "review_near_duplicates",
+    FindingCategory.ENCODING_ISSUES: "normalize_encoding",
+    FindingCategory.FORMAT_INCONSISTENCY: "normalize_format",
+    FindingCategory.TERM_VARIANTS: "normalize_label",
+    FindingCategory.FIELD_MISUSE: "move_value_to_field",
+    FindingCategory.AMBIGUOUS_VALUE: "flag_for_review",
+    FindingCategory.GND_MATCH_MISSING: "flag_for_authority_lookup",
+    FindingCategory.GEO_ENRICHMENT_CANDIDATE: "flag_for_authority_lookup",
+    FindingCategory.NORM_DATA_CANDIDATE: "flag_for_authority_lookup",
+    FindingCategory.CROSS_FIELD_CONFLICT: "review_conflict",
+    FindingCategory.PROVENANCE_GAP: "fill_missing",
+    FindingCategory.REMEDIATION_CANDIDATE: "apply_suggested_value",
+}
+
+_DEFAULT_ACTION = "manual_review"
+
+
+def _automation_potential(category: FindingCategory, severity: Severity) -> str:
+    if category in _HIGH_AUTOMATION_CATEGORIES:
+        return "high"
+    if category in _MEDIUM_AUTOMATION_CATEGORIES:
+        return "medium"
+    return "low"
+
+
+def _scope_description(cluster: IssueCluster) -> str:
+    cols = ", ".join(cluster.affected_columns) if cluster.affected_columns else "unbekannte Spalten"
+    return (
+        f"Betrifft {cluster.affected_records_count} Datensätze in Spalten: {cols}. "
+        f"Kategorie: {cluster.category.value}."
+    )
+
+
+def generate_work_packages(
+    report: QualityAnalysisReport,
+    queue: ReviewQueue | None = None,
+) -> list[WorkPackage]:
+    """Generate WorkPackages from a QualityAnalysisReport.
+
+    Each WARNING/CRITICAL IssueCluster becomes one WorkPackage.
+    If a ReviewQueue is provided, linked ReviewItem IDs are collected.
+    """
+    packages: list[WorkPackage] = []
+    now = _now_iso()
+
+    for cluster in report.issue_clusters:
+        if cluster.severity == Severity.INFO:
+            continue  # INFO clusters don't produce work packages
+
+        # Collect linked ReviewItem IDs from queue
+        item_ids: list[str] = []
+        if queue is not None:
+            for item in queue.filter(category=cluster.category.value):
+                if (
+                    not item.source_issue_ids
+                    or cluster.cluster_id in item.source_issue_ids
+                    or (
+                        item.column in cluster.affected_columns
+                        and item.record_id is None  # cluster-level items
+                    )
+                ):
+                    item_ids.append(item.item_id)
+
+        pkg = WorkPackage(
+            package_id=str(uuid.uuid4()),
+            title=cluster.label,
+            description=cluster.suggested_action or _DEFAULT_STRATEGY,
+            scope=_scope_description(cluster),
+            issue_family=cluster.category.value,
+            priority=cluster.severity,
+            affected_columns=list(cluster.affected_columns),
+            estimated_records=cluster.affected_records_count,
+            action_type=_ACTION_TYPE_MAP.get(cluster.category, _DEFAULT_ACTION),
+            automation_potential=_automation_potential(cluster.category, cluster.severity),
+            recommended_strategy=_STRATEGY_MAP.get(cluster.category, _DEFAULT_STRATEGY),
+            source_cluster_ids=[cluster.cluster_id],
+            item_ids=item_ids,
+            status=ReviewStatus.PENDING,
+            created_at=now,
+        )
+        packages.append(pkg)
+
+    # Also surface WorkPackageCandidates from the report that have no cluster
+    cluster_categories = {c.category for c in report.issue_clusters}
+    for wpc in report.work_package_candidates:
+        # Avoid duplicating if we already covered this category
+        # (WorkPackageCandidates use action_type, not category directly)
+        pkg = WorkPackage(
+            package_id=str(uuid.uuid4()),
+            title=wpc.title,
+            description=wpc.description,
+            scope=f"Betrifft ~{wpc.estimated_records} Datensätze in: "
+            f"{', '.join(wpc.affected_columns)}",
+            issue_family=wpc.action_type,
+            priority=wpc.priority,
+            affected_columns=list(wpc.affected_columns),
+            estimated_records=wpc.estimated_records,
+            action_type=wpc.action_type,
+            automation_potential="medium",
+            recommended_strategy=wpc.description,
+            source_cluster_ids=[],
+            item_ids=[],
+            status=ReviewStatus.PENDING,
+            created_at=now,
+        )
+        packages.append(pkg)
+
+    # Sort: CRITICAL first, then by estimated_records descending
+    packages.sort(
+        key=lambda p: (0 if p.priority == Severity.CRITICAL else 1, -p.estimated_records)
+    )
+    return packages

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,895 @@
+"""
+Tests für Phase 3 — Review Queues, Work Packages und Remediation.
+
+Alle Tests sind unit-basiert (kein Netzwerk, kein GPU, kein DB).
+"""
+from __future__ import annotations
+
+import unittest
+import uuid
+
+import pandas as pd
+
+from kwb.core.models import (
+    AnalysisProvenance,
+    AppliedChangeLog,
+    CellFinding,
+    FindingCategory,
+    IssueCluster,
+    QualityAnalysisReport,
+    RecordQualityReport,
+    RemediationActionType,
+    RemediationSuggestion,
+    ReviewItem,
+    ReviewStatus,
+    Severity,
+    WorkPackage,
+    WorkPackageCandidate,
+)
+from kwb.review.queue import ReviewQueue
+from kwb.review.remediation import apply_accepted_changes
+from kwb.review.work_packages import generate_work_packages
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _sample_cell_finding(
+    record_id: str = "obj-001",
+    column: str = "location_place_name",
+    value: str = "Kutsche",
+    severity: Severity = Severity.WARNING,
+    category: FindingCategory = FindingCategory.FIELD_MISUSE,
+    confidence: float = 0.9,
+) -> CellFinding:
+    return CellFinding(
+        record_id=record_id,
+        column=column,
+        value=value,
+        severity=severity,
+        category=category,
+        message=f"Wert '{value}' in Spalte '{column}' scheint fehlplatziert",
+        confidence=confidence,
+        reasoning="Nicht-Toponym in Ortsfeld",
+        suggested_action="move_or_review",
+        review_required=True,
+    )
+
+
+def _sample_record_report(
+    record_id: str = "obj-002",
+    review_required: bool = True,
+) -> RecordQualityReport:
+    return RecordQualityReport(
+        record_id=record_id,
+        source="test_glam",
+        severity=Severity.WARNING,
+        issues=["Datum in Ortsfeld", "Fehlende GND-Verknüpfung"],
+        confidence=0.75,
+        reasoning="Record hat multiple Probleme",
+        review_required=review_required,
+    )
+
+
+def _sample_cluster(
+    cluster_id: str = "cluster-001",
+    severity: Severity = Severity.WARNING,
+) -> IssueCluster:
+    return IssueCluster(
+        cluster_id=cluster_id,
+        label="Generische Begriffe in Ortsfeld",
+        category=FindingCategory.FIELD_MISUSE,
+        affected_columns=["location_place_name"],
+        affected_records_count=42,
+        severity=severity,
+        suggested_action="Werte in subject_general verschieben",
+    )
+
+
+def _sample_quality_report(
+    cell_findings: list | None = None,
+    record_reports: list | None = None,
+    issue_clusters: list | None = None,
+    work_package_candidates: list | None = None,
+) -> QualityAnalysisReport:
+    from kwb.core.models import DatasetProfile
+    return QualityAnalysisReport(
+        dataset_profiles=[
+            DatasetProfile(
+                source_path="test.csv",
+                source_name="test_glam",
+                row_count=100,
+                column_count=5,
+            )
+        ],
+        cell_findings=cell_findings if cell_findings is not None else [_sample_cell_finding()],
+        record_reports=record_reports if record_reports is not None else [_sample_record_report()],
+        issue_clusters=issue_clusters if issue_clusters is not None else [_sample_cluster()],
+        work_package_candidates=work_package_candidates if work_package_candidates is not None else [],
+        analysis_provenance=AnalysisProvenance(
+            analyzed_at="2026-03-25T10:00:00+00:00",
+            analyzer_version="0.6.0",
+            analysis_mode="rule_based",
+        ),
+    )
+
+
+def _sample_suggestion(
+    action_type: RemediationActionType = RemediationActionType.APPLY_SUGGESTED_VALUE,
+    status: ReviewStatus = ReviewStatus.ACCEPTED,
+    item_id: str | None = None,
+    original_value: str | None = "Kutsche",
+    suggested_value: str | None = "Landfahrzeug",
+    target_field: str = "subject_general",
+) -> RemediationSuggestion:
+    return RemediationSuggestion(
+        suggestion_id=str(uuid.uuid4()),
+        action_type=action_type,
+        original_value=original_value,
+        suggested_value=suggested_value,
+        reasoning="Korrekter Wert für Zielspalte",
+        item_id=item_id,
+        target_field=target_field,
+        confidence=0.85,
+        status=status,
+        is_ai_based=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReviewItem model
+# ---------------------------------------------------------------------------
+
+class TestReviewItemModel(unittest.TestCase):
+
+    def test_to_dict_contains_required_fields(self):
+        item = ReviewItem(
+            item_id="item-1",
+            source="test_glam",
+            record_id="obj-001",
+            column="location_place_name",
+            original_value="Kutsche",
+            category=FindingCategory.FIELD_MISUSE,
+            severity=Severity.WARNING,
+            confidence=0.9,
+            message="Fehlplatzierter Wert",
+            reasoning="Nicht-Toponym in Ortsfeld",
+            suggested_action="move_or_review",
+        )
+        d = item.to_dict()
+        self.assertEqual(d["item_id"], "item-1")
+        self.assertEqual(d["status"], "pending")
+        self.assertEqual(d["severity"], "warning")
+        self.assertEqual(d["category"], "field_misuse")
+        self.assertIsNone(d["reviewer"])
+        self.assertFalse(d["is_ai_based"])
+
+    def test_default_status_is_pending(self):
+        item = ReviewItem(
+            item_id="x",
+            source="",
+            record_id=None,
+            column=None,
+            original_value=None,
+            category=FindingCategory.MISSING_VALUES,
+            severity=Severity.INFO,
+            confidence=None,
+            message="",
+            reasoning="",
+            suggested_action=None,
+        )
+        self.assertEqual(item.status, ReviewStatus.PENDING)
+
+
+# ---------------------------------------------------------------------------
+# Tests: ReviewQueue
+# ---------------------------------------------------------------------------
+
+class TestReviewQueue(unittest.TestCase):
+
+    def test_from_quality_report_creates_items(self):
+        report = _sample_quality_report()
+        queue = ReviewQueue.from_quality_report(report, source="test_glam")
+        # Should create items from cell_finding + record_report + cluster
+        items = queue.all_items()
+        self.assertGreater(len(items), 0)
+
+    def test_from_quality_report_cell_finding_item(self):
+        cf = _sample_cell_finding(record_id="obj-001", column="location_place_name")
+        report = _sample_quality_report(
+            cell_findings=[cf],
+            record_reports=[],
+            issue_clusters=[],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        items = queue.all_items()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].record_id, "obj-001")
+        self.assertEqual(items[0].column, "location_place_name")
+        self.assertEqual(items[0].original_value, "Kutsche")
+
+    def test_from_quality_report_record_report_review_required(self):
+        rr = _sample_record_report(review_required=True)
+        rr_no = _sample_record_report(record_id="obj-003", review_required=False)
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[rr, rr_no],
+            issue_clusters=[],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        items = queue.all_items()
+        # Only the review_required=True record should produce an item
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].record_id, "obj-002")
+
+    def test_from_quality_report_skips_info_clusters(self):
+        info_cluster = _sample_cluster(severity=Severity.INFO)
+        warn_cluster = _sample_cluster(cluster_id="cluster-002", severity=Severity.WARNING)
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[],
+            issue_clusters=[info_cluster, warn_cluster],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        items = queue.all_items()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].severity, Severity.WARNING)
+
+    def test_update_status_accepted(self):
+        report = _sample_quality_report()
+        queue = ReviewQueue.from_quality_report(report)
+        items = queue.all_items()
+        item_id = items[0].item_id
+
+        updated = queue.update_status(item_id, ReviewStatus.ACCEPTED, reviewer="curator-1")
+        self.assertIsNotNone(updated)
+        self.assertEqual(updated.status, ReviewStatus.ACCEPTED)
+        self.assertEqual(updated.reviewer, "curator-1")
+        self.assertIsNotNone(updated.reviewed_at)
+
+    def test_update_status_unknown_id_returns_none(self):
+        queue = ReviewQueue()
+        result = queue.update_status("nonexistent-id", ReviewStatus.REJECTED)
+        self.assertIsNone(result)
+
+    def test_decisions_recorded(self):
+        report = _sample_quality_report()
+        queue = ReviewQueue.from_quality_report(report)
+        item_id = queue.all_items()[0].item_id
+        queue.update_status(item_id, ReviewStatus.NEEDS_EXPERT_REVIEW, note="Bitte Experten fragen")
+        decisions = queue.decisions()
+        self.assertEqual(len(decisions), 1)
+        self.assertEqual(decisions[0].decision, ReviewStatus.NEEDS_EXPERT_REVIEW)
+        self.assertEqual(decisions[0].note, "Bitte Experten fragen")
+
+    def test_filter_by_severity(self):
+        cf_warn = _sample_cell_finding(record_id="r1", severity=Severity.WARNING)
+        cf_crit = _sample_cell_finding(record_id="r2", severity=Severity.CRITICAL)
+        report = _sample_quality_report(
+            cell_findings=[cf_warn, cf_crit],
+            record_reports=[],
+            issue_clusters=[],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        warnings = queue.filter(severity="warning")
+        criticals = queue.filter(severity="critical")
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(len(criticals), 1)
+
+    def test_filter_by_column(self):
+        cf1 = _sample_cell_finding(column="location_place_name")
+        cf2 = _sample_cell_finding(record_id="obj-002", column="subject_general")
+        report = _sample_quality_report(
+            cell_findings=[cf1, cf2],
+            record_reports=[],
+            issue_clusters=[],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        items = queue.filter(column="location_place_name")
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].column, "location_place_name")
+
+    def test_filter_by_status(self):
+        report = _sample_quality_report()
+        queue = ReviewQueue.from_quality_report(report)
+        items = queue.all_items()
+        # All start as pending
+        pending = queue.filter(status="pending")
+        self.assertEqual(len(pending), len(items))
+
+        item_id = items[0].item_id
+        queue.update_status(item_id, ReviewStatus.ACCEPTED)
+        accepted = queue.filter(status="accepted")
+        self.assertEqual(len(accepted), 1)
+
+    def test_filter_by_min_confidence(self):
+        cf_high = _sample_cell_finding(record_id="r1", confidence=0.9)
+        cf_low = _sample_cell_finding(record_id="r2", confidence=0.4)
+        report = _sample_quality_report(
+            cell_findings=[cf_high, cf_low],
+            record_reports=[],
+            issue_clusters=[],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        high = queue.filter(min_confidence=0.8)
+        self.assertEqual(len(high), 1)
+
+    def test_summary_structure(self):
+        report = _sample_quality_report()
+        queue = ReviewQueue.from_quality_report(report)
+        summary = queue.summary()
+        self.assertIn("total", summary)
+        self.assertIn("by_status", summary)
+        self.assertIn("by_severity", summary)
+        self.assertIn("by_category", summary)
+        self.assertGreater(summary["total"], 0)
+
+    def test_to_dict_round_trip(self):
+        report = _sample_quality_report()
+        queue = ReviewQueue.from_quality_report(report)
+        d = queue.to_dict()
+        self.assertIn("items", d)
+        self.assertIn("decisions", d)
+        self.assertIn("summary", d)
+        self.assertIsInstance(d["items"], list)
+
+
+# ---------------------------------------------------------------------------
+# Tests: WorkPackage generation
+# ---------------------------------------------------------------------------
+
+class TestWorkPackageGeneration(unittest.TestCase):
+
+    def test_generate_from_clusters(self):
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[],
+            issue_clusters=[_sample_cluster()],
+        )
+        packages = generate_work_packages(report)
+        self.assertEqual(len(packages), 1)
+        pkg = packages[0]
+        self.assertIsInstance(pkg, WorkPackage)
+        self.assertEqual(pkg.issue_family, FindingCategory.FIELD_MISUSE.value)
+        self.assertEqual(pkg.estimated_records, 42)
+        self.assertIn("location_place_name", pkg.affected_columns)
+
+    def test_skips_info_clusters(self):
+        info_cluster = _sample_cluster(severity=Severity.INFO)
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[],
+            issue_clusters=[info_cluster],
+        )
+        packages = generate_work_packages(report)
+        self.assertEqual(len(packages), 0)
+
+    def test_critical_before_warning(self):
+        warn_cluster = _sample_cluster(cluster_id="c1", severity=Severity.WARNING)
+        warn_cluster.affected_records_count = 100
+        crit_cluster = _sample_cluster(cluster_id="c2", severity=Severity.CRITICAL)
+        crit_cluster.affected_records_count = 10
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[],
+            issue_clusters=[warn_cluster, crit_cluster],
+        )
+        packages = generate_work_packages(report)
+        self.assertEqual(len(packages), 2)
+        self.assertEqual(packages[0].priority, Severity.CRITICAL)
+        self.assertEqual(packages[1].priority, Severity.WARNING)
+
+    def test_package_has_automation_potential(self):
+        cluster = IssueCluster(
+            cluster_id="enc-001",
+            label="Encoding-Artefakte",
+            category=FindingCategory.ENCODING_ISSUES,
+            affected_columns=["description"],
+            affected_records_count=20,
+            severity=Severity.WARNING,
+        )
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[],
+            issue_clusters=[cluster],
+        )
+        packages = generate_work_packages(report)
+        self.assertEqual(len(packages), 1)
+        self.assertEqual(packages[0].automation_potential, "high")
+
+    def test_package_links_item_ids_from_queue(self):
+        cluster = _sample_cluster()
+        cf = _sample_cell_finding(column="location_place_name", category=FindingCategory.FIELD_MISUSE)
+        report = _sample_quality_report(
+            cell_findings=[cf],
+            record_reports=[],
+            issue_clusters=[cluster],
+        )
+        queue = ReviewQueue.from_quality_report(report)
+        packages = generate_work_packages(report, queue=queue)
+        self.assertEqual(len(packages), 1)
+        # The cluster item should be linked
+        self.assertIsInstance(packages[0].item_ids, list)
+
+    def test_package_from_work_package_candidates(self):
+        wpc = WorkPackageCandidate(
+            title="Terme normalisieren",
+            description="Varianten auf Vorzugsform bringen",
+            priority=Severity.WARNING,
+            affected_columns=["subject_general"],
+            estimated_records=55,
+            action_type="normalize_label",
+        )
+        report = _sample_quality_report(
+            cell_findings=[],
+            record_reports=[],
+            issue_clusters=[],
+            work_package_candidates=[wpc],
+        )
+        packages = generate_work_packages(report)
+        self.assertEqual(len(packages), 1)
+        self.assertEqual(packages[0].title, "Terme normalisieren")
+        self.assertEqual(packages[0].estimated_records, 55)
+
+    def test_to_dict_serializable(self):
+        report = _sample_quality_report()
+        packages = generate_work_packages(report)
+        for p in packages:
+            d = p.to_dict()
+            self.assertIn("package_id", d)
+            self.assertIn("priority", d)
+            self.assertIn("automation_potential", d)
+            self.assertIn("recommended_strategy", d)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Remediation
+# ---------------------------------------------------------------------------
+
+class TestRemediation(unittest.TestCase):
+
+    def _make_df(self) -> pd.DataFrame:
+        return pd.DataFrame({
+            "record_id": ["obj-001", "obj-002", "obj-003"],
+            "subject_general": ["Landschaft", "Kutsche", "Alpen"],
+            "location_place_name": ["Bern", "Hasliberg", "Grindelwald"],
+        })
+
+    def test_apply_suggested_value_updates_cell(self):
+        df = self._make_df()
+        sug = _sample_suggestion(
+            action_type=RemediationActionType.APPLY_SUGGESTED_VALUE,
+            status=ReviewStatus.ACCEPTED,
+            original_value="Kutsche",
+            suggested_value="Landfahrzeug",
+            target_field="subject_general",
+        )
+        updated, log = apply_accepted_changes(df, [sug], "ds1")
+        self.assertIn("Landfahrzeug", updated["subject_general"].values)
+        self.assertEqual(len(log), 1)
+        self.assertEqual(log[0].original_value, "Kutsche")
+        self.assertEqual(log[0].new_value, "Landfahrzeug")
+
+    def test_pending_suggestion_not_applied(self):
+        df = self._make_df()
+        sug = _sample_suggestion(
+            status=ReviewStatus.PENDING,
+            original_value="Kutsche",
+            suggested_value="SHOULD_NOT_APPEAR",
+            target_field="subject_general",
+        )
+        updated, log = apply_accepted_changes(df, [sug], "ds1")
+        self.assertNotIn("SHOULD_NOT_APPEAR", updated["subject_general"].values)
+        self.assertEqual(len(log), 0)
+
+    def test_rejected_suggestion_not_applied(self):
+        df = self._make_df()
+        sug = _sample_suggestion(
+            status=ReviewStatus.REJECTED,
+            original_value="Kutsche",
+            suggested_value="SHOULD_NOT_APPEAR",
+            target_field="subject_general",
+        )
+        updated, log = apply_accepted_changes(df, [sug], "ds1")
+        self.assertEqual(len(log), 0)
+
+    def test_normalize_label_batch_updates(self):
+        df = pd.DataFrame({
+            "record_id": ["r1", "r2", "r3"],
+            "subject_general": ["Kutsche", "kutsche", "Landschaft"],
+        })
+        sug = RemediationSuggestion(
+            suggestion_id=str(uuid.uuid4()),
+            action_type=RemediationActionType.NORMALIZE_LABEL,
+            original_value="Kutsche",
+            suggested_value="Landfahrzeug",
+            reasoning="Normalisierung",
+            target_field="subject_general",
+            status=ReviewStatus.ACCEPTED,
+        )
+        updated, log = apply_accepted_changes(df, [sug], "ds1")
+        # Only exact match "Kutsche" should be replaced
+        self.assertEqual(updated.loc[0, "subject_general"], "Landfahrzeug")
+        self.assertEqual(updated.loc[1, "subject_general"], "kutsche")  # case-sensitive
+        self.assertEqual(len(log), 1)
+
+    def test_flag_for_authority_lookup_does_not_change_value(self):
+        df = self._make_df()
+        sug = RemediationSuggestion(
+            suggestion_id=str(uuid.uuid4()),
+            action_type=RemediationActionType.FLAG_FOR_AUTHORITY_LOOKUP,
+            original_value="Bern",
+            suggested_value=None,
+            reasoning="GND lookup erforderlich",
+            target_field="location_place_name",
+            status=ReviewStatus.ACCEPTED,
+        )
+        updated, log = apply_accepted_changes(df, [sug], "ds1")
+        # Value unchanged
+        self.assertEqual(list(df["location_place_name"]), list(updated["location_place_name"]))
+        self.assertEqual(len(log), 1)
+        self.assertIn("unchanged", log[0].note or "")
+
+    def test_leave_unchanged_mark_uncertain_logs_entry(self):
+        df = self._make_df()
+        sug = RemediationSuggestion(
+            suggestion_id=str(uuid.uuid4()),
+            action_type=RemediationActionType.LEAVE_UNCHANGED_MARK_UNCERTAIN,
+            original_value="Alpen",
+            suggested_value=None,
+            reasoning="Unklar ob Toponym oder Motiv",
+            target_field="subject_general",
+            status=ReviewStatus.ACCEPTED,
+        )
+        updated, log = apply_accepted_changes(df, [sug], "ds1")
+        self.assertEqual(len(log), 1)
+        self.assertIn("uncertain", log[0].note or "")
+
+    def test_original_df_not_mutated(self):
+        df = self._make_df()
+        original_values = df["subject_general"].tolist()
+        sug = _sample_suggestion(
+            status=ReviewStatus.ACCEPTED,
+            original_value="Kutsche",
+            suggested_value="Fahrzeug",
+            target_field="subject_general",
+        )
+        apply_accepted_changes(df, [sug], "ds1")
+        # Original should be unchanged
+        self.assertEqual(df["subject_general"].tolist(), original_values)
+
+    def test_multiple_suggestions_all_applied(self):
+        df = self._make_df()
+        sug1 = _sample_suggestion(
+            status=ReviewStatus.ACCEPTED,
+            original_value="Kutsche",
+            suggested_value="Landfahrzeug",
+            target_field="subject_general",
+        )
+        sug2 = RemediationSuggestion(
+            suggestion_id=str(uuid.uuid4()),
+            action_type=RemediationActionType.NORMALIZE_LABEL,
+            original_value="Alpen",
+            suggested_value="Gebirge",
+            reasoning="Normalisierung",
+            target_field="subject_general",
+            status=ReviewStatus.ACCEPTED,
+        )
+        updated, log = apply_accepted_changes(df, [sug1, sug2], "ds1")
+        self.assertEqual(len(log), 2)
+
+    def test_changelog_contains_metadata(self):
+        df = self._make_df()
+        sug = _sample_suggestion(
+            status=ReviewStatus.ACCEPTED,
+            original_value="Kutsche",
+            suggested_value="Landfahrzeug",
+            target_field="subject_general",
+        )
+        _, log = apply_accepted_changes(df, [sug], "ds1", reviewer="curator-1")
+        self.assertEqual(log[0].reviewer, "curator-1")
+        self.assertEqual(log[0].dataset_id, "ds1")
+        self.assertIsNotNone(log[0].applied_at)
+        self.assertEqual(log[0].action_type, RemediationActionType.APPLY_SUGGESTED_VALUE)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Model serialization
+# ---------------------------------------------------------------------------
+
+class TestPhase3ModelSerialization(unittest.TestCase):
+
+    def test_work_package_to_dict(self):
+        wp = WorkPackage(
+            package_id="wp-1",
+            title="Test Package",
+            description="Beschreibung",
+            scope="42 Datensätze",
+            issue_family="field_misuse",
+            priority=Severity.WARNING,
+            affected_columns=["location_place_name"],
+            estimated_records=42,
+            action_type="move_value_to_field",
+            automation_potential="medium",
+            recommended_strategy="Manuell prüfen",
+            created_at="2026-03-25T10:00:00+00:00",
+        )
+        d = wp.to_dict()
+        self.assertEqual(d["priority"], "warning")
+        self.assertEqual(d["status"], "pending")
+        self.assertIn("package_id", d)
+
+    def test_applied_change_log_to_dict(self):
+        log = AppliedChangeLog(
+            change_id="cl-1",
+            dataset_id="ds1",
+            record_id="obj-001",
+            column="subject_general",
+            original_value="Kutsche",
+            new_value="Landfahrzeug",
+            action_type=RemediationActionType.APPLY_SUGGESTED_VALUE,
+            applied_at="2026-03-25T10:00:00+00:00",
+            reviewer="curator-1",
+        )
+        d = log.to_dict()
+        self.assertEqual(d["action_type"], "apply_suggested_value")
+        self.assertEqual(d["original_value"], "Kutsche")
+        self.assertEqual(d["new_value"], "Landfahrzeug")
+
+    def test_remediation_suggestion_to_dict(self):
+        sug = _sample_suggestion()
+        d = sug.to_dict()
+        self.assertEqual(d["status"], "accepted")
+        self.assertIn("suggestion_id", d)
+        self.assertIn("action_type", d)
+        self.assertTrue(d["is_ai_based"])
+
+    def test_review_status_values(self):
+        for s in ReviewStatus:
+            self.assertIsInstance(s.value, str)
+
+    def test_remediation_action_type_values(self):
+        for a in RemediationActionType:
+            self.assertIsInstance(a.value, str)
+
+
+# ---------------------------------------------------------------------------
+# Tests: API routes
+# ---------------------------------------------------------------------------
+
+class TestReviewAPIRoutes(unittest.TestCase):
+    """Integration-level tests for the review API routes using TestClient."""
+
+    def setUp(self):
+        try:
+            from fastapi.testclient import TestClient
+            from kwb.api.app import app
+            import kwb.api.deps as deps
+
+            self.client = TestClient(app)
+            # Reset Phase 3 state
+            state = deps.get_state()
+            state["review_queue"] = None
+            state["work_packages"] = []
+            state["changelog"] = []
+            state["suggestions"] = {}
+            # Inject a test dataset
+            df = pd.DataFrame({
+                "record_id": ["obj-001", "obj-002", "obj-003"],
+                "subject_general": ["Landschaft", "Kutsche", "Alpen"],
+                "location_place_name": ["Bern", "Hasliberg", "Grindelwald"],
+            })
+            from kwb.core.models import DatasetProfile
+            profile = DatasetProfile(
+                source_path="test.csv",
+                source_name="test",
+                row_count=3,
+                column_count=3,
+            )
+            state["datasets"]["test-ds"] = (df, profile)
+            # Inject a QualityAnalysisReport as last report
+            state["report"] = _sample_quality_report()
+
+        except Exception:
+            self.client = None
+
+    def _skip_if_no_client(self):
+        if self.client is None:
+            self.skipTest("FastAPI TestClient nicht verfügbar")
+
+    def test_schema_endpoint(self):
+        self._skip_if_no_client()
+        resp = self.client.get("/api/review/schema")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("review_statuses", data)
+        self.assertIn("remediation_action_types", data)
+        self.assertIn("endpoints", data)
+
+    def test_items_summary_empty_queue(self):
+        self._skip_if_no_client()
+        resp = self.client.get("/api/review/items/summary")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertIn("summary", data)
+
+    def test_list_items_empty_queue(self):
+        self._skip_if_no_client()
+        resp = self.client.get("/api/review/items")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertIn("items", data)
+
+    def test_build_queue_from_report(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/queue/build", json={})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertIn("summary", data)
+        self.assertGreater(data["summary"]["total"], 0)
+
+    def test_update_item_status_invalid(self):
+        self._skip_if_no_client()
+        resp = self.client.patch(
+            "/api/review/items/nonexistent/status",
+            json={"status": "invalid_status"},
+        )
+        self.assertEqual(resp.status_code, 422)
+
+    def test_update_item_status_not_found(self):
+        self._skip_if_no_client()
+        resp = self.client.patch(
+            "/api/review/items/nonexistent-id/status",
+            json={"status": "accepted"},
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    def test_generate_work_packages(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/work-packages/generate", json={})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertIn("work_packages", data)
+
+    def test_list_work_packages(self):
+        self._skip_if_no_client()
+        self.client.post("/api/review/work-packages/generate", json={})
+        resp = self.client.get("/api/review/work-packages")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("work_packages", data)
+
+    def test_add_and_list_suggestion(self):
+        self._skip_if_no_client()
+        payload = {
+            "action_type": "apply_suggested_value",
+            "original_value": "Kutsche",
+            "suggested_value": "Landfahrzeug",
+            "reasoning": "Nicht-Toponym",
+            "target_field": "subject_general",
+        }
+        resp = self.client.post("/api/review/suggestions", json=payload)
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["status"], "ok")
+        self.assertIn("suggestion", data)
+        sug_id = data["suggestion"]["suggestion_id"]
+
+        # List
+        resp2 = self.client.get("/api/review/suggestions")
+        self.assertEqual(resp2.status_code, 200)
+        sugs = resp2.json()["suggestions"]
+        ids = [s["suggestion_id"] for s in sugs]
+        self.assertIn(sug_id, ids)
+
+    def test_add_suggestion_missing_reasoning(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/suggestions", json={
+            "action_type": "normalize_label",
+            "original_value": "x",
+            "suggested_value": "y",
+        })
+        self.assertEqual(resp.status_code, 422)
+
+    def test_update_suggestion_status(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/suggestions", json={
+            "action_type": "normalize_label",
+            "original_value": "Kutsche",
+            "suggested_value": "Fahrzeug",
+            "reasoning": "Test",
+        })
+        sug_id = resp.json()["suggestion"]["suggestion_id"]
+
+        resp2 = self.client.patch(
+            f"/api/review/suggestions/{sug_id}/status",
+            json={"status": "accepted"},
+        )
+        self.assertEqual(resp2.status_code, 200)
+        self.assertEqual(resp2.json()["suggestion"]["status"], "accepted")
+
+    def test_apply_no_accepted_suggestions(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/apply", json={"dataset_id": "test-ds"})
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertEqual(data["applied_count"], 0)
+
+    def test_apply_accepted_suggestion_to_dataset(self):
+        self._skip_if_no_client()
+        # Add + accept a suggestion
+        resp = self.client.post("/api/review/suggestions", json={
+            "action_type": "normalize_label",
+            "original_value": "Kutsche",
+            "suggested_value": "Landfahrzeug",
+            "reasoning": "Normalisierung",
+            "target_field": "subject_general",
+        })
+        sug_id = resp.json()["suggestion"]["suggestion_id"]
+        self.client.patch(f"/api/review/suggestions/{sug_id}/status", json={"status": "accepted"})
+
+        resp2 = self.client.post("/api/review/apply", json={
+            "dataset_id": "test-ds",
+            "reviewer": "curator-1",
+        })
+        self.assertEqual(resp2.status_code, 200)
+        data = resp2.json()
+        self.assertEqual(data["applied_count"], 1)
+
+    def test_dry_run_does_not_modify_dataset(self):
+        self._skip_if_no_client()
+        import kwb.api.deps as deps
+        df_before = deps.get_datasets()["test-ds"][0]["subject_general"].tolist()
+
+        resp = self.client.post("/api/review/suggestions", json={
+            "action_type": "normalize_label",
+            "original_value": "Kutsche",
+            "suggested_value": "SHOULD_NOT_APPEAR",
+            "reasoning": "Test",
+            "target_field": "subject_general",
+        })
+        sug_id = resp.json()["suggestion"]["suggestion_id"]
+        self.client.patch(f"/api/review/suggestions/{sug_id}/status", json={"status": "accepted"})
+
+        self.client.post("/api/review/apply", json={
+            "dataset_id": "test-ds",
+            "dry_run": True,
+        })
+        df_after = deps.get_datasets()["test-ds"][0]["subject_general"].tolist()
+        self.assertEqual(df_before, df_after)
+
+    def test_changelog_empty_initially(self):
+        self._skip_if_no_client()
+        resp = self.client.get("/api/review/changelog")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()["total"], 0)
+
+    def test_export_returns_complete_structure(self):
+        self._skip_if_no_client()
+        resp = self.client.get("/api/review/export")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("review_queue", data)
+        self.assertIn("work_packages", data)
+        self.assertIn("suggestions", data)
+        self.assertIn("changelog", data)
+        self.assertIn("exported_at", data)
+
+    def test_apply_missing_dataset_id(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/apply", json={})
+        self.assertEqual(resp.status_code, 422)
+
+    def test_apply_nonexistent_dataset(self):
+        self._skip_if_no_client()
+        resp = self.client.post("/api/review/apply", json={"dataset_id": "nonexistent"})
+        self.assertEqual(resp.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements Phase 3 of the quality assurance workflow: curatorial review queues, work package generation, and remediation suggestion management. Adds comprehensive review infrastructure with API endpoints for managing review items, work packages, and applying accepted changes to datasets.

## Problem
The system had no mechanism for curators to review quality findings, organize them into actionable work packages, or apply remediation suggestions. Phase 1 (analysis) and Phase 2 (AI quality checks) produced findings, but there was no Phase 3 workflow to act on them.

## Root cause
Missing implementation of the review and remediation layer that bridges quality analysis results to actual data corrections.

## Solution
Added three core modules:

1. **`kwb/review/queue.py`** — `ReviewQueue` class that:
   - Builds review items from `QualityAnalysisReport` (cell findings, record reports, issue clusters)
   - Filters items by severity, column, category, status, confidence, source
   - Updates item status with reviewer tracking and timestamps
   - Provides summary statistics (counts by status/severity/category)

2. **`kwb/review/work_packages.py`** — `generate_work_packages()` function that:
   - Converts `IssueCluster` objects into actionable `WorkPackage` instances
   - Assigns automation potential (high/medium/low) based on finding category
   - Recommends remediation strategies per category
   - Links work packages to review items via queue
   - Skips INFO-level clusters

3. **`kwb/review/remediation.py`** — `apply_accepted_changes()` function that:
   - Applies only ACCEPTED `RemediationSuggestion` objects to DataFrames
   - Supports multiple action types: apply value, move field, normalize label, flag for lookup, mark uncertain
   - Records all changes in `AppliedChangeLog` for full traceability
   - Returns updated DataFrame and change history

4. **`kwb/api/routes/review.py`** — REST API endpoints:
   - `GET /api/review/items` — list/filter review items
   - `PATCH /api/review/items/{item_id}/status` — update item status
   - `GET /api/review/items/summary` — queue statistics
   - `POST /api/review/queue/build` — build queue from quality report
   - `GET /api/review/work-packages` — list work packages
   - `POST /api/review/work-packages/generate` — generate from report
   - `GET/POST /api/review/suggestions` — manage remediation suggestions
   - `PATCH /api/review/suggestions/{sid}/status` — accept/reject suggestions
   - `POST /api/review/apply` — apply accepted changes to dataset
   - `GET /api/review/changelog` — view applied changes

5. **Data models** in `kwb/core/models.py`:
   - `ReviewStatus` enum (pending, accepted, rejected, needs_expert_review, applied)
   - `RemediationActionType` enum (6 action types)
   - `ReviewItem` — single finding for review
   - `ReviewDecision` — curatorial decision record
   - `WorkPackage` — bundled work unit
   - `RemediationSuggestion` — proposed change
   - `AppliedChangeLog` — change audit trail

## Files changed
- `src/kwb/review/queue.py` (new, 228 lines)
- `src/kwb/review/work_packages.py` (new, 191 lines)
- `src/kwb/review/remediation.py` (new, 242 lines)
- `src/kwb/review/__init__.py` (new)
- `src/kwb/api/routes/review.py` (new, 535 lines)
- `src/kwb/core/models.py` (modified, +200 lines for Phase 3 models)
- `src/kwb/api/app.py` (modified, register review router)
- `src/kwb/api/deps.py` (modified, add review state keys)

https://claude.ai/code/session_01MeQDE7vXzg7QEwQFHF8ja9