### PR TITLE
feat: Review-Queues, Bereinigung & Phase Navigator (Issue #90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,11 @@ Python 3.10+, MIT-Lizenz, v0.5.2.
 # Tests ausführen (immer vor Commit!)
 PYTHONPATH=src python -m unittest discover tests
 
+# Testkatalog aktualisieren (PFLICHT nach Tests hinzufügen/entfernen!)
+# Muss vor jedem Commit ausgeführt werden, wenn tests/ oder src/ geändert wurden.
+# Der CI-Check "Testkatalog Konsistenz" schlägt sonst fehl.
+python scripts/update_test_catalog.py --update-doc
+
 # Linting
 ruff check src/ tests/
 

--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 315/450 Tests bestanden, 35 fehlgeschlagen, 100 übersprungen
+**Gesamtstatus:** 315/451 Tests bestanden, 36 fehlgeschlagen, 100 übersprungen
 
 ---
 
@@ -263,6 +263,7 @@
 | test_pipeline_steps.py | 0/1 | 1 | 0 | ❌ |
 | test_quality_analysis_report.py | 51/52 | 1 | 0 | ❌ |
 | test_quality_measures.py | 0/1 | 1 | 0 | ❌ |
+| test_review.py | 0/1 | 1 | 0 | ❌ |
 | test_roadmap.py | 0/1 | 1 | 0 | ❌ |
 | test_services.py | 0/1 | 1 | 0 | ❌ |
 | test_utils.py | 30/30 | 0 | 0 | ✅ |
@@ -270,7 +271,7 @@
 | test_workspace_export.py | 0/1 | 1 | 0 | ❌ |
 | test_xlsx_loader.py | 0/1 | 1 | 0 | ❌ |
 | test_xml_loader.py | 0/1 | 1 | 0 | ❌ |
-| **Gesamt** | **315/450** | **35** | **100** | **❌** |
+| **Gesamt** | **315/451** | **36** | **100** | **❌** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 315/451 Tests bestanden, 36 fehlgeschlagen, 100 übersprungen
+**Gesamtstatus:** 774/906 Tests bestanden, 0 fehlgeschlagen, 132 übersprungen
 
 ---
 
@@ -237,41 +237,41 @@
 <!-- AUTO-TESTS-START -->
 | Test-Suite | Bestanden | Fehlgeschlagen | Übersprungen | Status |
 |------------|-----------|----------------|--------------|--------|
-| test_ai.py | 0/1 | 1 | 0 | ❌ |
+| test_ai.py | 19/19 | 0 | 0 | ✅ |
 | test_api.py | 0/51 | 0 | 51 | ✅ |
 | test_authority_review.py | 9/9 | 0 | 0 | ✅ |
-| test_cli.py | 0/1 | 1 | 0 | ❌ |
-| test_comprehensive.py | 16/22 | 6 | 0 | ❌ |
-| test_core.py | 0/1 | 1 | 0 | ❌ |
-| test_dictionaries_mds_auth.py | 26/37 | 11 | 0 | ❌ |
+| test_cli.py | 8/8 | 0 | 0 | ✅ |
+| test_comprehensive.py | 22/22 | 0 | 0 | ✅ |
+| test_core.py | 18/18 | 0 | 0 | ✅ |
+| test_dictionaries_mds_auth.py | 37/37 | 0 | 0 | ✅ |
 | test_edtf.py | 82/82 | 0 | 0 | ✅ |
 | test_geonames.py | 9/9 | 0 | 0 | ✅ |
-| test_gnd.py | 0/1 | 1 | 0 | ❌ |
-| test_gnd_enrich.py | 0/1 | 1 | 0 | ❌ |
+| test_gnd.py | 14/14 | 0 | 0 | ✅ |
+| test_gnd_enrich.py | 24/40 | 0 | 16 | ✅ |
 | test_goobi_api.py | 4/4 | 0 | 0 | ✅ |
-| test_goobi_export.py | 0/1 | 1 | 0 | ❌ |
+| test_goobi_export.py | 32/32 | 0 | 0 | ✅ |
 | test_gpu_config_api.py | 0/10 | 0 | 10 | ✅ |
 | test_image_fixtures.py | 10/10 | 0 | 0 | ✅ |
 | test_image_upload.py | 0/31 | 0 | 31 | ✅ |
-| test_llm_quality.py | 0/1 | 1 | 0 | ❌ |
-| test_ner.py | 0/1 | 1 | 0 | ❌ |
-| test_ner_edtf.py | 0/1 | 1 | 0 | ❌ |
-| test_new_features.py | 0/1 | 1 | 0 | ❌ |
+| test_llm_quality.py | 55/55 | 0 | 0 | ✅ |
+| test_ner.py | 29/29 | 0 | 0 | ✅ |
+| test_ner_edtf.py | 31/31 | 0 | 0 | ✅ |
+| test_new_features.py | 29/41 | 0 | 12 | ✅ |
 | test_open_issues.py | 24/32 | 0 | 8 | ✅ |
 | test_pdf_loader.py | 3/3 | 0 | 0 | ✅ |
 | test_pipeline.py | 18/18 | 0 | 0 | ✅ |
-| test_pipeline_steps.py | 0/1 | 1 | 0 | ❌ |
-| test_quality_analysis_report.py | 51/52 | 1 | 0 | ❌ |
-| test_quality_measures.py | 0/1 | 1 | 0 | ❌ |
-| test_review.py | 0/1 | 1 | 0 | ❌ |
-| test_roadmap.py | 0/1 | 1 | 0 | ❌ |
-| test_services.py | 0/1 | 1 | 0 | ❌ |
+| test_pipeline_steps.py | 10/10 | 0 | 0 | ✅ |
+| test_quality_analysis_report.py | 52/52 | 0 | 0 | ✅ |
+| test_quality_measures.py | 55/55 | 0 | 0 | ✅ |
+| test_review.py | 54/54 | 0 | 0 | ✅ |
+| test_roadmap.py | 8/8 | 0 | 0 | ✅ |
+| test_services.py | 20/20 | 0 | 0 | ✅ |
 | test_utils.py | 30/30 | 0 | 0 | ✅ |
 | test_workspace.py | 33/33 | 0 | 0 | ✅ |
-| test_workspace_export.py | 0/1 | 1 | 0 | ❌ |
-| test_xlsx_loader.py | 0/1 | 1 | 0 | ❌ |
-| test_xml_loader.py | 0/1 | 1 | 0 | ❌ |
-| **Gesamt** | **315/451** | **36** | **100** | **❌** |
+| test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
+| test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
+| test_xml_loader.py | 8/8 | 0 | 0 | ✅ |
+| **Gesamt** | **774/906** | **0** | **132** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Auto-update docs/FUNKTIONSKATALOG.md test statistics before every commit.
+# Prevents "Testkatalog Konsistenz" CI failures.
+#
+# Install: sh scripts/install-hooks.sh
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$REPO_ROOT/scripts/update_test_catalog.py"
+DOC="docs/FUNKTIONSKATALOG.md"
+
+[ -f "$SCRIPT" ] || exit 0
+
+cd "$REPO_ROOT"
+
+# Only run if Python tests or source files are staged
+CHANGED=$(git diff --cached --name-only)
+echo "$CHANGED" | grep -qE '(^tests/|^src/|\.py$)' || exit 0
+
+printf "pre-commit: Testkatalog aktualisieren ... "
+if python "$SCRIPT" --update-doc 2>/dev/null; then
+  if ! git diff --quiet "$DOC"; then
+    git add "$DOC"
+    printf "aktualisiert und gestaged.\n"
+  else
+    printf "bereits aktuell.\n"
+  fi
+else
+  printf "Fehler (nicht blockierend).\n"
+fi

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+# Install project git hooks into .git/hooks/.
+# Run once after cloning: sh scripts/install-hooks.sh
+set -e
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+SRC="$REPO_ROOT/scripts/hooks"
+DST="$REPO_ROOT/.git/hooks"
+for hook in "$SRC"/*; do
+  name="$(basename "$hook")"
+  cp "$hook" "$DST/$name"
+  chmod +x "$DST/$name"
+  echo "Installed: $name"
+done
+echo "Hooks installed."

--- a/scripts/update_test_catalog.py
+++ b/scripts/update_test_catalog.py
@@ -39,7 +39,7 @@ def run_suite(pytest_cmd: str, test_file: Path, repo_root: Path) -> SuiteResult:
     env["KWB_FORCE_NO_FASTAPI"] = "1"
     env["PYTHONPATH"] = str(repo_root / "src") + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
 
-    cmd = [pytest_cmd, "-q", str(test_file), f"--junitxml={xml_path}"]
+    cmd = pytest_cmd.split() + ["-q", str(test_file), f"--junitxml={xml_path}"]
     proc = subprocess.run(cmd, cwd=repo_root, env=env, capture_output=True, text=True)
 
     if not xml_path.exists():
@@ -155,7 +155,7 @@ def check_catalog(catalog_path: Path, expected_table: str) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Aggregiert pytest-Ergebnisse pro tests/test_*.py und aktualisiert docs/FUNKTIONSKATALOG.md")
-    parser.add_argument("--pytest", default="pytest", help="Pfad/Befehl für pytest")
+    parser.add_argument("--pytest", default=None, help="Pfad/Befehl für pytest (Standard: sys.executable -m pytest)")
     parser.add_argument("--repo-root", default=".", help="Repository-Wurzel")
     parser.add_argument("--update-doc", action="store_true", help="docs/FUNKTIONSKATALOG.md automatisch aktualisieren")
     parser.add_argument("--check-doc", action="store_true", help="prüft, ob docs/FUNKTIONSKATALOG.md zur aktuellen Testlage passt")
@@ -167,7 +167,10 @@ def main() -> int:
         print("Keine tests/test_*.py gefunden", file=sys.stderr)
         return 2
 
-    results = [run_suite(args.pytest, t, repo_root) for t in tests]
+    # Default: use the same Python that's running this script so that installed
+    # packages are identical between the driver and the test subprocess.
+    pytest_cmd = args.pytest or f"{sys.executable} -m pytest"
+    results = [run_suite(pytest_cmd, t, repo_root) for t in tests]
     table = build_table(results)
 
     if args.update_doc:

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -26,40 +26,35 @@
 <label class="btn sm s" style="cursor:pointer;margin-top:0">&#128193; Laden<input type="file" accept=".json" style="display:none" onchange="loadWS(this.files[0])"></label></span>
 </div>
 
-<!-- ===== PIPELINE STEPPER ===== -->
+<!-- ===== PHASE NAVIGATOR (6 non-blocking phases) ===== -->
 <div class="stepper" id="stepper">
 <div class="step active" data-step="1" onclick="goStep(1)">
 <div class="step-num">1</div>
-<div class="step-lbl">Upload &amp; Parse</div>
+<div class="step-lbl">Upload &amp; Analyse</div>
 </div>
 <div class="step-conn"></div>
-<div class="step locked" data-step="2" onclick="goStep(2)">
+<div class="step no-data" data-step="2" onclick="goStep(2)">
 <div class="step-num">2</div>
+<div class="step-lbl">Bereinigung</div>
+</div>
+<div class="step-conn"></div>
+<div class="step no-data" data-step="3" onclick="goStep(3)">
+<div class="step-num">3</div>
 <div class="step-lbl">Extraktion</div>
 </div>
 <div class="step-conn"></div>
-<div class="step locked" data-step="3" onclick="goStep(3)">
-<div class="step-num">3</div>
-<div class="step-lbl">Qualit&auml;tspr&uuml;fung</div>
-</div>
-<div class="step-conn"></div>
-<div class="step locked" data-step="4" onclick="goStep(4)">
+<div class="step no-data" data-step="4" onclick="goStep(4)">
 <div class="step-num">4</div>
-<div class="step-lbl">Gesamtlauf</div>
-</div>
-<div class="step-conn"></div>
-<div class="step locked" data-step="5" onclick="goStep(5)">
-<div class="step-num">5</div>
 <div class="step-lbl">Anreicherung</div>
 </div>
 <div class="step-conn"></div>
-<div class="step locked" data-step="6" onclick="goStep(6)">
-<div class="step-num">6</div>
+<div class="step no-data" data-step="5" onclick="goStep(5)">
+<div class="step-num">5</div>
 <div class="step-lbl">W&ouml;rterbuch</div>
 </div>
 <div class="step-conn"></div>
-<div class="step locked" data-step="7" onclick="goStep(7)">
-<div class="step-num">7</div>
+<div class="step" data-step="6" onclick="goStep(6)">
+<div class="step-num">6</div>
 <div class="step-lbl">Export</div>
 </div>
 </div>
@@ -69,10 +64,19 @@
 <!-- ===== STEP 1: UPLOAD & PARSE ===== -->
 <div class="step-panel active" data-step="1">
 <h2>Schritt 1: Daten laden, parsen &amp; analysieren</h2>
-<div class="three-pane">
+<!-- Material context selector -->
+<div class="mat-ctx-bar" id="mat-ctx-bar">
+<span style="font-size:.72rem;font-weight:600;color:#555">Materialart:</span>
+<div class="mat-ctx-pill active" data-ctx="table" onclick="setMatCtx('table')">&#128202; Metadaten</div>
+<div class="mat-ctx-pill" data-ctx="images" onclick="setMatCtx('images')">&#128248; Bilder</div>
+<div class="mat-ctx-pill" data-ctx="pdf" onclick="setMatCtx('pdf')">&#128209; PDF</div>
+<div class="mat-ctx-pill" data-ctx="mixed" onclick="setMatCtx('mixed')">&#10564; Gemischt</div>
+<span id="mat-auto-hint" style="font-size:.62rem;color:#1d4ed8;margin-left:.3rem;display:none">&#8592; automatisch erkannt</span>
+</div>
+<div class="mat-workspace mat-ctx-table" id="mat-workspace">
 
-<!-- Pane 1: Metadata (CSV / XLSX / XML) -->
-<div class="pane">
+<!-- Section: Metadata (CSV / XLSX / XML) -->
+<div class="mat-section" data-ctx="table">
 <div class="pane-hdr">&#128196; Metadaten</div>
 <div class="c">
 <h3>1a. Dateien hochladen</h3>
@@ -128,8 +132,8 @@
 </div>
 </div>
 
-<!-- Pane 2: Images (JPG / PNG / TIFF / WEBP) -->
-<div class="pane">
+<!-- Section: Images (JPG / PNG / TIFF / WEBP) -->
+<div class="mat-section" data-ctx="images">
 <div class="pane-hdr">&#128248; Bilder</div>
 <div class="c">
 <h3>Bilder hochladen</h3>
@@ -138,7 +142,7 @@
 <label>Ordner <span style="font-weight:400;color:#888">(inkl. Unterordner)</span></label>
 <input type="file" id="img-folder-p1" webkitdirectory multiple style="font-size:.75rem;width:100%">
 <button class="btn f" onclick="uploadImages()">&#11014;&#65039; Hochladen</button>
-<div id="img-upload-status" class="em" style="margin-top:.4rem;font-size:.73rem"></div>
+<div id="img-upload-status-p1" class="em" style="margin-top:.4rem;font-size:.73rem"></div>
 </div>
 <div class="c" id="img-pane1-info" style="display:none">
 <h3>Hochgeladene Bilder <span id="img-pane1-count" style="font-size:.7rem;color:#888"></span></h3>
@@ -146,8 +150,8 @@
 </div>
 </div>
 
-<!-- Pane 3: PDF-Dokumente -->
-<div class="pane">
+<!-- Section: PDF-Dokumente -->
+<div class="mat-section" data-ctx="pdf">
 <div class="pane-hdr">&#128209; PDF-Dokumente</div>
 <div class="c">
 <h3>PDF hochladen</h3>
@@ -164,12 +168,12 @@
 </div>
 </div>
 
-</div><!-- /.three-pane -->
+</div><!-- /.mat-workspace -->
 
 <!-- Analysis Results (full width below panes) -->
 <div id="de" class="em" style="margin-top:1rem"><h3>Willkommen bei Debussy</h3><p style="font-size:.8rem">Lade Dateien hoch, starte die Analyse, und setze die ID-Spalte fest.</p>
-<div style="margin-top:.6rem;padding:.5rem;background:#f0f7ff;border:1px solid #d0e3ff;border-radius:4px;font-size:.75rem;line-height:1.5"><strong>Pipeline-Workflow:</strong><br>
-&#9312; Upload &amp; Parse &rarr; &#9313; Extraktion (NER + Bilder + PDF) &rarr; &#9314; Qualit&auml;tspr&uuml;fung &rarr; &#9315; Gesamtlauf &rarr; &#9316; Anreicherung &rarr; &#9317; W&ouml;rterbuch &rarr; &#9318; Export</div></div>
+<div style="margin-top:.6rem;padding:.5rem;background:#f0f7ff;border:1px solid #d0e3ff;border-radius:4px;font-size:.75rem;line-height:1.5"><strong>Werkbank-Phasen:</strong><br>
+&#9312; Upload &amp; Analyse &rarr; &#9313; Bereinigung (Review-Queue, Arbeitspakete) &rarr; &#9314; Extraktion (NER + Bilder + PDF) &rarr; &#9315; Anreicherung &rarr; &#9316; W&ouml;rterbuch &rarr; &#9317; Export (jederzeit verf&uuml;gbar)</div></div>
 <div id="dr" style="display:none"><div class="sg" id="dsg"></div>
 <div class="c"><div class="tabs" id="dt"><div class="tab a" data-t="find">Findings</div><div class="tab" data-t="qm">Qualit&auml;tsbericht</div><div class="tab" data-t="llmq">KI-Qualit&auml;tspr&uuml;fung</div><div class="tab" data-t="cols">Spalten &amp; Profil</div><div class="tab" data-t="md">Markdown</div></div>
 <div class="tp a" data-t="find"><div class="fl" id="fbar"></div><div id="flist"></div></div>
@@ -212,9 +216,139 @@
 </div></div>
 </div>
 
-<!-- ===== STEP 2: DATA EXTRACTION ===== -->
+<!-- ===== PHASE 2: BEREINIGUNG ===== -->
 <div class="step-panel" data-step="2">
-<h2>Schritt 2: Datenextraktion</h2>
+<h2>Phase 2: Bereinigung</h2>
+<p style="font-size:.78rem;color:#666;margin-bottom:.8rem">Review-Queue, Arbeitspakete und strukturierte Bereinigung auf Basis der Qualit&auml;tsanalyse (Phase 1 + KI). Reinigung des Datenmaterials <em>vor</em> der Extraktion f&uuml;hrt zu besseren NER-Ergebnissen.</p>
+
+<div class="tabs" id="rev-tabs">
+<div class="tab a" data-t="rev-overview">&#128202; &Uuml;berblick</div>
+<div class="tab" data-t="rev-queue">&#128203; Review-Queue</div>
+<div class="tab" data-t="rev-wp">&#128218; Arbeitspakete</div>
+<div class="tab" data-t="rev-sug">&#128161; Vorschl&auml;ge</div>
+<div class="tab" data-t="rev-log">&#128196; Protokoll</div>
+</div>
+
+<!-- Tab: Überblick -->
+<div class="tp a" data-t="rev-overview">
+<div class="g2">
+<div class="sb">
+<div class="c">
+<h3>Review-Queue aufbauen</h3>
+<p style="font-size:.72rem;color:#666;margin-bottom:.4rem">Erzeugt Review-Items aus dem letzten Qualit&auml;tsbericht (Zellbefunde, Record-Berichte, Issue-Cluster).</p>
+<label>Quelle <span style="font-weight:400;color:#888">(optional)</span></label>
+<input type="text" id="rev-source" placeholder="z.B. phase1-analyse">
+<label style="display:flex;align-items:center;gap:.4rem;margin-top:.4rem"><input type="checkbox" id="rev-is-ai" style="width:auto;margin-top:0"> KI-basiert markieren</label>
+<button class="btn f" onclick="buildRevQueue()" style="margin-top:.5rem">&#128260; Queue aufbauen</button>
+<div id="rev-build-status" style="font-size:.73rem;color:var(--ok);margin-top:.3rem"></div>
+</div>
+<div class="c">
+<h3>Arbeitspakete generieren</h3>
+<p style="font-size:.72rem;color:#666;margin-bottom:.4rem">Gruppiert Issue-Cluster aus dem Bericht zu priorisierten Arbeitspaketen mit Automatisierungspotenzial.</p>
+<button class="btn f" onclick="generateWorkPackages()">&#128230; Arbeitspakete generieren</button>
+<div id="rev-wp-status" style="font-size:.73rem;color:var(--ok);margin-top:.3rem"></div>
+</div>
+</div>
+<div>
+<h3 style="font-size:.82rem;margin-bottom:.5rem">&#128202; Status-&Uuml;bersicht</h3>
+<div class="sg" id="rev-summary-bar" style="margin-bottom:.6rem"></div>
+<button class="btn sm s" onclick="loadRevSummary()">&#128260; Aktualisieren</button>
+</div>
+</div>
+</div>
+
+<!-- Tab: Review-Queue -->
+<div class="tp" data-t="rev-queue">
+<div style="display:flex;justify-content:space-between;align-items:center;flex-wrap:wrap;gap:.4rem;margin-bottom:.4rem">
+<span style="font-size:.82rem;font-weight:600">Review-Items <span id="rev-items-count" style="font-size:.72rem;font-weight:400;color:#888"></span></span>
+<div style="display:flex;gap:.3rem;flex-wrap:wrap">
+<button class="btn sm" onclick="batchRevStatus('accepted')">&#10003; Alle akzeptieren</button>
+<button class="btn sm s" onclick="batchRevStatus('rejected')" style="background:#888">&#10007; Alle ablehnen</button>
+<button class="btn sm s" onclick="exportRevStatus()">&#11015;&#65039; Exportieren</button>
+<button class="btn sm s" onclick="loadRevItems()">&#128260; Laden</button>
+</div>
+</div>
+<div class="fl" id="rev-filter-status" style="margin-bottom:.3rem">
+<strong style="font-size:.7rem;align-self:center">Status:</strong>
+<div class="fb2 a" data-val="" onclick="filterRevQueue('status','',this)">Alle</div>
+<div class="fb2" data-val="pending" onclick="filterRevQueue('status','pending',this)">Offen</div>
+<div class="fb2" data-val="accepted" onclick="filterRevQueue('status','accepted',this)">Akzeptiert</div>
+<div class="fb2" data-val="rejected" onclick="filterRevQueue('status','rejected',this)">Abgelehnt</div>
+<div class="fb2" data-val="needs_expert_review" onclick="filterRevQueue('status','needs_expert_review',this)">Experte</div>
+<div class="fb2" data-val="applied" onclick="filterRevQueue('status','applied',this)">Angewendet</div>
+</div>
+<div class="fl" id="rev-filter-severity">
+<strong style="font-size:.7rem;align-self:center">Schwere:</strong>
+<div class="fb2 a" data-val="" onclick="filterRevQueue('severity','',this)">Alle</div>
+<div class="fb2" data-val="critical" onclick="filterRevQueue('severity','critical',this)">Kritisch</div>
+<div class="fb2" data-val="warning" onclick="filterRevQueue('severity','warning',this)">Warnung</div>
+<div class="fb2" data-val="info" onclick="filterRevQueue('severity','info',this)">Info</div>
+</div>
+<div id="rev-items-list" class="scroll-box" style="max-height:520px;margin-top:.4rem">
+<div class="em" style="font-size:.78rem">Queue aufbauen oder &raquo;Laden&laquo; klicken.</div>
+</div>
+</div>
+
+<!-- Tab: Arbeitspakete -->
+<div class="tp" data-t="rev-wp">
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem">
+<span style="font-size:.82rem;font-weight:600">Arbeitspakete <span id="rev-wp-count" style="font-size:.72rem;font-weight:400;color:#888"></span></span>
+<div style="display:flex;gap:.3rem">
+<button class="btn sm" onclick="generateWorkPackages()">&#128230; Generieren</button>
+<button class="btn sm s" onclick="loadWorkPackages()">&#128260; Laden</button>
+</div>
+</div>
+<div id="rev-wp-list" class="scroll-box" style="max-height:520px">
+<div class="em" style="font-size:.78rem">Arbeitspakete generieren oder &raquo;Laden&laquo; klicken.</div>
+</div>
+</div>
+
+<!-- Tab: Vorschläge -->
+<div class="tp" data-t="rev-sug">
+<div class="c" style="margin-bottom:.8rem">
+<h3>&#9889; Akzeptierte &Auml;nderungen anwenden</h3>
+<p style="font-size:.72rem;color:#666;margin-bottom:.4rem">Wendet alle Vorschl&auml;ge mit Status &laquo;akzeptiert&raquo; auf den gew&auml;hlten Datensatz an.</p>
+<label>Datensatz</label>
+<select id="rev-apply-ds" style="width:100%"><option value="">&#8212; alle &#8212;</option></select>
+<div style="display:flex;gap:.4rem;margin-top:.5rem;flex-wrap:wrap">
+<button class="btn sm" onclick="revApplyChanges(true)">&#128269; Vorschau (dry run)</button>
+<button class="btn sm" onclick="revApplyChanges(false)">&#10003; Anwenden</button>
+</div>
+<div id="rev-apply-status" style="font-size:.73rem;color:var(--ok);margin-top:.3rem"></div>
+</div>
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem">
+<span style="font-size:.82rem;font-weight:600">Vorschl&auml;ge <span id="rev-sug-count" style="font-size:.72rem;font-weight:400;color:#888"></span></span>
+<button class="btn sm s" onclick="loadRevSuggestions()">&#128260; Laden</button>
+</div>
+<div id="rev-sug-list" class="scroll-box" style="max-height:400px">
+<div class="em" style="font-size:.78rem">Keine Vorschl&auml;ge.</div>
+</div>
+</div>
+
+<!-- Tab: Protokoll -->
+<div class="tp" data-t="rev-log">
+<div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.5rem">
+<span style="font-size:.82rem;font-weight:600">&Auml;nderungsprotokoll <span id="rev-log-count" style="font-size:.72rem;font-weight:400;color:#888"></span></span>
+<button class="btn sm s" onclick="loadRevChangelog()">&#128260; Laden</button>
+</div>
+<div id="rev-log-empty" class="em" style="font-size:.78rem">Noch keine &Auml;nderungen angewendet.</div>
+<div class="scroll-box" style="max-height:500px">
+<table class="etbl"><thead><tr><th>Record</th><th>Spalte</th><th>Original</th><th>Neu</th><th>Aktion</th><th>Datum</th></tr></thead><tbody id="rev-log-body"></tbody></table>
+</div>
+</div>
+</div>
+
+<!-- ===== PHASE 3: EXTRAKTION ===== -->
+<div class="step-panel" data-step="3">
+<h2>Phase 3: Datenextraktion</h2>
+<div class="tabs" id="ext-main-tabs">
+<div class="tab a" data-t="ext-ner">&#128196; NER &amp; Bilder &amp; PDF</div>
+<div class="tab" data-t="ext-qgate">&#128270; Testlauf-Review</div>
+<div class="tab" data-t="ext-full">&#9654;&#65039; Gesamtlauf</div>
+</div>
+
+<!-- Sub-tab: Extraktion -->
+<div class="tp a" data-t="ext-ner">
 <div class="track-cols">
 
 <!-- Text Track: NER -->
@@ -349,13 +483,11 @@
 </div>
 
 </div>
-</div>
+</div><!-- /.tp ext-ner -->
 
-<!-- ===== STEP 3: QUALITY GATEWAY ===== -->
-<div class="step-panel" data-step="3">
-<h2>Schritt 3: Qualit&auml;tspr&uuml;fung</h2>
-<p style="font-size:.78rem;color:#666;margin-bottom:1rem">Pr&uuml;fe die Ergebnisse der 2%-Testl&auml;ufe. Akzeptiere oder lehne Ergebnisse ab, bevor der Gesamtlauf gestartet wird.</p>
-
+<!-- Sub-tab: Testlauf-Review -->
+<div class="tp" data-t="ext-qgate">
+<p style="font-size:.78rem;color:#666;margin-bottom:.8rem">Pr&uuml;fe die Ergebnisse der 2%-Testl&auml;ufe. Akzeptiere oder lehne Ergebnisse ab, bevor der Gesamtlauf gestartet wird.</p>
 <div class="g2">
 <div>
 <div class="c">
@@ -376,7 +508,6 @@
 </div>
 </div>
 </div>
-
 <div>
 <div class="c">
 <h3>Bild-Testergebnisse</h3>
@@ -393,17 +524,11 @@
 </div>
 </div>
 </div>
+</div><!-- /.tp ext-qgate -->
 
-<div style="margin-top:1rem;text-align:center">
-<button class="btn" onclick="markTestReviewed()" style="padding:.6rem 2rem;font-size:.85rem">&#10003; Qualit&auml;tspr&uuml;fung abgeschlossen &mdash; Weiter zu Schritt 4</button>
-</div>
-</div>
-
-<!-- ===== STEP 4: FULL RUN ===== -->
-<div class="step-panel" data-step="4">
-<h2>Schritt 4: Gesamtlauf</h2>
-<p style="font-size:.78rem;color:#666;margin-bottom:1rem">Starte den vollst&auml;ndigen NER- und Bildanalyse-Lauf auf dem gesamten Datensatz.</p>
-
+<!-- Sub-tab: Gesamtlauf -->
+<div class="tp" data-t="ext-full">
+<p style="font-size:.78rem;color:#666;margin-bottom:.8rem">Starte den vollst&auml;ndigen NER- und Bildanalyse-Lauf auf dem gesamten Datensatz.</p>
 <div class="g2">
 <div class="c">
 <h3>&#128196; NER Gesamtlauf</h3>
@@ -417,15 +542,16 @@
 <div id="img-full-status" style="font-size:.72rem;color:#555;margin-top:.4rem"></div>
 </div>
 </div>
-
 <div style="margin-top:1rem;text-align:center">
-<button class="btn" onclick="completeStep(4)" style="padding:.6rem 2rem;font-size:.85rem">&#10003; Gesamtlauf abgeschlossen &mdash; Weiter zu Schritt 5</button>
+<button class="btn" onclick="completeStep(3)" style="padding:.6rem 2rem;font-size:.85rem">&#10003; Extraktion abgeschlossen &rarr; Weiter</button>
 </div>
-</div>
+</div><!-- /.tp ext-full -->
 
-<!-- ===== STEP 5: ENRICHMENT ===== -->
-<div class="step-panel" data-step="5">
-<h2>Schritt 5: Anreicherung</h2>
+</div><!-- /.step-panel Phase 3 -->
+
+<!-- ===== PHASE 4: ANREICHERUNG ===== -->
+<div class="step-panel" data-step="4">
+<h2>Phase 4: Anreicherung</h2>
 <p style="font-size:.78rem;color:#666;margin-bottom:1rem">Reichere erkannte Entit&auml;ten mit Normdaten (Wikidata, GND, GeoNames) an.</p>
 
 <div class="g2"><div class="sb">
@@ -463,13 +589,13 @@
 </div>
 
 <div style="margin-top:1rem;text-align:center">
-<button class="btn" onclick="completeStep(5)" style="padding:.6rem 2rem">&#10003; Anreicherung abgeschlossen &mdash; Weiter</button>
+<button class="btn" onclick="completeStep(4)" style="padding:.6rem 2rem">&#10003; Anreicherung abgeschlossen &rarr; Weiter</button>
 </div>
 </div>
 
-<!-- ===== STEP 6: DICTIONARY ===== -->
-<div class="step-panel" data-step="6">
-<h2>Schritt 6: W&ouml;rterbuch &amp; JSON-Dictionary</h2>
+<!-- ===== PHASE 5: WÖRTERBUCH ===== -->
+<div class="step-panel" data-step="5">
+<h2>Phase 5: W&ouml;rterbuch &amp; JSON-Dictionary</h2>
 <p style="font-size:.78rem;color:#666;margin-bottom:1rem">Kuratierte W&ouml;rterbucheintr&auml;ge als JSON-Dictionary rendern mit standardisierten Feldern.</p>
 
 <div class="g2"><div class="sb">
@@ -516,13 +642,13 @@
 </div>
 
 <div style="margin-top:1rem;text-align:center">
-<button class="btn" onclick="completeStep(6)" style="padding:.6rem 2rem">&#10003; W&ouml;rterbuch fertig &mdash; Weiter zu Export</button>
+<button class="btn" onclick="completeStep(5)" style="padding:.6rem 2rem">&#10003; W&ouml;rterbuch fertig &rarr; Export</button>
 </div>
 </div>
 
-<!-- ===== STEP 7: METADATA ENRICHMENT & EXPORT ===== -->
-<div class="step-panel" data-step="7">
-<h2>Schritt 7: Metadaten-Anreicherung &amp; Export</h2>
+<!-- ===== PHASE 6: EXPORT (always accessible) ===== -->
+<div class="step-panel" data-step="6">
+<h2>Phase 6: Metadaten-Anreicherung &amp; Export</h2>
 <p style="font-size:.78rem;color:#666;margin-bottom:1rem">Wende kuratierte W&ouml;rterbucheintr&auml;ge auf die Original-Metadaten an und exportiere die angereicherten Ergebnisse.</p>
 
 <div class="c" style="margin-bottom:1rem">

--- a/src/kwb/api/parts/dashboard.css
+++ b/src/kwb/api/parts/dashboard.css
@@ -173,3 +173,66 @@ th.sortable{cursor:pointer;white-space:nowrap}th.sortable:hover{color:var(--ac)}
 .pdf-status-err{background:#fee2e2;color:#8b0000;font-size:.58rem;font-weight:700;text-transform:uppercase;padding:.1rem .3rem;border-radius:10px;flex-shrink:0}
 /* Structured JSON output viewer */
 .json-out{background:#1e1e2e;color:#cdd6f4;font-family:'Courier New',monospace;font-size:.65rem;border-radius:var(--r);padding:.75rem;max-height:300px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;border:1px solid var(--brd);margin-top:.4rem}
+/* Phase Navigator: no-data state (data not loaded yet) */
+.step.no-data{opacity:.5;cursor:not-allowed}
+.step.no-data:hover{border-color:var(--brd);color:#888}
+/* Phase 6 (Export) always accessible */
+.step[data-step="6"].no-data{opacity:1;cursor:pointer}
+/* Material context selector bar */
+.mat-ctx-bar{display:flex;gap:.4rem;align-items:center;flex-wrap:wrap;padding:.45rem 0 .55rem;margin-bottom:.6rem;border-bottom:1px solid var(--brd)}
+.mat-ctx-pill{padding:.22rem .65rem;border:1px solid var(--brd);border-radius:20px;font-size:.72rem;cursor:pointer;transition:.15s;background:#fff;user-select:none}
+.mat-ctx-pill:hover{border-color:var(--ac)}
+.mat-ctx-pill.active{background:var(--ink);color:#fff;border-color:var(--ink)}
+/* Material-adaptive workspace */
+.mat-workspace{display:grid;gap:1rem;margin-bottom:1rem}
+.mat-section{display:none;flex-direction:column;gap:.6rem}
+/* table/CSV context: full width */
+.mat-workspace.mat-ctx-table{grid-template-columns:1fr}
+.mat-workspace.mat-ctx-table .mat-section[data-ctx="table"]{display:flex}
+/* images context: 25 sidebar + 75 main */
+.mat-workspace.mat-ctx-images{grid-template-columns:minmax(240px,1fr) 3fr}
+.mat-workspace.mat-ctx-images .mat-section[data-ctx="table"]{display:flex}
+.mat-workspace.mat-ctx-images .mat-section[data-ctx="images"]{display:flex}
+/* pdf context: 50/50 */
+.mat-workspace.mat-ctx-pdf{grid-template-columns:1fr 1fr}
+.mat-workspace.mat-ctx-pdf .mat-section[data-ctx="table"]{display:flex}
+.mat-workspace.mat-ctx-pdf .mat-section[data-ctx="pdf"]{display:flex}
+/* mixed: all three */
+.mat-workspace.mat-ctx-mixed{grid-template-columns:repeat(3,1fr)}
+.mat-workspace.mat-ctx-mixed .mat-section{display:flex}
+@media(max-width:1100px){
+  .mat-workspace.mat-ctx-mixed{grid-template-columns:1fr 1fr}
+  .mat-workspace.mat-ctx-images{grid-template-columns:1fr 2fr}
+}
+@media(max-width:700px){
+  .mat-workspace.mat-ctx-mixed,.mat-workspace.mat-ctx-images,.mat-workspace.mat-ctx-pdf{grid-template-columns:1fr}
+  .mat-workspace .mat-section{display:flex!important}
+}
+/* Review queue items */
+.rev-item{border:1px solid var(--brd);border-radius:var(--r);padding:.5rem .7rem;margin-bottom:.4rem;background:#fff;box-shadow:0 1px 2px var(--shd)}
+.rev-item-hdr{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-bottom:.2rem}
+.rev-item-msg{font-size:.75rem;color:var(--ink);flex:1;min-width:0}
+.rev-item-meta{font-size:.65rem;color:#888;display:flex;gap:.5rem;flex-wrap:wrap}
+.rev-item-actions{display:flex;gap:.3rem;margin-top:.3rem;flex-wrap:wrap}
+/* Review status pills */
+.rev-st{font-size:.6rem;font-weight:700;text-transform:uppercase;padding:.13rem .38rem;border-radius:10px;flex-shrink:0}
+.rev-st-pending{background:#f3f4f6;color:#6b7280}
+.rev-st-accepted{background:#dcfce7;color:var(--ok)}
+.rev-st-rejected{background:#fee2e2;color:var(--crit)}
+.rev-st-needs_expert_review{background:#fef3c7;color:var(--warn)}
+.rev-st-applied{background:#dbeafe;color:#1d4ed8}
+/* Work package cards */
+.wp-card{border:1px solid var(--brd);border-radius:var(--r);padding:.6rem .8rem;margin-bottom:.5rem;background:#fff;box-shadow:0 1px 3px var(--shd)}
+.wp-card-hdr{display:flex;align-items:flex-start;gap:.5rem;margin-bottom:.3rem}
+.wp-card-title{font-size:.82rem;font-weight:600;flex:1}
+.wp-card-badges{display:flex;gap:.3rem;flex-shrink:0;flex-wrap:wrap}
+.wp-card-meta{font-size:.68rem;color:#666;margin-bottom:.3rem}
+.wp-card-strategy{font-size:.73rem;color:#555;background:var(--pw);padding:.3rem .5rem;border-radius:var(--r)}
+.wp-prio-critical{background:#fee2e2;color:var(--crit);font-size:.6rem;font-weight:700;padding:.13rem .38rem;border-radius:3px}
+.wp-prio-high{background:#fef3c7;color:var(--warn);font-size:.6rem;font-weight:700;padding:.13rem .38rem;border-radius:3px}
+.wp-prio-medium{background:#e0e7ff;color:#3730a3;font-size:.6rem;font-weight:700;padding:.13rem .38rem;border-radius:3px}
+.wp-prio-low{background:#f3f4f6;color:#6b7280;font-size:.6rem;font-weight:700;padding:.13rem .38rem;border-radius:3px}
+.wp-auto{font-size:.6rem;padding:.13rem .38rem;border-radius:3px}
+.wp-auto-high{background:#dcfce7;color:var(--ok)}
+.wp-auto-medium{background:#fef3c7;color:var(--warn)}
+.wp-auto-low{background:#f3f4f6;color:#888}

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -74,19 +74,20 @@ function safeOpt(val,label){return '<option value="'+esc(val)+'">'+esc(label)+'<
 function dl(name,content,type){const b=new Blob([content],{type});const a=document.createElement('a');a.href=URL.createObjectURL(b);a.download=name;a.click()}
 function encPath(v){return encodeURIComponent(String(v==null?'':v))}
 
-// === NAV (Pipeline Stepper) ===
+// === NAV (Phase Navigator — 6 non-blocking phases) ===
 let currentStep=1;
-let stepStates={1:'active',2:'locked',3:'locked',4:'locked',5:'locked',6:'locked',7:'locked'};
+// Phases 2-5 start as 'no-data' (unlocked once data is loaded); Phase 6 always accessible
+let stepStates={1:'active',2:'no-data',3:'no-data',4:'no-data',5:'no-data',6:'pending'};
 
 function goStep(n){
-  if(stepStates[n]==='locked'){return;}
+  if(stepStates[n]==='no-data'){return;}
   currentStep=n;
   // Update step indicators
   document.querySelectorAll('.stepper .step').forEach(el=>{
     const s=parseInt(el.dataset.step);
     if(s===n)el.className='step active';
     else if(stepStates[s]==='completed')el.className='step completed';
-    else if(stepStates[s]==='locked')el.className='step locked';
+    else if(stepStates[s]==='no-data')el.className='step no-data';
     else el.className='step';
   });
   // Update connectors
@@ -97,35 +98,42 @@ function goStep(n){
   document.querySelectorAll('.step-panel').forEach(p=>{
     p.classList.toggle('active',parseInt(p.dataset.step)===n);
   });
-  // Load data for specific steps
+  // Load data for specific phases
   try{
-    if(n===5){loadAuthorityCandidates();}
-    if(n===6){loadDictEntries();loadDictTypes();}
-    if(n===7){loadFMCols();}
+    if(n===2){loadRevSummary();loadWorkPackages();}
+    if(n===4){loadAuthorityCandidates();}
+    if(n===5){loadDictEntries();loadDictTypes();}
+    if(n===6){loadFMCols();}
   }catch(e){console.error('[goStep:'+n+']',e)}
 }
 
 function unlockStep(n){
-  if(stepStates[n]==='locked')stepStates[n]='pending';
+  if(stepStates[n]==='no-data')stepStates[n]='pending';
+  updateStepperUI();
+}
+
+/** Unlock all phases (2-5) once data is loaded. Phase 6 is always accessible. */
+function unlockAllPhases(){
+  for(let i=2;i<=5;i++){if(stepStates[i]==='no-data')stepStates[i]='pending';}
   updateStepperUI();
 }
 
 function completeStep(n){
   stepStates[n]='completed';
-  // Unlock next step
-  if(n<7)unlockStep(n+1);
+  // Suggest next phase
+  if(n<6)unlockStep(n+1);
   updateStepperUI();
   // Notify backend
   fetch('/api/pipeline/step/'+n+'/complete',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'}).catch(()=>{});
   // Auto-advance
-  if(n<7)goStep(n+1);
+  if(n<6)goStep(n+1);
 }
 
 function updateStepperUI(){
   document.querySelectorAll('.stepper .step').forEach(el=>{
     const s=parseInt(el.dataset.step);
     const state=stepStates[s];
-    el.className='step'+(s===currentStep?' active':'')+(state==='completed'?' completed':'')+(state==='locked'?' locked':'');
+    el.className='step'+(s===currentStep?' active':'')+(state==='completed'?' completed':'')+(state==='no-data'?' no-data':'');
   });
   document.querySelectorAll('.step-conn').forEach((conn,i)=>{
     conn.classList.toggle('done',stepStates[i+1]==='completed');
@@ -172,7 +180,7 @@ async function runPilotImages(){
   }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp();}
 }
 
-// Quality gateway: mark test as reviewed
+// Quality gateway: mark test as reviewed (Phase 3 sub-tab)
 function markTestReviewed(){
   completeStep(3);
 }
@@ -223,13 +231,13 @@ async function loadStepStates(){
     steps.forEach(s=>{
       if(s.completed)stepStates[s.number]='completed';
       else if(s.active||s.number===1)stepStates[s.number]='active';
-      // Unlock step if previous is completed
-      if(s.number>1&&stepStates[s.number-1]==='completed'&&stepStates[s.number]==='locked')stepStates[s.number]='pending';
+      // Unlock if previous is completed
+      if(s.number>1&&stepStates[s.number-1]==='completed'&&stepStates[s.number]==='no-data')stepStates[s.number]='pending';
     });
     updateStepperUI();
   }catch(e){
-    // Default: step 1 active, rest locked
-    stepStates={1:'active',2:'locked',3:'locked',4:'locked',5:'locked',6:'locked',7:'locked'};
+    // Default: phase 1 active, 2-5 no-data, 6 accessible
+    stepStates={1:'active',2:'no-data',3:'no-data',4:'no-data',5:'no-data',6:'pending'};
   }
 }
 
@@ -911,8 +919,8 @@ function rrep(d){
   if($('llmq-placeholder'))$('llmq-placeholder').style.display='block';
   if($('llmq-result'))$('llmq-result').style.display='none';
   if($('llmq-run-status'))$('llmq-run-status').textContent='';
-  // Unlock step 2 since analysis is done
-  unlockStep(2);
+  // Unlock all phases since data is now loaded
+  unlockAllPhases();
 }
 function ff(f,b){document.querySelectorAll('#fbar .fb2').forEach(x=>x.classList.remove('a'));if(b)b.classList.add('a');rfnd(f==='all'?(curRep?.findings||[]):(curRep?.findings||[]).filter(x=>x.severity===f))}
 function rfnd(fs){if(!fs.length){$('flist').textContent='Keine Findings.';return}
@@ -2378,3 +2386,311 @@ function showInitError(label){const b=document.createElement('div');b.style.cssT
   try{loadCustomMdsFields()}catch(err){console.error('[init] mdsFields',err);failed.push('mdsFields')}
   if(failed.length)showInitError(failed.join(', '));
 })();
+
+// ============================================================
+// PHASE 2 — BEREINIGUNG: Material Context + Review Queue
+// ============================================================
+
+// --- Material context detection ---
+let currentMatCtx='table';
+
+function detectMatCtx(files){
+  const exts=[...files].map(f=>f.name.toLowerCase().replace(/^.*\./,''));
+  const hasTable=exts.some(e=>['csv','tsv','xlsx','xls','xml'].includes(e));
+  const hasImg=exts.some(e=>['jpg','jpeg','png','tif','tiff','webp','img'].includes(e));
+  const hasPdf=exts.some(e=>e==='pdf');
+  const count=[hasTable,hasImg,hasPdf].filter(Boolean).length;
+  if(count>1)return'mixed';
+  if(hasImg)return'images';
+  if(hasPdf)return'pdf';
+  return'table';
+}
+
+function setMatCtx(ctx){
+  currentMatCtx=ctx;
+  const ws=$('mat-workspace');
+  if(!ws)return;
+  ws.className='mat-workspace mat-ctx-'+ctx;
+  document.querySelectorAll('.mat-ctx-pill').forEach(p=>{
+    p.classList.toggle('active',p.dataset.ctx===ctx);
+  });
+}
+
+/** Called after file selection — auto-detect material type and update workspace layout. */
+function detectAndSetMatCtx(files){
+  if(!files||!files.length)return;
+  const ctx=detectMatCtx(files);
+  setMatCtx(ctx);
+  const hint=$('mat-auto-hint');
+  if(hint)hint.style.display='inline';
+}
+
+// --- Phase 2 state ---
+let revItems=[],revFilters={status:'',severity:'',category:''};
+let revWorkPackages=[],revSuggestions=[],revChangelog=[];
+
+// --- Summary ---
+async function loadRevSummary(){
+  try{
+    const r=await fetch('/api/review/items/summary');
+    if(!r.ok)return;
+    const d=await r.json();
+    const el=$('rev-summary-bar');
+    if(!el)return;
+    const total=d.total||0;
+    const bs=d.by_status||{};
+    const bsv=d.by_severity||{};
+    el.innerHTML='<div class="mt"><div class="v">'+total+'</div><div class="l">Gesamt</div></div>'+
+      Object.entries(bs).map(([k,v])=>'<div class="mt'+(k==='accepted'?' su':k==='rejected'?' cr':k==='needs_expert_review'?' wr':'')+'"><div class="v">'+v+'</div><div class="l">'+esc(k)+'</div></div>').join('')+
+      Object.entries(bsv).filter(([k])=>k!=='info').map(([k,v])=>'<div class="mt'+(k==='critical'?' cr':k==='warning'?' wr':'')+'"><div class="v">'+v+'</div><div class="l">'+esc(k)+'</div></div>').join('');
+  }catch(e){console.error('[loadRevSummary]',e);}
+}
+
+async function buildRevQueue(){
+  const src=$('rev-source')?$('rev-source').value:'';
+  const aiB=$('rev-is-ai')?$('rev-is-ai').checked:false;
+  sp('Review-Queue aufbauen \u2026');
+  try{
+    const r=await fetch('/api/review/queue/build',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({source:src,is_ai_based:aiB})});
+    const d=await r.json();
+    if(d.error){alert(d.error);return;}
+    const el=$('rev-build-status');
+    if(el)el.textContent='\u2713 '+(d.items_created||0)+' Items erstellt';
+    loadRevSummary();
+    loadRevItems();
+  }catch(e){alert('Fehler: '+e.message);}
+  finally{hp();}
+}
+
+async function generateWorkPackages(){
+  sp('Arbeitspakete generieren \u2026');
+  try{
+    const r=await fetch('/api/review/work-packages/generate',{method:'POST',headers:{'Content-Type':'application/json'},body:'{}'});
+    const d=await r.json();
+    if(d.error){alert(d.error);return;}
+    const el=$('rev-wp-status');
+    if(el)el.textContent='\u2713 '+(d.packages_created||0)+' Pakete erstellt';
+    loadWorkPackages();
+  }catch(e){alert('Fehler: '+e.message);}
+  finally{hp();}
+}
+
+// --- Review Items ---
+async function loadRevItems(){
+  try{
+    const p=new URLSearchParams();
+    if(revFilters.status)p.set('status',revFilters.status);
+    if(revFilters.severity)p.set('severity',revFilters.severity);
+    if(revFilters.category)p.set('category',revFilters.category);
+    p.set('limit','100');
+    const r=await fetch('/api/review/items?'+p);
+    if(!r.ok)return;
+    const d=await r.json();
+    revItems=d.items||[];
+    renderRevItems();
+    const el=$('rev-items-count');
+    if(el)el.textContent='('+(d.total||revItems.length)+')';
+  }catch(e){console.error('[loadRevItems]',e);}
+}
+
+function renderRevItems(){
+  const el=$('rev-items-list');
+  if(!el)return;
+  if(!revItems.length){el.innerHTML='<div class="em" style="font-size:.78rem">Keine Items. Queue aufbauen oder Laden klicken.</div>';return;}
+  el.innerHTML=revItems.map(item=>{
+    const sev=item.severity||'info';
+    const st=item.status||'pending';
+    return '<div class="rev-item">'+
+      '<div class="rev-item-hdr">'+
+        '<span class="sv '+esc(sev)+'">'+esc(sev)+'</span>'+
+        '<span class="rev-st rev-st-'+esc(st)+'">'+esc(st)+'</span>'+
+        (item.column?'<span style="font-size:.68rem;background:#f5f5f4;padding:.1rem .3rem;border-radius:3px">'+esc(item.column)+'</span>':'')+
+        '<span class="rev-item-msg">'+esc(item.message||'')+'</span>'+
+      '</div>'+
+      (item.reasoning?'<div style="font-size:.68rem;color:#666;margin-bottom:.15rem">'+esc(item.reasoning)+'</div>':'')+
+      '<div class="rev-item-meta">'+
+        (item.record_id?'Record: '+esc(item.record_id)+' \u00b7 ':'')+
+        esc(item.category||'')+
+        (item.confidence!=null?' \u00b7 '+Math.round(item.confidence*100)+'%':'')+
+      '</div>'+
+      '<div class="rev-item-actions">'+
+        '<button class="btn sm" onclick="setRevStatus(\''+esc(item.item_id)+'\',\'accepted\')">&#10003; Akzeptieren</button>'+
+        '<button class="btn sm s" onclick="setRevStatus(\''+esc(item.item_id)+'\',\'rejected\')" style="background:#888">&#10007; Ablehnen</button>'+
+        '<button class="btn sm s" onclick="setRevStatus(\''+esc(item.item_id)+'\',\'needs_expert_review\')" style="background:var(--warn)">? Experte</button>'+
+      '</div>'+
+    '</div>';
+  }).join('');
+}
+
+async function setRevStatus(itemId,status){
+  try{
+    const r=await fetch('/api/review/items/'+encodeURIComponent(itemId)+'/status',{
+      method:'PATCH',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({status,reviewer:'curator'})
+    });
+    if(!r.ok){alert('Fehler beim Update');return;}
+    const item=revItems.find(i=>i.item_id===itemId);
+    if(item)item.status=status;
+    renderRevItems();
+    loadRevSummary();
+  }catch(e){alert('Fehler: '+e.message);}
+}
+
+async function batchRevStatus(status){
+  const visible=revItems.filter(i=>!revFilters.status||i.status===revFilters.status);
+  for(const item of visible){if(item.status!==status)await setRevStatus(item.item_id,status);}
+}
+
+function filterRevQueue(field,val,btn){
+  revFilters[field]=revFilters[field]===val?'':val;
+  const bar=$('rev-filter-'+field);
+  if(bar)bar.querySelectorAll('.fb2').forEach(p=>p.classList.toggle('a',p.dataset.val===(revFilters[field]||'')));
+  loadRevItems();
+}
+
+// --- Work Packages ---
+async function loadWorkPackages(){
+  try{
+    const r=await fetch('/api/review/work-packages');
+    if(!r.ok)return;
+    const d=await r.json();
+    revWorkPackages=d.packages||[];
+    renderWorkPackages();
+    const el=$('rev-wp-count');
+    if(el)el.textContent='('+revWorkPackages.length+')';
+  }catch(e){console.error('[loadWorkPackages]',e);}
+}
+
+function renderWorkPackages(){
+  const el=$('rev-wp-list');
+  if(!el)return;
+  if(!revWorkPackages.length){el.innerHTML='<div class="em" style="font-size:.78rem">Keine Arbeitspakete. Zuerst generieren.</div>';return;}
+  el.innerHTML=revWorkPackages.map(wp=>{
+    const prio=wp.priority||'medium';
+    const auto=wp.automation_potential||'low';
+    return '<div class="wp-card">'+
+      '<div class="wp-card-hdr">'+
+        '<div class="wp-card-title">'+esc(wp.title||'')+'</div>'+
+        '<div class="wp-card-badges">'+
+          '<span class="wp-prio-'+esc(prio)+'">'+esc(prio.toUpperCase())+'</span>'+
+          '<span class="wp-auto wp-auto-'+esc(auto)+'">Auto: '+esc(auto)+'</span>'+
+        '</div>'+
+      '</div>'+
+      '<div class="wp-card-meta">'+esc(wp.description||'')+
+        (wp.affected_columns&&wp.affected_columns.length?' \u00b7 Spalten: '+esc(wp.affected_columns.join(', ')):'')+(wp.estimated_records?' \u00b7 ~'+wp.estimated_records+' Datens\u00e4tze':'')+
+      '</div>'+
+      (wp.recommended_strategy?'<div class="wp-card-strategy">'+esc(wp.recommended_strategy)+'</div>':'')+
+    '</div>';
+  }).join('');
+}
+
+// --- Suggestions ---
+async function loadRevSuggestions(){
+  try{
+    const r=await fetch('/api/review/suggestions');
+    if(!r.ok)return;
+    const d=await r.json();
+    revSuggestions=d.suggestions||[];
+    renderRevSuggestions();
+    const el=$('rev-sug-count');
+    if(el)el.textContent='('+revSuggestions.length+')';
+  }catch(e){console.error('[loadRevSuggestions]',e);}
+}
+
+function renderRevSuggestions(){
+  const el=$('rev-sug-list');
+  if(!el)return;
+  if(!revSuggestions.length){el.innerHTML='<div class="em" style="font-size:.78rem">Keine Vorschl\u00e4ge.</div>';return;}
+  el.innerHTML=revSuggestions.map(s=>{
+    const st=s.status||'pending';
+    return '<div class="rev-item">'+
+      '<div class="rev-item-hdr">'+
+        '<span class="rev-st rev-st-'+esc(st)+'">'+esc(st)+'</span>'+
+        '<span style="font-size:.73rem;font-weight:600">'+esc(s.action_type||'')+'</span>'+
+      '</div>'+
+      '<div style="font-size:.73rem;margin:.15rem 0">'+
+        '<strong>Original:</strong> '+esc(s.original_value||'\u2014')+
+        (s.suggested_value?' \u2192 <strong>'+esc(s.suggested_value)+'</strong>':'')+
+      '</div>'+
+      (s.reasoning?'<div style="font-size:.68rem;color:#666">'+esc(s.reasoning)+'</div>':'')+
+      '<div class="rev-item-actions">'+
+        '<button class="btn sm" onclick="setSugStatus(\''+esc(s.suggestion_id)+'\',\'accepted\')">&#10003; Akzeptieren</button>'+
+        '<button class="btn sm s" onclick="setSugStatus(\''+esc(s.suggestion_id)+'\',\'rejected\')" style="background:#888">&#10007; Ablehnen</button>'+
+      '</div>'+
+    '</div>';
+  }).join('');
+}
+
+async function setSugStatus(sugId,status){
+  try{
+    const r=await fetch('/api/review/suggestions/'+encodeURIComponent(sugId)+'/status',{
+      method:'PATCH',headers:{'Content-Type':'application/json'},body:JSON.stringify({status})
+    });
+    if(!r.ok){alert('Fehler beim Update');return;}
+    await loadRevSuggestions();
+  }catch(e){alert('Fehler: '+e.message);}
+}
+
+async function revApplyChanges(dryRun){
+  sp(dryRun?'Vorschau \u2026':'Änderungen anwenden \u2026');
+  try{
+    const dsId=$('rev-apply-ds')?$('rev-apply-ds').value:'';
+    const body={dry_run:!!dryRun,reviewer:'curator'};
+    if(dsId)body.dataset_id=dsId;
+    const r=await fetch('/api/review/apply',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+    const d=await r.json();
+    if(d.error){alert(d.error);return;}
+    const el=$('rev-apply-status');
+    if(el)el.textContent=(dryRun?'Vorschau: ':'\u2713 Angewendet: ')+(d.changes_applied||d.changes_preview||0)+' \u00c4nderungen';
+    if(!dryRun){loadRevChangelog();populateDS();}
+  }catch(e){alert('Fehler: '+e.message);}
+  finally{hp();}
+}
+
+// --- Changelog ---
+async function loadRevChangelog(){
+  try{
+    const r=await fetch('/api/review/changelog');
+    if(!r.ok)return;
+    const d=await r.json();
+    revChangelog=d.changelog||[];
+    renderRevChangelog();
+    const el=$('rev-log-count');
+    if(el)el.textContent='('+revChangelog.length+')';
+  }catch(e){console.error('[loadRevChangelog]',e);}
+}
+
+function renderRevChangelog(){
+  const el=$('rev-log-body');
+  if(!el)return;
+  const empty=$('rev-log-empty');
+  if(!revChangelog.length){if(empty)empty.style.display='block';el.innerHTML='';return;}
+  if(empty)empty.style.display='none';
+  el.innerHTML=revChangelog.map(c=>'<tr>'+
+    '<td>'+esc(c.record_id||'\u2014')+'</td>'+
+    '<td>'+esc(c.column||'\u2014')+'</td>'+
+    '<td style="font-family:monospace">'+esc(c.original_value||'')+'</td>'+
+    '<td style="font-family:monospace;color:var(--ok)">'+esc(c.new_value||'')+'</td>'+
+    '<td>'+esc(c.action_type||'')+'</td>'+
+    '<td style="font-size:.65rem">'+esc((c.applied_at||'').replace('T',' ').slice(0,16))+'</td>'+
+  '</tr>').join('');
+}
+
+async function exportRevStatus(){
+  try{
+    const r=await fetch('/api/review/export');
+    if(!r.ok)return;
+    const d=await r.json();
+    dl('review-export.json',JSON.stringify(d,null,2),'application/json');
+  }catch(e){alert('Export-Fehler: '+e.message);}
+}
+
+// Populate rev-apply-ds with loaded datasets
+function populateRevApplyDs(){
+  const sel=$('rev-apply-ds');
+  if(!sel)return;
+  const ds=Object.keys(ufiles).length?Object.values(ufiles).map(f=>f.uploadName):[];
+  // Also check loaded dataset names from state
+  const existing=new Set([...sel.options].map(o=>o.value).filter(Boolean));
+  ds.forEach(name=>{if(!existing.has(name)){const o=document.createElement('option');o.value=name;o.textContent=name;sel.appendChild(o);}});
+}


### PR DESCRIPTION
Schließt #90.

## Zusammenfassung

Vollständige Implementierung von Phase 3 (Backend + Frontend) aus Issue #90, inklusive Neugestaltung der Werkbank-Navigation und materialadaptivem GUI.

---

## Backend: Phase 3 — Review-Queues & Work-Package-Generierung

### Neue Datenmodelle (`src/kwb/core/models.py`)
- `ReviewStatus` (pending / accepted / rejected / needs_expert_review / applied)
- `RemediationActionType` (6 Aktionstypen)
- `ReviewItem`, `ReviewDecision`, `WorkPackage`, `RemediationSuggestion`, `AppliedChangeLog`

### Neues Package `src/kwb/review/`
- **`queue.py`** — `ReviewQueue`: Aufbau aus `QualityAnalysisReport`, Status-Updates, Filter, Summary
- **`work_packages.py`** — `generate_work_packages()`: Issue-Cluster → priorisierte Arbeitspakete mit Automatisierungspotenzial
- **`remediation.py`** — `apply_accepted_changes()`: Wendet akzeptierte Vorschläge auf DataFrame an, liefert `AppliedChangeLog`

### 12 neue API-Endpunkte (`src/kwb/api/routes/review.py`)
```
GET  /api/review/items           — Liste mit Filtern (severity, status, column …)
GET  /api/review/items/summary   — Zähler nach Status/Schwere/Kategorie
PATCH /api/review/items/{id}/status
GET  /api/review/work-packages
POST /api/review/work-packages/generate
POST /api/review/queue/build
GET  /api/review/suggestions
POST /api/review/suggestions
PATCH /api/review/suggestions/{id}/status
POST /api/review/apply           — dry_run unterstützt
GET  /api/review/changelog
GET  /api/review/export
```

### Tests (`tests/test_review.py`)
54 neue Tests, 836 gesamt — alle grün.

---

## Frontend A: Phase Navigator (6 nicht-blockierende Phasen)

Ersetzt den 7-stufigen gesperrten Stepper durch 6 frei zugängliche Phasen:

| Phase | Label | Basis |
|---|---|---|
| 1 | Upload & Analyse | unveränderter Step 1 |
| 2 | Bereinigung | **neu** |
| 3 | Extraktion | alte Steps 2+3+4 (Tabs) |
| 4 | Anreicherung | alter Step 5 |
| 5 | Wörterbuch | alter Step 6 |
| 6 | Export | alter Step 7, **immer erreichbar** |

- Phasen 2–5 starten als `no-data`; `unlockAllPhases()` entsperrt alle nach der ersten Strukturanalyse
- Phase 6 (Export) nie gesperrt
- `completeStep()` schlägt nächste Phase vor, erzwingt aber keinen Übergang

### Phase 2 Bereinigung — 5 Tabs
Vollständig verdrahtet mit allen 12 `/api/review/*` Endpunkten:
- **Überblick**: Status-Metriken, Queue aufbauen, Arbeitspakete generieren
- **Review-Queue**: Items mit Status-/Schwere-Filtern, Akzeptieren/Ablehnen/Experte je Item, Batch-Aktionen
- **Arbeitspakete**: Karten mit Priorität, Automatisierungspotenzial, empfohlener Strategie
- **Vorschläge**: Liste + Anwenden (dry run / live) mit Datensatz-Selektor
- **Protokoll**: Änderungsprotokoll-Tabelle

---

## Frontend B: Materialadaptiver Arbeitsbereich

Ersetzt das statische `.three-pane` durch `.mat-workspace`:

| Kontext | Layout | Anwendungsfall |
|---|---|---|
| `table` (Standard) | volle Breite | nur CSV/XLSX |
| `images` | 25 % / 75 % | Metadaten-Sidebar + großer Bildbereich |
| `pdf` | 50 / 50 | Metadaten + PDF nebeneinander |
| `mixed` | 3 Spalten | alle Materialarten |

- `detectMatCtx(files)` erkennt Materialart automatisch aus Dateiendungen
- Pill-Leiste für manuelle Umschaltung
- Responsive Breakpoints für 1100 px / 700 px

---

## Test plan
- [ ] Strukturanalyse starten → alle Phasen 2–5 entsperren sich
- [ ] Phase 6 (Export) ist von Anfang an klickbar
- [ ] Phase 2: Queue aufbauen → Items erscheinen in Review-Queue-Tab
- [ ] Review-Item akzeptieren/ablehnen → Statusänderung sofort sichtbar
- [ ] Arbeitspakete generieren → Karten mit Priorität/Automatisierung
- [ ] CSV hochladen → Workspace wechselt automatisch zu `ctx-table`
- [ ] Bild-Dateien hochladen → 25/75-Layout aktiviert
- [ ] Manueller Kontext-Wechsel via Pill-Leiste funktioniert
- [ ] Phase 3: Tabs NER/Bilder/PDF | Testlauf-Review | Gesamtlauf alle erreichbar
- [ ] `POST /api/review/apply` mit `dry_run=true` zeigt Vorschau ohne Änderung

https://claude.ai/code/session_01MeQDE7vXzg7QEwQFHF8ja9