### PR TITLE
feat: Bilder-Galerie (C96) + PDF-Arbeitsfläche (C97)

### DIFF
--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -132,11 +132,15 @@
 </div>
 </div>
 
-<!-- Section: Images (JPG / PNG / TIFF / WEBP) -->
+<!-- Section: Images (JPG / PNG / TIFF / WEBP) — gallery workspace -->
 <div class="mat-section" data-ctx="images">
-<div class="pane-hdr">&#128248; Bilder</div>
+<div class="pane-hdr">&#128248; Bilder-Arbeitsfläche</div>
+<div class="ig-workspace">
+
+<!-- Sidebar (25 %) -->
+<div class="ig-sidebar">
 <div class="c">
-<h3>Bilder hochladen</h3>
+<h3>Hochladen</h3>
 <label>Einzelne Dateien</label>
 <input type="file" id="img-files-p1" multiple accept=".jpg,.jpeg,.png,.tif,.tiff,.webp,.img" style="font-size:.75rem;width:100%">
 <label>Ordner <span style="font-weight:400;color:#888">(inkl. Unterordner)</span></label>
@@ -145,9 +149,77 @@
 <div id="img-upload-status-p1" class="em" style="margin-top:.4rem;font-size:.73rem"></div>
 </div>
 <div class="c" id="img-pane1-info" style="display:none">
-<h3>Hochgeladene Bilder <span id="img-pane1-count" style="font-size:.7rem;color:#888"></span></h3>
-<div id="img-pane1-list" style="max-height:200px;overflow-y:auto"></div>
+<h3>Hochgeladen <span id="img-pane1-count" style="font-size:.7rem;color:#888"></span></h3>
+<div id="img-pane1-list" style="max-height:160px;overflow-y:auto"></div>
 </div>
+<div class="c">
+<h3>Filter &amp; Ansicht</h3>
+<label style="margin-bottom:.3rem;display:block">Status</label>
+<div id="img-filters" class="fl" style="gap:.3rem;flex-wrap:wrap">
+<div class="fb2 a" onclick="setImgFilter('all',this)">Alle</div>
+<div class="fb2" onclick="setImgFilter('pending',this)">Offen</div>
+<div class="fb2" onclick="setImgFilter('accepted',this)">Freigegeben</div>
+<div class="fb2" onclick="setImgFilter('rejected',this)">Verworfen</div>
+<div class="fb2" onclick="setImgFilter('tiny',this)">Kleine</div>
+<div class="fb2" onclick="setImgFilter('dup',this)">Duplikate</div>
+<div class="fb2" onclick="setImgFilter('no_analysis',this)">Ohne Analyse</div>
+</div>
+<label style="margin:.5rem 0 .3rem;display:block">Kachelgr&ouml;&szlig;e</label>
+<div class="ig-density">
+<button id="igd-s" onclick="setGalleryDensity('s')">S</button>
+<button id="igd-m" class="active" onclick="setGalleryDensity('m')">M</button>
+<button id="igd-l" onclick="setGalleryDensity('l')">L</button>
+</div>
+</div>
+<div class="c">
+<h3>KI-Analyse</h3>
+<label>Modell</label>
+<select id="img-model-sidebar" class="sel" style="width:100%"><option value="">Standard (aus Konfiguration)</option></select>
+<label>Aufgabe</label>
+<select id="img-task-sidebar" class="sel" style="width:100%">
+<option value="image_description">Bildbeschreibung / Alt-Text</option>
+<option value="person_face_visibility">Personen- / Gesichtssichtbarkeit</option>
+</select>
+<button class="btn f" onclick="analyzeImages()" style="margin-top:.4rem">&#128270; Alle analysieren</button>
+<button class="btn f" onclick="runOCR()" style="margin-top:.3rem">&#128196; OCR starten</button>
+<button class="btn sm" onclick="runPilotImages()" style="margin-top:.3rem">&#129514; 2%-Testlauf</button>
+<div id="img-full-status" style="font-size:.72rem;color:#555;margin-top:.4rem"></div>
+<div id="img-mock-hint" class="em" style="font-size:.73rem;color:#996600;display:none;margin-top:.3rem">Hinweis: Im Testdaten-Modus nur Beispieldaten.</div>
+</div>
+<div class="c">
+<h3>Massenbearbeitung</h3>
+<input type="text" id="img-bulk-reviewer" placeholder="Reviewer" style="width:100%;margin-bottom:.3rem">
+<input type="text" id="img-bulk-comment" placeholder="Kommentar" style="width:100%">
+<div style="display:flex;gap:.3rem;margin-top:.35rem;flex-wrap:wrap">
+<button class="btn sm" onclick="bulkReviewVisible('accepted')">&#10003; Best&auml;tigen</button>
+<button class="btn sm s" onclick="bulkReviewVisible('rejected')">&#10007; Verwerfen</button>
+</div>
+</div>
+</div><!-- /.ig-sidebar -->
+
+<!-- Gallery main (75 %) -->
+<div class="ig-main" id="ig-main">
+<div class="ig-gallery-col">
+<div class="ig-statusbar">
+<span id="img-gallery-count"></span>
+<span id="img-gallery-analyzed" style="margin-left:auto"></span>
+</div>
+<div id="img-list-empty" class="em" style="font-size:.78rem">Noch keine Bilder hochgeladen.</div>
+<div id="img-gallery" class="img-gallery ig-m"></div>
+</div>
+<div id="img-detail-panel" class="img-detail-panel">
+<div class="img-detail-hdr">
+<strong id="img-detail-name"></strong>
+<button class="btn sm s" onclick="closeImgDetail()" style="margin-left:auto;margin-top:0">&#215; Schlie&szlig;en</button>
+</div>
+<div style="padding:.5rem .6rem;flex:1;overflow-y:auto">
+<div id="img-detail-preview" style="text-align:center;margin-bottom:.5rem"></div>
+<div id="img-detail-body"></div>
+</div>
+</div>
+</div><!-- /.ig-main -->
+
+</div><!-- /.ig-workspace -->
 </div>
 
 <!-- Section: PDF-Dokumente -->
@@ -511,16 +583,12 @@
 <div>
 <div class="c">
 <h3>Bild-Testergebnisse</h3>
-<div id="img-mock-hint" class="em" style="font-size:.73rem;color:#996600;display:none;margin-bottom:.4rem">Hinweis: Im Testdaten-Modus nur Beispieldaten.</div>
-<select id="img-review-filter" style="width:170px;margin-bottom:.4rem" onchange="applyImageFilter()">
-<option value="all">Alle Status</option><option value="pending">pending</option><option value="accepted">accepted</option><option value="rejected">rejected</option>
-</select>
-<div id="img-results-empty" class="em" style="font-size:.78rem">Noch keine Ergebnisse.</div>
-<div id="img-results"></div>
-<div style="margin-top:.5rem;display:flex;gap:.3rem;flex-wrap:wrap">
-<button class="btn sm" onclick="bulkReviewVisible('accepted')">&#10003; Alle best&auml;tigen</button>
-<button class="btn sm s" onclick="bulkReviewVisible('rejected')">&#10007; Alle verwerfen</button>
-</div>
+<p style="font-size:.75rem;color:#666;margin-bottom:.4rem">Die Bild-Review-Galerie befindet sich in der <strong>Bilder-Arbeitsfläche</strong> (Kontextreiter &#128248; Bilder).</p>
+<button class="btn sm" onclick="setMatCtx('images')">&#128248; Zur Bilder-Galerie wechseln</button>
+<!-- Legacy containers kept for JS backward-compat -->
+<div id="img-results-empty" style="display:none"></div>
+<div id="img-results" style="display:none"></div>
+<select id="img-review-filter" style="display:none"><option value="all">all</option><option value="pending">pending</option><option value="accepted">accepted</option><option value="rejected">rejected</option></select>
 </div>
 </div>
 </div>

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -222,9 +222,13 @@
 </div><!-- /.ig-workspace -->
 </div>
 
-<!-- Section: PDF-Dokumente -->
+<!-- Section: PDF-Arbeitsfläche (50/50 split: Scan links, Text+NER rechts) -->
 <div class="mat-section" data-ctx="pdf">
-<div class="pane-hdr">&#128209; PDF-Dokumente</div>
+<div class="pane-hdr">&#128209; PDF-Arbeitsfläche</div>
+<div class="pdf-workspace">
+
+<!-- Left panel: Upload + Controls + Scan -->
+<div class="pdf-scan-panel">
 <div class="c">
 <h3>PDF hochladen</h3>
 <div class="uz" id="uz-pdf" onclick="document.getElementById('fi-pdf').click()">
@@ -236,8 +240,70 @@
 </div>
 <div class="c" id="pdf-pane1-info" style="display:none">
 <h3>Dokumente <span id="pdf-pane1-count" style="font-size:.7rem;color:#888"></span></h3>
-<div id="pdf-pane1-list" style="max-height:200px;overflow-y:auto"></div>
+<div id="pdf-pane1-list" style="max-height:120px;overflow-y:auto"></div>
 </div>
+<div class="c">
+<h3>Extraktion &amp; NER</h3>
+<label>Dokument</label>
+<select id="pdf-ner-doc" onchange="onPdfDocChange()" style="width:100%"><option value="">&#8212; Bitte erst PDF hochladen &#8212;</option></select>
+<div id="pdf-doc-info" style="font-size:.73rem;color:#888;margin-top:.2rem"></div>
+<label>Modell (Vision/OCR)</label>
+<select id="pdf-model" style="width:100%"><option value="">Standard (aus Konfiguration)</option></select>
+<label>Max. Seiten</label>
+<input type="number" id="pdf-max-pages" value="20" min="1" max="200">
+<button class="btn f" onclick="extractPDFText()" style="margin-top:.4rem">&#128269; Text extrahieren (OCR)</button>
+<div id="pdf-extract-status" style="font-size:.73rem;margin-top:.3rem"></div>
+<hr style="border:none;border-top:1px solid var(--brd);margin:.5rem 0">
+<label>Entity-Typen</label>
+<div id="pdf-ner-types" class="cl" style="max-height:120px">
+<div class="ci"><input type="checkbox" value="PER" class="pdf-ner-cb" checked><span class="etype etype-PER">PER</span><span>Personen</span></div>
+<div class="ci"><input type="checkbox" value="ORG" class="pdf-ner-cb" checked><span class="etype etype-ORG">ORG</span><span>Organisationen</span></div>
+<div class="ci"><input type="checkbox" value="LOC" class="pdf-ner-cb" checked><span class="etype etype-LOC">LOC</span><span>Orte</span></div>
+<div class="ci"><input type="checkbox" value="GPE" class="pdf-ner-cb" checked><span class="etype etype-GPE">GPE</span><span>Geo-politisch</span></div>
+<div class="ci"><input type="checkbox" value="DAT" class="pdf-ner-cb" checked><span class="etype etype-DAT">DAT</span><span>Datierung</span></div>
+<div class="ci"><input type="checkbox" value="TOP" class="pdf-ner-cb" checked><span class="etype etype-CON">TOP</span><span>Schlagworte</span></div>
+</div>
+<button class="btn f" onclick="runPDFNER()" style="margin-top:.4rem">&#129514; NER ausf&uuml;hren</button>
+<div id="pdf-ner-status" style="font-size:.73rem;margin-top:.3rem"></div>
+<div style="display:flex;gap:.3rem;margin-top:.4rem;flex-wrap:wrap">
+<button class="btn sm" onclick="downloadPDFExtractionJSON()">&#11015;&#65039; Text (JSON)</button>
+<button class="btn sm" onclick="downloadPDFNERJSON()">&#11015;&#65039; Entities (JSON)</button>
+</div>
+</div>
+<div class="c" id="pdf-scan-container" style="display:none">
+<div class="pdf-page-nav">
+<button class="btn sm" id="pdf-prev-btn" onclick="pdfPageNav(-1)">&#9664; Zurück</button>
+<span id="pdf-page-indicator" style="flex:1;text-align:center;font-size:.75rem;color:#555">Seite 1</span>
+<button class="btn sm" id="pdf-next-btn" onclick="pdfPageNav(+1)">Vor &#9654;</button>
+</div>
+<div class="pdf-scan-view">
+<img id="pdf-page-img" style="display:none" alt="Seiten-Scan">
+<div id="pdf-page-no-img" style="padding:1.5rem;text-align:center;color:#888;font-size:.78rem;display:none">Keine Scan-Vorschau (kein pdf2image installiert)</div>
+</div>
+</div>
+</div><!-- /.pdf-scan-panel -->
+
+<!-- Right panel: Text + NER -->
+<div class="pdf-text-panel">
+<div class="pdf-view-hdr">
+<div class="tabs" style="border:none;background:none;padding:0;margin:0;display:flex">
+<div class="tab a" data-t="text" onclick="setPdfViewTab('text',this)">&#128196; Volltext</div>
+<div class="tab" data-t="entities" onclick="setPdfViewTab('entities',this)">&#129514; Entities</div>
+</div>
+<span id="pdf-view-pageinfo" style="font-size:.68rem;color:#888;margin-left:auto"></span>
+</div>
+<div id="pdf-text-tab" class="pdf-text-view">
+<span id="pdf-text-empty" style="color:#aaa;font-size:.78rem">Noch kein Text extrahiert. Dokument wählen und &raquo;Text extrahieren&laquo; klicken.</span>
+</div>
+<div id="pdf-entities-tab" class="pdf-entities-view" style="display:none">
+<div id="pdf-ner-summary-view" style="display:flex;gap:.3rem;flex-wrap:wrap;padding:.5rem .5rem .3rem;border-bottom:1px solid var(--brd)"></div>
+<div class="scroll-box" style="max-height:calc(100vh - 360px)">
+<table class="etbl" id="pdf-ner-tbl-view"><thead><tr><th>Entity</th><th>Typ</th><th>Konf.</th><th>Seite</th></tr></thead><tbody id="pdf-ner-body-view"></tbody></table>
+</div>
+</div>
+</div><!-- /.pdf-text-panel -->
+
+</div><!-- /.pdf-workspace -->
 </div>
 
 </div><!-- /.mat-workspace -->
@@ -505,52 +571,16 @@
 <div class="track-col">
 <div class="c">
 <h3>&#128209; PDF: Textextraktion &amp; NER</h3>
-<label>Dokument</label>
-<select id="pdf-ner-doc" onchange="onPdfDocChange()" style="width:100%"><option value="">&#8212; Bitte erst PDF hochladen &#8212;</option></select>
-<div id="pdf-doc-info" style="font-size:.73rem;color:#888;margin-top:.2rem"></div>
-<label>Modell (Vision/OCR)</label>
-<select id="pdf-model" style="width:100%"><option value="">Standard (aus Konfiguration)</option></select>
-<label>Max. Seiten f&uuml;r Extraktion</label>
-<input type="number" id="pdf-max-pages" value="20" min="1" max="200">
-
-<hr style="border:none;border-top:1px solid var(--brd);margin:.6rem 0">
-<h3>1. Textextraktion (OCR)</h3>
-<p style="font-size:.72rem;color:#666;margin-bottom:.3rem">Vision-Modell liest Text von jeder PDF-Seite. Ergebnis als strukturiertes JSON.</p>
-<button class="btn f" onclick="extractPDFText()">&#128269; Text extrahieren (OCR)</button>
-<div id="pdf-extract-status" style="font-size:.73rem;margin-top:.3rem"></div>
-
-<hr style="border:none;border-top:1px solid var(--brd);margin:.6rem 0">
-<h3>2. NER auf extrahiertem Text</h3>
-<label>Entity-Typen</label>
-<div id="pdf-ner-types" class="cl" style="max-height:140px">
-<div class="ci"><input type="checkbox" value="PER" class="pdf-ner-cb" checked><span class="etype etype-PER">PER</span><span>Personen</span></div>
-<div class="ci"><input type="checkbox" value="ORG" class="pdf-ner-cb" checked><span class="etype etype-ORG">ORG</span><span>Organisationen</span></div>
-<div class="ci"><input type="checkbox" value="LOC" class="pdf-ner-cb" checked><span class="etype etype-LOC">LOC</span><span>Orte</span></div>
-<div class="ci"><input type="checkbox" value="GPE" class="pdf-ner-cb" checked><span class="etype etype-GPE">GPE</span><span>Geo-politisch</span></div>
-<div class="ci"><input type="checkbox" value="DAT" class="pdf-ner-cb" checked><span class="etype etype-DAT">DAT</span><span>Datierung</span></div>
-<div class="ci"><input type="checkbox" value="TOP" class="pdf-ner-cb" checked><span class="etype etype-CON">TOP</span><span>Schlagworte</span></div>
-</div>
-<button class="btn f" onclick="runPDFNER()" style="margin-top:.4rem">&#129514; NER ausf&uuml;hren</button>
-<div id="pdf-ner-status" style="font-size:.73rem;margin-top:.3rem"></div>
-
-<hr style="border:none;border-top:1px solid var(--brd);margin:.6rem 0">
-<h3>Strukturierte JSON-Ausgabe</h3>
-<p style="font-size:.72rem;color:#666;margin-bottom:.3rem">Valides JSON: Textextraktion (Seite, Text, Konfidenz) oder Entities (Text, Typ, Konfidenz, Quelle).</p>
-<div style="display:flex;gap:.3rem;flex-wrap:wrap">
-<button class="btn sm" onclick="downloadPDFExtractionJSON()">&#11015;&#65039; Textextraktion (JSON)</button>
-<button class="btn sm" onclick="downloadPDFNERJSON()">&#11015;&#65039; Entities (JSON)</button>
-</div>
-</div>
-
-<div id="pdf-extract-result" class="c" style="display:none;margin-top:.6rem">
-<h3>Extrahierter Text <span id="pdf-pages-count" style="font-size:.7rem;color:#888"></span></h3>
-<div id="pdf-extract-pages" class="scroll-box" style="max-height:260px"></div>
-</div>
-
-<div id="pdf-ner-result" class="c" style="display:none;margin-top:.6rem">
-<h3>Erkannte Entities <span id="pdf-ner-count" style="font-size:.7rem;color:#888"></span></h3>
-<div id="pdf-ner-summary" style="font-size:.72rem;color:#555;margin-bottom:.4rem;flex-wrap:wrap;display:flex;gap:.3rem"></div>
-<div class="scroll-box"><table class="etbl" id="pdf-ner-tbl"><thead><tr><th>Entity</th><th>Typ</th><th>Konf.</th><th>Seite</th></tr></thead><tbody id="pdf-ner-body"></tbody></table></div>
+<p style="font-size:.75rem;color:#666;margin-bottom:.4rem">Die PDF-Arbeitsfläche mit Scan-Vorschau, Textextraktion und NER-Highlighting befindet sich im Kontextreiter <strong>&#128209; PDF</strong>.</p>
+<button class="btn sm" onclick="setMatCtx('pdf')">&#128209; Zur PDF-Arbeitsfläche wechseln</button>
+<!-- Legacy containers kept for backward-compat -->
+<div id="pdf-extract-result" style="display:none"></div>
+<div id="pdf-extract-pages" style="display:none"></div>
+<span id="pdf-pages-count" style="display:none"></span>
+<div id="pdf-ner-result" style="display:none"></div>
+<span id="pdf-ner-count" style="display:none"></span>
+<div id="pdf-ner-summary" style="display:none"></div>
+<table style="display:none"><tbody id="pdf-ner-body"></tbody></table>
 </div>
 </div>
 

--- a/src/kwb/api/parts/dashboard.css
+++ b/src/kwb/api/parts/dashboard.css
@@ -193,9 +193,9 @@ th.sortable{cursor:pointer;white-space:nowrap}th.sortable:hover{color:var(--ac)}
 .mat-workspace.mat-ctx-images{grid-template-columns:1fr}
 .mat-workspace.mat-ctx-images .mat-section[data-ctx="table"]{display:none}
 .mat-workspace.mat-ctx-images .mat-section[data-ctx="images"]{display:flex}
-/* pdf context: 50/50 */
-.mat-workspace.mat-ctx-pdf{grid-template-columns:1fr 1fr}
-.mat-workspace.mat-ctx-pdf .mat-section[data-ctx="table"]{display:flex}
+/* pdf context: full width, pdf workspace only */
+.mat-workspace.mat-ctx-pdf{grid-template-columns:1fr}
+.mat-workspace.mat-ctx-pdf .mat-section[data-ctx="table"]{display:none}
 .mat-workspace.mat-ctx-pdf .mat-section[data-ctx="pdf"]{display:flex}
 /* mixed: all three */
 .mat-workspace.mat-ctx-mixed{grid-template-columns:repeat(3,1fr)}
@@ -247,6 +247,33 @@ th.sortable{cursor:pointer;white-space:nowrap}th.sortable:hover{color:var(--ac)}
 .ig-density button.active{background:var(--ink);color:#fff;border-color:var(--ink)}
 /* Gallery status bar */
 .ig-statusbar{font-size:.7rem;color:#666;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap;min-height:1.4rem}
+/* PDF split workspace */
+.pdf-workspace{display:grid;grid-template-columns:1fr 1fr;gap:1rem;width:100%}
+.pdf-scan-panel{display:flex;flex-direction:column;gap:.6rem;min-width:0;overflow-y:auto;max-height:calc(100vh - 200px)}
+.pdf-text-panel{display:flex;flex-direction:column;min-width:0;border:1px solid var(--brd);border-radius:var(--r);background:#fff;overflow:hidden;max-height:calc(100vh - 200px)}
+.pdf-view-hdr{display:flex;align-items:center;padding:.35rem .6rem;border-bottom:1px solid var(--brd);background:var(--pw);flex-shrink:0;gap:.4rem}
+.pdf-view-hdr .tabs{margin:0;border:none;padding:0;background:none;display:flex;gap:0}
+.pdf-view-hdr .tab{padding:.2rem .6rem;font-size:.72rem}
+.pdf-text-view{flex:1;overflow-y:auto;padding:.6rem;font-size:.78rem;line-height:1.7;white-space:pre-wrap;font-family:'Courier New',monospace}
+.pdf-entities-view{flex:1;overflow-y:auto}
+.pdf-page-nav{display:flex;align-items:center;gap:.4rem;margin-bottom:.4rem}
+.pdf-page-nav .btn{padding:.2rem .55rem;font-size:.72rem;margin-top:0}
+.pdf-scan-view{border:1px solid var(--brd);border-radius:var(--r);overflow:hidden;background:var(--pw);min-height:120px}
+.pdf-scan-view img{display:block;width:100%}
+/* NER highlighting in text */
+mark.ner-highlight{border-radius:3px;padding:.05em .15em;cursor:default;font-style:normal}
+mark.ner-PER{background:#dbeafe;color:#1e40af}
+mark.ner-ORG{background:#fef9c3;color:#854d0e}
+mark.ner-LOC{background:#dcfce7;color:#166534}
+mark.ner-GPE{background:#d1fae5;color:#065f46}
+mark.ner-DAT{background:#fce7f3;color:#9d174d}
+mark.ner-TOP,mark.ner-CON{background:#ede9fe;color:#4c1d95}
+mark.ner-highlight:hover::after{content:attr(data-type);font-size:.6rem;background:rgba(0,0,0,.7);color:#fff;padding:.1rem .3rem;border-radius:3px;margin-left:.2rem;vertical-align:middle;pointer-events:none}
+@media(max-width:900px){
+  .pdf-workspace{grid-template-columns:1fr}
+  .pdf-scan-panel{max-height:none}
+  .pdf-text-panel{max-height:60vh}
+}
 /* Review queue items */
 .rev-item{border:1px solid var(--brd);border-radius:var(--r);padding:.5rem .7rem;margin-bottom:.4rem;background:#fff;box-shadow:0 1px 2px var(--shd)}
 .rev-item-hdr{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-bottom:.2rem}

--- a/src/kwb/api/parts/dashboard.css
+++ b/src/kwb/api/parts/dashboard.css
@@ -189,9 +189,9 @@ th.sortable{cursor:pointer;white-space:nowrap}th.sortable:hover{color:var(--ac)}
 /* table/CSV context: full width */
 .mat-workspace.mat-ctx-table{grid-template-columns:1fr}
 .mat-workspace.mat-ctx-table .mat-section[data-ctx="table"]{display:flex}
-/* images context: 25 sidebar + 75 main */
-.mat-workspace.mat-ctx-images{grid-template-columns:minmax(240px,1fr) 3fr}
-.mat-workspace.mat-ctx-images .mat-section[data-ctx="table"]{display:flex}
+/* images context: full width, gallery section only */
+.mat-workspace.mat-ctx-images{grid-template-columns:1fr}
+.mat-workspace.mat-ctx-images .mat-section[data-ctx="table"]{display:none}
 .mat-workspace.mat-ctx-images .mat-section[data-ctx="images"]{display:flex}
 /* pdf context: 50/50 */
 .mat-workspace.mat-ctx-pdf{grid-template-columns:1fr 1fr}
@@ -202,12 +202,51 @@ th.sortable{cursor:pointer;white-space:nowrap}th.sortable:hover{color:var(--ac)}
 .mat-workspace.mat-ctx-mixed .mat-section{display:flex}
 @media(max-width:1100px){
   .mat-workspace.mat-ctx-mixed{grid-template-columns:1fr 1fr}
-  .mat-workspace.mat-ctx-images{grid-template-columns:1fr 2fr}
+  .ig-workspace{grid-template-columns:minmax(200px,1fr) 2fr}
 }
 @media(max-width:700px){
-  .mat-workspace.mat-ctx-mixed,.mat-workspace.mat-ctx-images,.mat-workspace.mat-ctx-pdf{grid-template-columns:1fr}
+  .mat-workspace.mat-ctx-mixed,.mat-workspace.mat-ctx-pdf{grid-template-columns:1fr}
   .mat-workspace .mat-section{display:flex!important}
+  .ig-workspace{grid-template-columns:1fr}
+  .ig-main.has-detail{grid-template-columns:1fr;grid-template-rows:auto auto}
 }
+/* Image gallery workspace */
+.ig-workspace{display:grid;grid-template-columns:minmax(220px,1fr) 3fr;gap:1rem;width:100%}
+.ig-sidebar{display:flex;flex-direction:column;gap:.6rem;min-width:0;overflow-y:auto;max-height:calc(100vh - 200px)}
+.ig-main{display:grid;grid-template-columns:1fr;gap:.6rem;min-width:0;align-content:start}
+.ig-main.has-detail{grid-template-columns:1fr minmax(280px,340px)}
+/* Gallery grid */
+.img-gallery{display:grid;gap:.35rem;overflow-y:auto;max-height:calc(100vh - 260px);align-content:start}
+.img-gallery.ig-s{grid-template-columns:repeat(auto-fill,minmax(72px,1fr))}
+.img-gallery.ig-m{grid-template-columns:repeat(auto-fill,minmax(110px,1fr))}
+.img-gallery.ig-l{grid-template-columns:repeat(auto-fill,minmax(160px,1fr))}
+/* Gallery tile */
+.img-tile{position:relative;border:2px solid var(--brd);border-radius:var(--r);cursor:pointer;overflow:hidden;aspect-ratio:1;background:var(--pw);transition:border-color .12s}
+.img-tile:hover{border-color:var(--ac)}
+.img-tile.selected{border-color:var(--ac);box-shadow:0 0 0 2px color-mix(in srgb,var(--ac) 35%,transparent)}
+.img-tile .it-thumb{width:100%;height:100%;object-fit:cover;display:block}
+.img-tile .it-tiff{display:flex;align-items:center;justify-content:center;width:100%;height:100%;font-size:.7rem;font-weight:700;color:#888;background:var(--pw)}
+.img-tile .it-name{position:absolute;bottom:0;left:0;right:0;font-size:.55rem;background:rgba(0,0,0,.55);color:#fff;padding:.15rem .3rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;pointer-events:none}
+.it-badge{position:absolute;top:.2rem;right:.2rem;font-size:.58rem;font-weight:700;padding:.1rem .3rem;border-radius:10px;line-height:1;pointer-events:none}
+.it-badge-pending{background:#f3f4f6;color:#6b7280}
+.it-badge-accepted{background:#dcfce7;color:var(--ok)}
+.it-badge-rejected{background:#fee2e2;color:var(--crit)}
+.it-analyzed-dot{position:absolute;top:.2rem;left:.2rem;width:6px;height:6px;border-radius:50%;background:var(--ac);pointer-events:none}
+.img-tile .it-actions{position:absolute;inset:0;display:none;align-items:flex-end;justify-content:center;padding:.25rem;background:linear-gradient(to bottom,transparent 50%,rgba(0,0,0,.55));gap:.25rem}
+.img-tile:hover .it-actions{display:flex}
+.img-tile .it-actions .btn{padding:.1rem .3rem;font-size:.6rem;line-height:1.4;margin-top:0}
+/* Detail panel */
+.img-detail-panel{display:none;flex-direction:column;border:1px solid var(--brd);border-radius:var(--r);background:#fff;overflow-y:auto;max-height:calc(100vh - 260px);box-shadow:0 2px 6px var(--shd)}
+.img-detail-panel.open{display:flex}
+.img-detail-hdr{display:flex;align-items:center;gap:.4rem;padding:.5rem .6rem;border-bottom:1px solid var(--brd);background:var(--pw);border-radius:var(--r) var(--r) 0 0;flex-shrink:0}
+.img-detail-hdr strong{font-size:.8rem;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+/* Density selector */
+.ig-density{display:flex;gap:.25rem}
+.ig-density button{padding:.2rem .55rem;border:1px solid var(--brd);background:#fff;border-radius:3px;font-size:.7rem;cursor:pointer;transition:.12s;line-height:1;margin-top:0}
+.ig-density button:hover{border-color:var(--ac)}
+.ig-density button.active{background:var(--ink);color:#fff;border-color:var(--ink)}
+/* Gallery status bar */
+.ig-statusbar{font-size:.7rem;color:#666;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap;min-height:1.4rem}
 /* Review queue items */
 .rev-item{border:1px solid var(--brd);border-radius:var(--r);padding:.5rem .7rem;margin-bottom:.4rem;background:#fff;box-shadow:0 1px 2px var(--shd)}
 .rev-item-hdr{display:flex;align-items:center;gap:.4rem;flex-wrap:wrap;margin-bottom:.2rem}

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -167,15 +167,16 @@ function getBoolParams(){
 async function runPilotImages(){
   if(!uploadedImages.length){alert('Erst Bilder hochladen.');return}
   const ids=uploadedImages.slice(0,Math.max(1,Math.ceil(uploadedImages.length*0.02))).map(i=>i.id);
-  const mod=$('img-model').value;
+  const mod=($('img-model-sidebar')&&$('img-model-sidebar').value)||($('img-model')&&$('img-model').value)||'';
+  const task=($('img-task-sidebar')&&$('img-task-sidebar').value)||($('img-task')&&$('img-task').value)||'image_description';
   const boolParams=getBoolParams();
   sp('Bild-Testlauf …',ids.length+' Bild(er)');
-  const body={image_ids:ids,model:mod,prompt_task:$('img-task').value,boolean_params:boolParams};
+  const body={image_ids:ids,model:mod,prompt_task:task,boolean_params:boolParams};
   try{
     await fetchSSE('/api/images/analyze/stream',body,
       evt=>{spUp(evt.current,evt.total,esc(evt.filename||''));},
       result=>{renderImgResults(result.results||[]);},
-      msg=>{$('img-results-empty').textContent='Fehler: '+msg;}
+      msg=>{const el=$('img-full-status');if(el)el.textContent='Fehler: '+msg;}
     );
   }catch(e){if(e.name!=='AbortError')alert(e.message);}finally{hp();}
 }
@@ -1364,6 +1365,7 @@ async function chkGPU(){try{const d=await(await fetch('/api/gpu/status')).json()
         visionModels.map(m=>safeOpt(m,m+' [VISION]')).join('')+
         textModels.map(m=>safeOpt(m,m+' [TEXT]')).join('');
       if($('img-model'))$('img-model').innerHTML=visionOpts;
+      if($('img-model-sidebar'))$('img-model-sidebar').innerHTML=visionOpts;
       if($('pdf-model'))$('pdf-model').innerHTML=visionOpts;
     }else{
       setDot('off','GPUStack: nicht erreichbar');
@@ -1477,100 +1479,230 @@ function _filteredImages(){
     return !!h && (hc[h] || 0) > 1;
   });
   if(imgFilter === 'no_analysis') return uploadedImages.filter(img=>!img.analyzed);
+  if(['pending','accepted','rejected'].includes(imgFilter))
+    return uploadedImages.filter(img=>(img.review_status||'pending')===imgFilter);
   return uploadedImages;
 }
 
 function renderImgGrid(){
-  const grid = $('img-grid');
+  const gallery = $('img-gallery');
   const empty = $('img-list-empty');
-  if(!grid)return;
-  if(!uploadedImages.length){if(empty)empty.style.display='block';grid.innerHTML='';return}
+  if(!gallery) return;
+  if(!uploadedImages.length){
+    if(empty){empty.style.display='block';empty.textContent='Noch keine Bilder hochgeladen.';}
+    gallery.innerHTML='';
+    _updateGalleryStatusBar(0,0);
+    return;
+  }
   const shown = _filteredImages();
-  if(!shown.length){if(empty){empty.style.display='block';empty.textContent='Keine Bilder für den gewählten Filter.';}grid.innerHTML='';return}
-  if(empty){empty.style.display='none';empty.textContent='Noch keine Bilder hochgeladen.';}
-  grid.innerHTML = shown.map(function(img){
+  if(!shown.length){
+    if(empty){empty.style.display='block';empty.textContent='Keine Bilder für den gewählten Filter.';}
+    gallery.innerHTML='';
+    _updateGalleryStatusBar(0,uploadedImages.length);
+    return;
+  }
+  if(empty) empty.style.display='none';
+  gallery.innerHTML = shown.map(function(img){
     const imgUrl='/api/images/'+encPath(img.id)+'/data';
-    const info=(img.filename||'')+' — '+(img.width||'?')+'x'+(img.height||'?');
     const isTiff=(img.media_type||'').includes('tiff');
-    const thumb=isTiff
-      ?'<div class="img-open" data-src="'+esc(imgUrl)+'" data-info="'+esc(img.filename||'')+'" style="height:140px;display:flex;align-items:center;justify-content:center;background:#eee;border-radius:3px;color:#888;font-size:.85rem;font-weight:600;cursor:pointer">TIFF</div>'
-      :'<img class="img-thumb img-open" src="'+esc(imgUrl)+'" alt="'+esc(img.filename)+'" data-src="'+esc(imgUrl)+'" data-info="'+esc(info)+'"'
-      +' style="width:100%;height:140px;object-fit:contain;background:#eee;border-radius:3px;display:block;cursor:pointer">'
-      +'<div style="display:none;height:140px;align-items:center;justify-content:center;background:#eee;border-radius:3px;color:#aaa;font-size:.68rem">Vorschau n/v</div>';
-    return '<div style="border:1px solid var(--brd);border-radius:4px;padding:.4rem;font-size:.72rem;background:#fafafa;display:flex;flex-direction:column;gap:.25rem">'
-      +thumb
-      +'<div style="font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="'+esc(img.filename)+'">'+esc(img.filename)+'</div>'
-      +'<div style="color:#888;font-size:.65rem">'+((img.size_bytes/1024).toFixed(1))+' KB &middot; '+esc(img.media_type||'')+'</div>'
-      +'<div><span class="bg '+(img.analyzed?'ac':'no')+'">'+esc(img.analyzed?'analysiert':'ausstehend')+'</span></div>'
-      +'</div>'}).join('');
-  grid.querySelectorAll('.img-open').forEach(el=>el.onclick=()=>openLightbox(el.dataset.src||'',el.dataset.info||''));
-  grid.querySelectorAll('.img-thumb').forEach(el=>el.onerror=()=>{el.style.display='none';if(el.nextElementSibling)el.nextElementSibling.style.display='flex'});
+    const status=img.review_status||'pending';
+    const thumbHtml=isTiff
+      ?'<div class="it-tiff">TIFF</div>'
+      :'<img class="it-thumb" src="'+esc(imgUrl)+'" alt="'+esc(img.filename||'')+'" loading="lazy">';
+    const badgeCls=status==='accepted'?'it-badge-accepted':status==='rejected'?'it-badge-rejected':'it-badge-pending';
+    const badgeTxt=status==='accepted'?'✓':status==='rejected'?'✗':'·';
+    return '<div class="img-tile" data-id="'+esc(img.id)+'" onclick="openImgDetail(\''+esc(img.id)+'\')">'
+      +thumbHtml
+      +'<div class="it-badge '+badgeCls+'">'+badgeTxt+'</div>'
+      +(img.analyzed?'<div class="it-analyzed-dot" title="Analysiert"></div>':'')
+      +'<div class="it-name" title="'+esc(img.filename||img.id)+'">'+esc(img.filename||img.id)+'</div>'
+      +'<div class="it-actions">'
+      +'<button class="btn sm" onclick="event.stopPropagation();quickReview(\''+esc(img.id)+'\',\'accepted\')" title="Freigeben">&#10003;</button>'
+      +'<button class="btn sm s" onclick="event.stopPropagation();quickReview(\''+esc(img.id)+'\',\'rejected\')" title="Verwerfen">&#10007;</button>'
+      +'</div>'
+      +'</div>';
+  }).join('');
+  // Error fallback for broken img tags
+  gallery.querySelectorAll('.it-thumb').forEach(function(el){
+    el.onerror=function(){this.style.display='none';
+      var fb=document.createElement('div');fb.className='it-tiff';fb.textContent='n/v';
+      this.parentNode.insertBefore(fb,this);};
+  });
+  _updateGalleryStatusBar(shown.length,uploadedImages.length);
+}
+
+function _updateGalleryStatusBar(shown, total){
+  const cnt=$('img-gallery-count');
+  const an=$('img-gallery-analyzed');
+  if(cnt) cnt.textContent=total?shown+' / '+total+' Bilder':'';
+  if(an){
+    const analyzed=uploadedImages.filter(i=>i.analyzed).length;
+    an.textContent=total?analyzed+' analysiert':'';
+  }
+}
+
+function setGalleryDensity(size){
+  const gallery=$('img-gallery');
+  if(!gallery) return;
+  gallery.className='img-gallery ig-'+size;
+  ['s','m','l'].forEach(function(s){
+    const btn=$('igd-'+s);
+    if(btn) btn.classList.toggle('active',s===size);
+  });
+}
+
+function openImgDetail(imageId){
+  const img=uploadedImages.find(i=>i.id===imageId);
+  if(!img) return;
+  const panel=$('img-detail-panel');
+  const mainEl=$('ig-main');
+  if(!panel) return;
+  // Highlight tile
+  document.querySelectorAll('.img-tile').forEach(t=>t.classList.remove('selected'));
+  const tile=document.querySelector('.img-tile[data-id="'+CSS.escape(imageId)+'"]');
+  if(tile){tile.classList.add('selected');tile.scrollIntoView({block:'nearest'});}
+  // Header
+  const nm=$('img-detail-name');if(nm) nm.textContent=img.filename||img.id;
+  // Preview
+  const preview=$('img-detail-preview');
+  if(preview){
+    const isTiff=(img.media_type||'').includes('tiff');
+    const imgUrl='/api/images/'+encPath(img.id)+'/data';
+    preview.innerHTML=isTiff
+      ?'<div style="background:var(--pw);padding:1.5rem;border-radius:var(--r);color:#888;font-size:.8rem">TIFF – Klick öffnet Vollbild</div>'
+      :'<img src="'+esc(imgUrl)+'" style="max-width:100%;max-height:160px;object-fit:contain;border-radius:4px;cursor:pointer" '
+        +'onclick="openLightbox(\''+esc(imgUrl)+'\',\''+esc(img.filename||img.id)+'\')" '
+        +'onerror="this.replaceWith(Object.assign(document.createElement(\'div\'),{textContent:\'Vorschau n/v\',style:\'padding:.8rem;color:#aaa;font-size:.75rem\'}))">';
+  }
+  // Body
+  const body=$('img-detail-body');
+  if(!body) return;
+  const r=img.result||{};
+  const status=img.review_status||'pending';
+  const stCls=status==='accepted'?'rev-st-accepted':status==='rejected'?'rev-st-rejected':'rev-st-pending';
+  body.innerHTML=
+    '<div style="margin-bottom:.5rem">'
+    +'<table style="font-size:.72rem;width:100%;border-collapse:collapse">'
+    +'<tr><td style="color:#888;padding:.1rem .4rem 0 0;white-space:nowrap">Status:</td><td><span class="rev-st '+stCls+'">'+esc(status)+'</span></td></tr>'
+    +'<tr><td style="color:#888;padding:.1rem .4rem 0 0">Größe:</td><td>'+(img.width||'?')+'×'+(img.height||'?')+' px</td></tr>'
+    +(img.size_bytes?'<tr><td style="color:#888;padding:.1rem .4rem 0 0">Datei:</td><td>'+((img.size_bytes/1024).toFixed(1))+' KB · '+esc(img.media_type||'')+'</td></tr>':'')
+    +'</table>'
+    +'</div>'
+    +(img.analyzed&&(r.description||r.objects)
+      ?'<div class="c" style="margin-bottom:.5rem;padding:.5rem">'
+        +'<h3 style="font-size:.78rem;margin-bottom:.3rem">KI-Analyse</h3>'
+        +(r.description?'<p style="font-size:.75rem;margin-bottom:.25rem">'+esc(r.description)+'</p>':'')
+        +(r.objects&&r.objects.length?'<p style="font-size:.72rem"><strong>Objekte:</strong> '+esc(r.objects.join(', '))+'</p>':'')
+        +(r.period?'<p style="font-size:.72rem"><strong>Periode:</strong> '+esc(r.period)+'</p>':'')
+        +(r.confidence?'<p style="font-size:.68rem;color:#888;margin-top:.15rem">Konfidenz: '+(r.confidence*100).toFixed(0)+'%</p>':'')
+        +'</div>'
+      :'')
+    +'<div class="c" style="padding:.5rem">'
+    +'<h3 style="font-size:.78rem;margin-bottom:.4rem">Review</h3>'
+    +'<input type="text" id="img-detail-record" placeholder="record_id (optional)" value="'+esc(img.record_id||'')+'" style="width:100%;margin-bottom:.3rem">'
+    +'<textarea id="img-detail-desc" style="width:100%;height:3rem;margin-bottom:.3rem">'+esc(r.description||'')+'</textarea>'
+    +'<input type="text" id="img-detail-comment" placeholder="Kommentar" value="'+esc(img.review_comment||'')+'" style="width:100%;margin-bottom:.3rem">'
+    +'<input type="text" id="img-detail-reviewer" placeholder="Reviewer" value="'+esc(img.reviewer||'')+'" style="width:100%;margin-bottom:.4rem">'
+    +'<div style="display:flex;gap:.3rem;flex-wrap:wrap">'
+    +'<button class="btn sm" onclick="saveDetailReview(\''+esc(img.id)+'\',\'pending\')">&#128190; Speichern</button>'
+    +'<button class="btn sm" style="background:var(--ok)" onclick="saveDetailReview(\''+esc(img.id)+'\',\'accepted\')">&#10003; Best&auml;tigen</button>'
+    +'<button class="btn sm s" onclick="saveDetailReview(\''+esc(img.id)+'\',\'rejected\')">&#10007; Verwerfen</button>'
+    +'</div>'
+    +'</div>';
+  panel.classList.add('open');
+  if(mainEl) mainEl.classList.add('has-detail');
+}
+
+function closeImgDetail(){
+  const panel=$('img-detail-panel');
+  if(panel) panel.classList.remove('open');
+  const mainEl=$('ig-main');if(mainEl) mainEl.classList.remove('has-detail');
+  document.querySelectorAll('.img-tile').forEach(t=>t.classList.remove('selected'));
+}
+
+async function saveDetailReview(imageId, forceStatus){
+  const img=uploadedImages.find(i=>i.id===imageId);
+  if(!img) return;
+  const payload={
+    status:forceStatus,
+    record_id:($('img-detail-record')&&$('img-detail-record').value)||img.record_id||'',
+    comment:($('img-detail-comment')&&$('img-detail-comment').value)||'',
+    reviewer:($('img-detail-reviewer')&&$('img-detail-reviewer').value)||'',
+    result_updates:{description:($('img-detail-desc')&&$('img-detail-desc').value)||''}
+  };
+  try{
+    const resp=await fetch('/api/images/'+encodeURIComponent(imageId)+'/review',{
+      method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(payload)
+    });
+    const d=await resp.json();
+    if(d.error){alert('Review-Fehler: '+d.error);return;}
+    img.review_status=d.image.review_status;
+    img.review_comment=d.image.review_comment;
+    img.reviewer=d.image.reviewer;
+    img.record_id=d.image.record_id;
+    if(d.image.result) img.result=d.image.result;
+    renderImgGrid();
+    openImgDetail(imageId);
+  }catch(e){alert('Review-Fehler: '+e.message);}
+}
+
+async function quickReview(imageId, status){
+  const img=uploadedImages.find(i=>i.id===imageId);
+  if(!img) return;
+  try{
+    const resp=await fetch('/api/images/'+encodeURIComponent(imageId)+'/review',{
+      method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({status,reviewer:'',comment:'',record_id:img.record_id||''})
+    });
+    const d=await resp.json();
+    if(d.error) return;
+    img.review_status=d.image.review_status;
+    renderImgGrid();
+  }catch(e){}
 }
 
 async function analyzeImages(){
   if(!uploadedImages.length){alert('Erst Bilder hochladen.');return}
-  const mod = $('img-model').value;
-  const sp_text = $('img-sp').value;
+  const mod=($('img-model-sidebar')&&$('img-model-sidebar').value)||($('img-model')&&$('img-model').value)||'';
+  const sp_text=($('img-sp')&&$('img-sp').value)||'';
+  const task=($('img-task-sidebar')&&$('img-task-sidebar').value)||($('img-task')&&$('img-task').value)||'image_description';
   const ids = uploadedImages.map(i=>i.id);
   sp('Bildanalyse läuft…', ids.length + ' Bild(er)');
   const boolParams=getBoolParams();
-  const body={image_ids:ids, model:mod, system_prompt:sp_text, prompt_task:$('img-task').value, boolean_params:boolParams};
+  const body={image_ids:ids, model:mod, system_prompt:sp_text, prompt_task:task, boolean_params:boolParams};
   try{
     await fetchSSE('/api/images/analyze/stream',body,
       evt=>{spUp(evt.current,evt.total,esc(evt.filename||''));},
       result=>{
         renderImgResults(result.results||[]);
-        if((result.results||[]).some(r=>r.result))$('img-results-empty').textContent='';
-        (result.results||[]).forEach(res=>{
-          const img=uploadedImages.find(i=>i.id===res.id);
-          if(img)img.analyzed=!!res.result;
-        });
         renderImgGrid();
       },
-      msg=>{$('img-results-empty').textContent='Fehler: '+msg;}
+      msg=>{ const el=$('img-full-status');if(el)el.textContent='Fehler: '+msg; }
     );
-  }catch(e){if(e.name!=='AbortError')$('img-results-empty').textContent='Fehler: '+e;}finally{hp();}
+  }catch(e){
+    if(e.name!=='AbortError'){const el=$('img-full-status');if(el)el.textContent='Fehler: '+e;}
+  }finally{hp();}
 }
 
 function renderImgResults(results){
   latestImageResults = results || [];
-  applyImageFilter();
+  // Merge analysis results into uploadedImages and re-render gallery
+  results.forEach(function(res){
+    var img=uploadedImages.find(i=>i.id===res.id);
+    if(img){
+      if(res.result) img.result=res.result;
+      if(res.review_status) img.review_status=res.review_status;
+      if(res.review_comment) img.review_comment=res.review_comment;
+      if(res.reviewer) img.reviewer=res.reviewer;
+      if(res.record_id) img.record_id=res.record_id;
+      img.analyzed=true;
+    }
+  });
+  renderImgGrid();
 }
 
 function applyImageFilter(){
-  const el=$('img-results');
-  const empty=$('img-results-empty');
-  const filter=($('img-review-filter')&&$('img-review-filter').value)||'all';
-  filteredImageResults = latestImageResults.filter(function(res){
-    return filter==='all' || (res.review_status||'pending')===filter;
-  });
-  if(!filteredImageResults.length){empty.style.display='block';el.innerHTML='';return}
-  empty.style.display='none';
-  el.innerHTML = filteredImageResults.map(function(res, idx){
-    const originalIdx = latestImageResults.indexOf(res);
-    if(res.error) return '<div class="card" style="border-color:#e55"><strong>'+esc(res.id||res.filename||'')+'</strong><br><span style="color:#c00">'+esc(res.error)+'</span></div>';
-    var r = res.result || {};
-    var status = res.review_status || 'pending';
-    return '<div class="card" style="margin-bottom:.5rem">'
-      +'<strong style="font-size:.8rem">'+esc(res.filename||res.id)+'</strong>'
-      +'<div style="display:grid;grid-template-columns:1fr 1fr;gap:.4rem;margin:.35rem 0">'
-      +'<input type="text" id="img-record-'+idx+'" placeholder="record_id (optional)" value="'+esc(res.record_id||'')+'">'
-      +'<select id="img-status-'+idx+'"><option value="pending"'+(status==='pending'?' selected':'')+'>pending</option><option value="accepted"'+(status==='accepted'?' selected':'')+'>accepted</option><option value="rejected"'+(status==='rejected'?' selected':'')+'>rejected</option></select>'
-      +'</div>'
-      +'<textarea id="img-desc-'+idx+'" style="height:4rem">'+esc(r.description||'')+'</textarea>'
-      +'<p style="font-size:.78rem;margin:.3rem 0">Objekte: '+esc((r.objects||[]).join(', '))+'</p>'
-      +(r.period?'<div style="font-size:.72rem;color:#555">Periode: '+esc(r.period)+'</div>':'')
-      +(r.confidence?'<div style="font-size:.65rem;color:#888">Konfidenz: '+(r.confidence*100).toFixed(0)+'%</div>':'')
-      +'<input type="text" id="img-comment-'+idx+'" placeholder="Kommentar" value="'+esc(res.review_comment||'')+'" style="margin-top:.25rem">'
-      +'<input type="text" id="img-reviewer-'+idx+'" placeholder="Reviewer" value="'+esc(res.reviewer||'')+'" style="margin-top:.25rem">'
-      +'<div style="display:flex;gap:.3rem;margin-top:.35rem">'
-      +'<button class="btn sm" onclick="saveImageReview('+idx+',\'pending\')">💾 anpassen</button>'
-      +'<button class="btn sm" style="background:var(--ok)" onclick="saveImageReview('+idx+',\'accepted\')">✅ bestätigen</button>'
-      +'<button class="btn sm" style="background:var(--crit)" onclick="saveImageReview('+idx+',\'rejected\')">🗑 verwerfen</button>'
-      +'</div>'
-      +'<div style="font-size:.65rem;color:#777;margin-top:.2rem">ID: '+esc(res.id)+' • #'+(originalIdx+1)+'</div>'
-      +'</div>';
-  }).join('');
+  renderImgGrid();
 }
 
 async function saveImageReview(idx, forceStatus){
@@ -1671,32 +1803,27 @@ async function loadImages(){
 // === OCR ===
 async function runOCR(){
   if(!uploadedImages.length){alert('Erst Bilder hochladen.');return;}
-  const mod=$('img-model').value;
+  const mod=($('img-model-sidebar')&&$('img-model-sidebar').value)||($('img-model')&&$('img-model').value)||'';
   const ids=uploadedImages.map(i=>i.id);
   sp('OCR läuft…',ids.length+' Bild(er)');
   _abortCtrl=new AbortController();
+  const statusEl=$('img-full-status');
   try{
     const r=await fetch('/api/images/ocr',{
       method:'POST',headers:{'Content-Type':'application/json'},
       signal:_abortCtrl.signal,
-      body:JSON.stringify({image_ids:ids,model:mod,system_prompt:$('ocr-sp').value||''})
+      body:JSON.stringify({image_ids:ids,model:mod,system_prompt:($('ocr-sp')&&$('ocr-sp').value)||''})
     });
     const data=await r.json();
-    if(data.error){$('img-results-empty').textContent='OCR-Fehler: '+data.error;hp();return;}
-    const el=$('img-results');
-    el.innerHTML='<h3 style="margin:.5rem 0">OCR-Ergebnisse ('+(data.processed||0)+'/'+(data.total||0)+')</h3>'
-      +(data.results||[]).map(function(res){
-        if(res.error)return '<div style="border:1px solid #e55;padding:.4rem;margin-bottom:.3rem;border-radius:4px">'+esc(res.id)+': '+esc(res.error)+'</div>';
-        var rc=res.result||{};var txt=rc.transcription||rc.text||'(kein Text erkannt)';
-        return '<div style="border:1px solid var(--brd);padding:.5rem;margin-bottom:.3rem;border-radius:4px">'
-          +'<strong style="font-size:.78rem">'+esc(res.filename||res.id)+'</strong> '
-          +(rc.text_found?'<span class="bg ac">Text</span>':'<span class="bg no">Kein Text</span>')
-          +'<div style="font-family:monospace;font-size:.75rem;margin:.3rem 0;padding:.3rem;background:var(--pw);border-radius:3px">'+esc(txt)+'</div>'
-          +(rc.overall_confidence?'<div style="font-size:.68rem;color:#888">Konfidenz: '+(rc.overall_confidence*100).toFixed(0)+'%</div>':'')
-          +'</div>';
-      }).join('');
-    $('img-results-empty').textContent='';
-  }catch(e){$('img-results-empty').textContent='Fehler: '+e;}finally{hp();}
+    if(data.error){if(statusEl)statusEl.textContent='OCR-Fehler: '+data.error;hp();return;}
+    // Merge OCR results into uploadedImages
+    (data.results||[]).forEach(function(res){
+      const img=uploadedImages.find(i=>i.id===res.id);
+      if(img&&res.result){img.result=res.result;img.analyzed=true;}
+    });
+    renderImgGrid();
+    if(statusEl)statusEl.textContent='OCR abgeschlossen: '+(data.processed||0)+'/'+(data.total||0)+' Bilder';
+  }catch(e){if(statusEl)statusEl.textContent='Fehler: '+e;}finally{hp();}
 }
 
 // === CSV EXPORT ===

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -2332,9 +2332,14 @@ function onPdfDocChange(){
   if(!sel||!info)return;
   const doc=_pdfDocs.find(d=>d.id===sel.value);
   info.textContent=doc?(doc.page_count+' Seiten · '+esc(doc.filename)):'';
-  _pdfExtraction=null;_pdfNerResult=null;
-  if($('pdf-extract-result'))$('pdf-extract-result').style.display='none';
-  if($('pdf-ner-result'))$('pdf-ner-result').style.display='none';
+  _pdfExtraction=null;_pdfNerResult=null;_pdfCurrentPage=1;_pdfTotalPages=1;
+  // Reset split view
+  const sc=$('pdf-scan-container');if(sc)sc.style.display='none';
+  const emptyEl=$('pdf-text-empty');if(emptyEl)emptyEl.style.display='';
+  const content=document.getElementById('pdf-text-content');if(content)content.remove();
+  const summary=$('pdf-ner-summary-view');if(summary)summary.innerHTML='';
+  const body=$('pdf-ner-body-view');if(body)body.innerHTML='';
+  const imgEl=$('pdf-page-img');if(imgEl){imgEl.style.display='none';imgEl.src='';}
 }
 
 async function extractPDFText(){
@@ -2358,18 +2363,125 @@ async function extractPDFText(){
 }
 
 function renderPDFExtractResults(r){
-  const el=$('pdf-extract-result');const pages=$('pdf-extract-pages');const cnt=$('pdf-pages-count');
-  if(!el||!pages)return;
-  el.style.display='block';
-  if(cnt)cnt.textContent='('+r.extracted_pages+' / '+r.total_pages+' Seiten)';
-  pages.innerHTML=(r.pages||[]).map(p=>{
-    const statusCls=p.confidence==='high'?'pdf-status-ok':p.confidence==='error'?'pdf-status-err':'pdf-status-pending';
-    return '<div class="pdf-page-item">'+
-      '<span class="pdf-page-num">S.'+p.page+'</span>'+
-      '<span class="'+statusCls+'">'+esc(p.confidence)+'</span>'+
-      '<span style="flex:1;overflow:hidden;font-size:.72rem;color:#555;white-space:pre-line;max-height:3.5rem;overflow-y:auto">'+esc((p.text||'').substring(0,200)+(p.text&&p.text.length>200?'…':''))+'</span>'+
-    '</div>';
+  // Show scan container + navigate to page 1
+  const sc=$('pdf-scan-container');if(sc)sc.style.display='block';
+  _pdfCurrentPage=1;
+  _pdfTotalPages=(r.pages||[]).length||r.total_pages||1;
+  renderPDFSplitView();
+}
+
+function renderPDFNERResults(r){
+  // Update entity tab in split view
+  const summary=$('pdf-ner-summary-view');
+  const body=$('pdf-ner-body-view');
+  if(summary)summary.innerHTML=Object.entries(r.entity_types||{}).map(([t,n])=>
+    '<span class="etype etype-'+esc(t)+'">'+esc(t)+'</span><span style="font-size:.68rem;margin-left:.15rem">'+n+'</span>'
+  ).join('');
+  if(body)body.innerHTML=(r.entities||[]).map(e=>'<tr>'+
+    '<td style="font-weight:600">'+esc(e.text||'')+'</td>'+
+    '<td><span class="etype etype-'+esc(e.type||'CON')+'">'+esc(e.type||'')+'</span></td>'+
+    '<td>'+Math.round((e.confidence||0)*100)+'%</td>'+
+    '<td style="font-size:.68rem;color:#888">'+esc(e.source||'')+'</td>'+
+  '</tr>').join('');
+  // Re-render text with highlighting for current page
+  renderPDFSplitView();
+}
+
+// State for split view
+let _pdfCurrentPage=1;
+let _pdfTotalPages=1;
+
+function renderPDFSplitView(){
+  const pages=(_pdfExtraction&&_pdfExtraction.pages)||[];
+  const totalPages=_pdfTotalPages||pages.length||1;
+  const page=pages.find(p=>p.page===_pdfCurrentPage);
+
+  // Page indicator
+  const indicator=$('pdf-page-indicator');
+  if(indicator)indicator.textContent='Seite '+_pdfCurrentPage+' / '+totalPages;
+  const pageInfo=$('pdf-view-pageinfo');
+  if(pageInfo)pageInfo.textContent='Seite '+_pdfCurrentPage+' von '+totalPages;
+
+  // Prev/next buttons
+  const prev=$('pdf-prev-btn');const next=$('pdf-next-btn');
+  if(prev)prev.disabled=_pdfCurrentPage<=1;
+  if(next)next.disabled=_pdfCurrentPage>=totalPages;
+
+  // Load scan image
+  const docSel=$('pdf-ner-doc');
+  const docId=docSel&&docSel.value;
+  const imgEl=$('pdf-page-img');
+  const noImgEl=$('pdf-page-no-img');
+  if(imgEl&&docId){
+    imgEl.style.display='none';
+    if(noImgEl)noImgEl.style.display='none';
+    imgEl.onerror=function(){
+      this.style.display='none';
+      if(noImgEl)noImgEl.style.display='block';
+    };
+    imgEl.onload=function(){this.style.display='block';};
+    imgEl.src='/api/pdf/'+encodeURIComponent(docId)+'/page/'+_pdfCurrentPage+'/image?_t='+Date.now();
+  }
+
+  // Render text with NER highlighting
+  const textTab=$('pdf-text-tab');
+  const emptyEl=$('pdf-text-empty');
+  if(textTab){
+    if(!page||!page.text){
+      if(emptyEl)emptyEl.style.display='';
+      const existing=textTab.querySelector('#pdf-text-content');
+      if(existing)existing.remove();
+    }else{
+      if(emptyEl)emptyEl.style.display='none';
+      const entities=(_pdfNerResult&&_pdfNerResult.entities)||[];
+      const pageEntities=entities.filter(e=>e.source==='page_'+_pdfCurrentPage||e.source==='page '+_pdfCurrentPage);
+      let content=textTab.querySelector('#pdf-text-content');
+      if(!content){content=document.createElement('div');content.id='pdf-text-content';textTab.appendChild(content);}
+      content.style.display='block';
+      content.innerHTML=_buildHighlightedText(page.text,pageEntities);
+    }
+  }
+}
+
+function _buildHighlightedText(text,entities){
+  if(!entities||!entities.length) return '<span>'+esc(text)+'</span>';
+  // Sort by length (longest first) to avoid partial overlaps
+  const sorted=[...entities].sort((a,b)=>(b.text||'').length-(a.text||'').length);
+  // Build segments
+  let segs=[{start:0,end:text.length,raw:text,entity:null}];
+  for(const entity of sorted){
+    const etxt=entity.text||'';if(!etxt)continue;
+    const newSegs=[];
+    for(const seg of segs){
+      if(seg.entity){newSegs.push(seg);continue;}
+      const idx=seg.raw.toLowerCase().indexOf(etxt.toLowerCase());
+      if(idx<0){newSegs.push(seg);continue;}
+      if(idx>0)newSegs.push({start:seg.start,end:seg.start+idx,raw:seg.raw.slice(0,idx),entity:null});
+      newSegs.push({start:seg.start+idx,end:seg.start+idx+etxt.length,raw:seg.raw.slice(idx,idx+etxt.length),entity});
+      const rest=seg.raw.slice(idx+etxt.length);
+      if(rest)newSegs.push({start:seg.start+idx+etxt.length,end:seg.end,raw:rest,entity:null});
+    }
+    segs=newSegs;
+  }
+  return segs.filter(s=>s.raw).map(s=>{
+    if(!s.entity) return esc(s.raw);
+    return '<mark class="ner-highlight ner-'+esc(s.entity.type||'CON')+'" data-type="'+esc(s.entity.type||'')+'" title="'+esc(s.entity.type||'')+' · '+Math.round((s.entity.confidence||0)*100)+'%">'+esc(s.raw)+'</mark>';
   }).join('');
+}
+
+function pdfPageNav(delta){
+  const pages=(_pdfExtraction&&_pdfExtraction.pages)||[];
+  const total=_pdfTotalPages||pages.length||1;
+  _pdfCurrentPage=Math.max(1,Math.min(total,_pdfCurrentPage+delta));
+  renderPDFSplitView();
+}
+
+function setPdfViewTab(tab,btn){
+  const textTab=$('pdf-text-tab');const entTab=$('pdf-entities-tab');
+  if(textTab)textTab.style.display=tab==='text'?'':'none';
+  if(entTab)entTab.style.display=tab==='entities'?'':'none';
+  document.querySelectorAll('.pdf-view-hdr .tab').forEach(t=>t.classList.remove('a'));
+  if(btn)btn.classList.add('a');
 }
 
 async function runPDFNER(){

--- a/src/kwb/api/routes/pdf.py
+++ b/src/kwb/api/routes/pdf.py
@@ -155,6 +155,30 @@ async def pdf_list():
 
 
 # ---------------------------------------------------------------------------
+# Page image (scan preview)
+# ---------------------------------------------------------------------------
+
+@router.get("/api/pdf/{doc_id}/page/{page_num}/image")
+async def pdf_page_image(doc_id: str, page_num: int):
+    """Return the rendered PNG scan for a single PDF page."""
+    import base64
+    from fastapi.responses import Response
+
+    doc = _pdf_store.get(doc_id)
+    if not doc:
+        return JSONResponse({"error": "Dokument nicht gefunden"}, status_code=404)
+    pages = doc.get("_pages_raw", [])
+    if page_num < 1 or page_num > len(pages):
+        return JSONResponse({"error": f"Seite {page_num} nicht vorhanden"}, status_code=404)
+    page = pages[page_num - 1]
+    b64 = getattr(page, "base64_data", None)
+    if not b64:
+        return JSONResponse({"error": "Keine Vorschau verfügbar"}, status_code=404)
+    img_bytes = base64.b64decode(b64)
+    return Response(content=img_bytes, media_type="image/png")
+
+
+# ---------------------------------------------------------------------------
 # Text Extraction (OCR via vision LLM)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- **#96 Bilder-Galerie**: `mat-ctx-images` als full-width Galerie-Workspace (25/75 intern). Kachel-Grid S/M/L, Status-Badges, Hover-Aktionen, Detailbereich mit KI-Analyse + Review-Formular, `quickReview()`, `saveDetailReview()`, `setGalleryDensity()`, Statusleiste.
- **#97 PDF-Arbeitsfläche**: `mat-ctx-pdf` als full-width 50/50-Split. Links: Upload + Extraktion + NER-Controls. Rechts: Volltext-Tab mit Entity-Highlighting + Entities-Tab, Seitennavigation, Scan-Vorschau via neuem Endpunkt `GET /api/pdf/{id}/page/{n}/image`.
- Doppelte Controls aus ext-ner-Tab durch Redirect-Hinweise ersetzt; Legacy-IDs als versteckte Platzhalter erhalten.

## Test plan

- [ ] `mat-ctx-images` öffnen → Galerie-Grid erscheint, Filter- und Dichte-Buttons funktionieren
- [ ] Kachel anklicken → Detailbereich öffnet sich, 50/50-Split aktiv
- [ ] Hover auf Kachel → ✓/✗ Schnellreview-Buttons sichtbar, Review wird gespeichert
- [ ] `mat-ctx-pdf` öffnen → 50/50-Split, Upload + Dok-Selector links
- [ ] Nach Textextraktion: Text erscheint rechts, Seitennavigation aktiv, Scan-Vorschau lädt
- [ ] Nach NER: Entities werden farbig im Text hervorgehoben
- [ ] CI „Testkatalog Konsistenz" grün (861 passed, 20 skipped)

https://claude.ai/code/session_01MeQDE7vXzg7QEwQFHF8ja9