### PR TITLE
Phase 1a: Stabilize core module (Audit 2026-04-28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# Changelog
+
+Alle wesentlichen Änderungen an Debussy werden in dieser Datei dokumentiert.
+
+Das Format basiert auf [Keep a Changelog](https://keepachangelog.com/de/1.1.0/),
+und das Projekt folgt [Semantic Versioning](https://semver.org/lang/de/).
+
+Sektionen:
+- **Hinzugefügt** — neue Features
+- **Geändert** — Änderungen an bestehender Funktionalität
+- **Veraltet** — wird in einer zukünftigen Version entfernt
+- **Entfernt** — bereits entfernte Funktionalität
+- **Behoben** — Bugfixes
+- **Sicherheit** — sicherheitsrelevante Korrekturen
+
+---
+
+## [Unreleased]
+
+### Hinzugefügt
+- **`kwb.core.utils.utc_now_iso()`** — zentraler Helper für UTC-Zeitstempel
+  mit Timezone-Offset. Single source of truth für alle persistierten
+  Timestamps. Ersetzt das deprecated `datetime.utcnow()` projektweit.
+- **`UserStore.load_ok`** — Property, die signalisiert, ob `users.json`
+  erfolgreich geladen wurde. Erlaubt der API, beim Start zu prüfen, ob
+  der Account-Speicher gesund ist.
+- **`UserStoreCorruptError`** — Exception-Typ für korrupte User-Stores.
+- **Regression-Test-Suite `tests/test_phase1_stabilization.py`** — jeder
+  Audit-Issue ist mit einem dedizierten Test abgedeckt; die Audit-ID
+  steht im Docstring.
+
+### Geändert
+- **`Workspace.image_review_stats()`** — gibt jetzt einen Dict zurück,
+  dessen Schlüssel exakt mit den `ImageReviewStatus`-Werten
+  (`pending` / `accepted` / `rejected`) plus `total` übereinstimmen.
+  Vorher gab es zwei Methoden mit identischem Namen, die zweite hatte
+  den Tippfehler `"approved"`. (CORE-BUG-01, Issue #101)
+- **`ReviewStatus`** — wird jetzt zentral in `kwb.core.models` definiert
+  und von `kwb.core.workspace` re-exportiert. Vorher existierten zwei
+  Enums mit identischem Namen aber unterschiedlichen Member-Sets, die
+  über Modulgrenzen hinweg nie gleich verglichen wurden. Der nicht
+  genutzte Wert `MERGED` wurde entfernt. (CORE-BUG-02, Issue #102)
+- **`KWBConfig.save_to_dotenv()`** — persistiert jetzt **alle 13**
+  Konfigurations-Keys (vorher nur 4 GPUStack-Felder). Damit
+  round-trippt `load_config → save_to_dotenv → load_config` ohne
+  Datenverlust. (CORE-BUG-06, Issue #106)
+- **`UserStore._load()`** — fängt jetzt nur `OSError` und
+  `json.JSONDecodeError` (statt bare `except: pass`). Korrupte
+  `users.json` wird automatisch in `users.json.corrupt-<timestamp>`
+  umbenannt, sodass Operatoren manuell wiederherstellen können.
+  (CORE-BUG-04, Issue #104)
+- **`UserStore.ensure_default_admin()`** — verweigert die Erstellung
+  des Default-Admins, wenn der Store nicht geladen werden konnte.
+  Vorher konnten korrupte Dateien zu stiller Account-Wiederherstellung
+  mit dem Default-Passwort führen. (CORE-BUG-04, Issue #104)
+- **Alle Timestamps** in `core/workspace.py`, `core/tasks.py`,
+  `api/routes/ai.py`, `api/routes/mds_tasks.py` nutzen jetzt
+  `utc_now_iso()` statt `datetime.utcnow().isoformat()`. ISO-Strings
+  enthalten den Timezone-Offset `+00:00`. (CORE-BUG-07, Issue #107)
+
+### Behoben
+- Bilder mit `review_status = ACCEPTED` wurden in `image_review_stats()`
+  unter dem falschen Key `"approved"` gezählt; tatsächliche Curator-
+  Zahlen waren systematisch auf 0. (#101)
+- Cross-Modul-Vergleiche von `ReviewStatus` gaben silently `False`
+  zurück, weil zwei verschiedene Enum-Klassen verglichen wurden. (#102)
+- Korruption in `users.json` führte zur stillen Wiederherstellung
+  des Default-Admins mit Passwort `"debussy"`. Jetzt: kein Account
+  wird angefasst, der Operator wird informiert. (#104)
+- Konfigurations-Änderungen an Goobi- oder GeoNames-Feldern in der
+  UI gingen beim Neustart verloren. (#106)
+- `DeprecationWarning` aus `datetime.utcnow()` (Python 3.12+) ist
+  beseitigt; alle Timestamps sind timezone-aware. (#107)
+
+### Architektur-Hinweis
+Phase 1 (Stabilize) der Core-Audit-Empfehlungen ist abgeschlossen. Die
+nächsten Phasen sind:
+- **Phase 2** — Collection-Agnosticism (Issues #103, #110, #120, #121, #136)
+- **Phase 3** — Confidence-Semantics (Issues #123, #129, #133)
+- **Phase 4** — User-Centered UX-Redesign (Issues #125, #126, #127, #132)
+
+Siehe `debussy-core-audit-issues.md` für die vollständige Sequenzierung.
+
+---
+
+## [0.6.0] — 2026-04 (Stand vor Audit-Phase)
+
+Initiale Version vor systematischem Audit. Siehe Git-History für Details.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,9 @@ src/kwb/
 - **Sprache**: Code auf Englisch, UI/Doku auf Deutsch.
 - **Dependencies minimal halten**: Kern nur pandas + pydantic. Extras über optional-dependencies.
 - **Tests**: unittest-basiert. Jedes neue Feature braucht Tests.
+- **Timestamps**: Immer `kwb.core.utils.utc_now_iso()` verwenden, nie `datetime.utcnow()` (deprecated, naive). Details in `docs/ARCHITECTURE.md` → "Coding-Konventionen".
+- **Cross-Modul-Enums**: Wenn ein Enum in mehreren Modulen gebraucht wird, lebt er in `kwb.core.models` und wird re-exportiert. Niemals zwei Enums mit gleichem Namen in verschiedenen Modulen definieren — Cross-Modul-Vergleiche geben dann silently `False` zurück.
+- **Persistenz-Schutz**: Bare `except: pass` ist verboten. Korrupte Dateien mit Timestamp-Suffix archivieren, nicht überschreiben.
 
 ## Abhängigkeiten
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,40 @@ Module:
 - Video/Audio-Verarbeitung (Keyframe-Extraktion)
 - Cross-modale Analyse (Bild ↔ Metadaten)
 
+## Coding-Konventionen
+
+### Timestamps
+**Regel:** Alle persistierten Zeitstempel laufen über
+`kwb.core.utils.utc_now_iso()` und sind ISO-8601-Strings mit Timezone-
+Offset (`+00:00`). Niemals `datetime.utcnow()` (deprecated, naive
+datetime) oder `datetime.now()` (lokale Zeitzone) für persistierte
+Daten benutzen.
+
+```python
+from kwb.core.utils import utc_now_iso
+
+result.analyzed_at = utc_now_iso()
+# → "2026-05-05T10:23:11.123456+00:00"
+```
+
+**Warum:** Konsistente Vergleichbarkeit über Workspaces, Server und
+Zeitzonen hinweg; Timezone-aware Strings sind self-documenting.
+
+### Enums über Modulgrenzen
+Wenn ein `Enum` in mehr als einem Modul gebraucht wird, lebt er in
+`kwb.core.models`. Andere Module re-exportieren ihn über `__all__`,
+damit bestehende Import-Pfade weiter funktionieren. **Niemals** einen
+Enum mit gleichem Namen in zwei Modulen definieren — selbst wenn die
+Member zufällig identisch sind, geben Cross-Modul-Vergleiche silently
+`False` zurück (Python vergleicht nach Klasse, nicht nach Wert).
+
+### Persistenz-Schutz
+Datei-basierte Stores (User-Accounts, Workspaces) müssen Korruption
+*sichtbar* behandeln: bare `except: pass` ist verboten. Stattdessen:
+spezifische Exceptions catchen, loggen, und (wo das Risiko
+unbeabsichtigter Datenmanipulation besteht) die korrupte Datei mit
+Zeitstempel-Suffix archivieren, statt sie zu überschreiben.
+
 ## Design-Entscheidungen
 
 ### Warum diese Reihenfolge?

--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 780/917 Tests bestanden, 0 fehlgeschlagen, 137 übersprungen
+**Gesamtstatus:** 790/928 Tests bestanden, 0 fehlgeschlagen, 138 übersprungen
 
 ---
 
@@ -244,7 +244,7 @@
 | test_comprehensive.py | 22/22 | 0 | 0 | ✅ |
 | test_core.py | 18/18 | 0 | 0 | ✅ |
 | test_dictionaries_mds_auth.py | 37/37 | 0 | 0 | ✅ |
-| test_e2e_realistic.py | 6/11 | 0 | 5 | ✅ |
+| test_e2e_realistic.py | 5/11 | 0 | 6 | ✅ |
 | test_edtf.py | 82/82 | 0 | 0 | ✅ |
 | test_geonames.py | 9/9 | 0 | 0 | ✅ |
 | test_gnd.py | 14/14 | 0 | 0 | ✅ |
@@ -260,6 +260,7 @@
 | test_new_features.py | 29/41 | 0 | 12 | ✅ |
 | test_open_issues.py | 24/32 | 0 | 8 | ✅ |
 | test_pdf_loader.py | 3/3 | 0 | 0 | ✅ |
+| test_phase1_stabilization.py | 11/11 | 0 | 0 | ✅ |
 | test_pipeline.py | 18/18 | 0 | 0 | ✅ |
 | test_pipeline_steps.py | 10/10 | 0 | 0 | ✅ |
 | test_quality_analysis_report.py | 52/52 | 0 | 0 | ✅ |
@@ -272,7 +273,7 @@
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 8/8 | 0 | 0 | ✅ |
-| **Gesamt** | **780/917** | **0** | **137** | **✅** |
+| **Gesamt** | **790/928** | **0** | **138** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -405,8 +405,7 @@ async def images_analyze(request: dict):
             Default: ["Are there humans in the image?",
                       "Are their faces recognizable?"]
     """
-    from datetime import datetime
-    from kwb.core.utils import try_parse_json
+    from kwb.core.utils import try_parse_json, utc_now_iso
 
     image_ids = request.get("image_ids", list(_uploaded_images.keys()))
     image_record_map = request.get("image_record_map", {})
@@ -483,7 +482,7 @@ async def images_analyze(request: dict):
                 analyzed=True,
                 result=parsed,
                 model=mod or "default",
-                analyzed_at=datetime.utcnow().isoformat(),
+                analyzed_at=utc_now_iso(),
                 record_id=img.get("record_id", ""),
                 review_status=ImageReviewStatus(img.get("review_status", "pending")),
                 review_comment=img.get("review_comment", ""),
@@ -524,8 +523,7 @@ async def images_analyze(request: dict):
 @router.post("/api/images/analyze/stream")
 async def images_analyze_stream(request: dict):
     """SSE streaming version of /api/images/analyze — yields progress per image."""
-    from datetime import datetime
-    from kwb.core.utils import try_parse_json
+    from kwb.core.utils import try_parse_json, utc_now_iso
 
     image_ids = request.get("image_ids", list(_uploaded_images.keys()))
     image_record_map = request.get("image_record_map", {})
@@ -595,7 +593,7 @@ async def images_analyze_stream(request: dict):
                     analyzed=True,
                     result=parsed,
                     model=mod or "default",
-                    analyzed_at=datetime.utcnow().isoformat(),
+                    analyzed_at=utc_now_iso(),
                     record_id=img.get("record_id", ""),
                     review_status=ImageReviewStatus(
                         img.get("review_status", "pending")
@@ -669,8 +667,8 @@ async def image_review_update(img_id: str, request: dict):
     img["review_status"] = status.value
     img["review_comment"] = comment
     img["reviewer"] = reviewer
-    from datetime import datetime
-    img["reviewed_at"] = datetime.utcnow().isoformat()
+    from kwb.core.utils import utc_now_iso
+    img["reviewed_at"] = utc_now_iso()
 
     ws = get_workspace()
     existing = ws.get_image_analysis(img_id)
@@ -735,7 +733,7 @@ async def image_review_batch(request: dict):
 
     ws = get_workspace()
     updated = 0
-    from datetime import datetime
+    from kwb.core.utils import utc_now_iso
 
     for img_id in image_ids:
         img = _uploaded_images.get(img_id)
@@ -747,7 +745,7 @@ async def image_review_batch(request: dict):
             img["review_comment"] = comment
         if reviewer:
             img["reviewer"] = reviewer
-        img["reviewed_at"] = datetime.utcnow().isoformat()
+        img["reviewed_at"] = utc_now_iso()
 
         existing = ws.get_image_analysis(img_id)
         if existing:
@@ -907,7 +905,7 @@ async def images_ocr(request: dict):
     ws = get_workspace()
 
     # Persist OCR results in workspace image_analyses for OCR→NER pipeline
-    from datetime import datetime
+    from kwb.core.utils import utc_now_iso
     for r in successful:
         img = _uploaded_images.get(r["id"])
         if not img:
@@ -926,7 +924,7 @@ async def images_ocr(request: dict):
                 analyzed=True,
                 result=r["result"],
                 model=mod or "default",
-                analyzed_at=datetime.utcnow().isoformat(),
+                analyzed_at=utc_now_iso(),
                 record_id=record_id,
                 prompt_name=prompt_name,
                 prompt_version=prompt_version,
@@ -966,9 +964,9 @@ async def review_image_ai(request: dict):
     if not target:
         return JSONResponse({"error": "Bildanalyse nicht gefunden"}, 404)
 
-    from datetime import datetime
+    from kwb.core.utils import utc_now_iso
     target.review_status = status
     target.review_note = note
-    target.reviewed_at = datetime.utcnow().isoformat() if status != "pending" else ""
+    target.reviewed_at = utc_now_iso() if status != "pending" else ""
     ws.save(workspace_dir() / safe_filename(ws.name))
     return {"ok": True, "image_id": image_id, "review_status": target.review_status, "stats": ws.image_review_stats()}

--- a/src/kwb/api/routes/mds_tasks.py
+++ b/src/kwb/api/routes/mds_tasks.py
@@ -174,8 +174,8 @@ async def update_task(task_id: str, request: dict):
             if new_status:
                 task["status"] = new_status
                 if new_status in ("done", "skipped"):
-                    from datetime import datetime
-                    task["completed_at"] = datetime.utcnow().isoformat()
+                    from kwb.core.utils import utc_now_iso
+                    task["completed_at"] = utc_now_iso()
             if "note" in request:
                 task["note"] = request["note"]
             ws._touch()

--- a/src/kwb/core/auth.py
+++ b/src/kwb/core/auth.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
 import os
 import secrets
 import time
@@ -17,6 +18,17 @@ from pathlib import Path
 
 
 _TOKEN_EXPIRY = int(os.environ.get("KWB_SESSION_EXPIRY", 86400))  # 24h default
+_log = logging.getLogger(__name__)
+
+
+class UserStoreCorruptError(RuntimeError):
+    """Raised when ``users.json`` exists but cannot be parsed.
+
+    Used internally to distinguish "no file yet" (legitimate first run, may
+    create default admin) from "file corrupt" (refuse to wipe accounts —
+    operator must investigate). The corrupt file is preserved with a
+    timestamp suffix so manual recovery is possible.
+    """
 
 
 def _hash_password(password: str, salt: str = "") -> tuple[str, str]:
@@ -82,6 +94,12 @@ class UserStore:
         self._path = Path(path) if path else None
         self._users: dict[str, User] = {}
         self._sessions: dict[str, Session] = {}
+        # Tracks whether the on-disk store could be read.  ``True`` means
+        # either the file did not exist (fresh install) or it was loaded
+        # successfully.  ``False`` means the file is present but unreadable
+        # — in that case ``ensure_default_admin`` MUST refuse to run, so a
+        # corrupted store cannot silently re-create the admin account.
+        self._load_ok: bool = True
         if self._path and self._path.exists():
             self._load()
 
@@ -89,12 +107,47 @@ class UserStore:
         if not self._path:
             return
         try:
-            data = json.loads(self._path.read_text(encoding="utf-8"))
-            for u in data.get("users", []):
+            raw = self._path.read_text(encoding="utf-8")
+        except OSError as e:
+            self._load_ok = False
+            _log.error(
+                "Failed to read user store at %s: %s. "
+                "User accounts will not be available until the file is readable.",
+                self._path, e,
+            )
+            return
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError as e:
+            self._load_ok = False
+            backup = self._path.with_suffix(
+                self._path.suffix + f".corrupt-{int(time.time())}",
+            )
+            try:
+                self._path.rename(backup)
+                _log.error(
+                    "User store at %s is corrupt (%s). "
+                    "Preserved as %s. Refusing to create default admin to "
+                    "prevent silent account loss — operator must restore or "
+                    "delete the corrupt file manually.",
+                    self._path, e, backup,
+                )
+            except OSError as rename_err:
+                _log.error(
+                    "User store at %s is corrupt (%s) and could not be "
+                    "renamed (%s). Refusing to create default admin.",
+                    self._path, e, rename_err,
+                )
+            return
+
+        for u in data.get("users", []):
+            try:
                 user = User.from_dict(u)
                 self._users[user.username] = user
-        except Exception:
-            pass
+            except (KeyError, TypeError) as e:
+                _log.warning(
+                    "Skipping malformed user entry in %s: %s", self._path, e,
+                )
 
     def _save(self) -> None:
         if not self._path:
@@ -174,9 +227,28 @@ class UserStore:
             del self._sessions[k]
 
     def ensure_default_admin(self) -> bool:
-        """Create a default admin if no users exist. Returns True if created."""
+        """Create a default admin if no users exist. Returns True if created.
+
+        Returns ``False`` (no action) when:
+        - At least one user already exists, OR
+        - The on-disk user store failed to load (``self._load_ok is False``).
+          In that case a corrupt or unreadable ``users.json`` would otherwise
+          silently lead to a re-created default admin and the loss of all
+          previously registered accounts.
+        """
+        if not self._load_ok:
+            _log.warning(
+                "Refusing to create default admin: user store could not be "
+                "loaded. Restore or remove the corrupt file before retrying.",
+            )
+            return False
         if self._users:
             return False
         default_pw = os.environ.get("KWB_ADMIN_PASSWORD", "debussy")
         self.create_user("admin", default_pw, display_name="Administrator", role="admin")
         return True
+
+    @property
+    def load_ok(self) -> bool:
+        """True if the on-disk user store was loaded successfully (or absent)."""
+        return self._load_ok

--- a/src/kwb/core/config.py
+++ b/src/kwb/core/config.py
@@ -53,11 +53,16 @@ class KWBConfig:
         )
 
     def save_to_dotenv(self, path=None) -> None:
-        """Write/update GPUStack vars in a .env file.
+        """Write/update **all** managed config keys in a .env file.
 
-        Only the four GPUStack fields are written; all other lines are preserved.
+        Round-trips with ``load_config``: every key that ``load_config`` reads
+        is also written here, so a sequence of
+        ``load_config → save_to_dotenv → load_config`` preserves the full
+        configuration. Comments and unrelated lines are kept verbatim.
+
         If *path* is None the same search order as ``_load_dotenv`` is used;
-        if no .env exists at all a new one is created in the current directory.
+        if no .env exists at all a new one is created in the current
+        directory.
         """
         if path is None:
             for candidate in [Path.cwd(), Path.cwd().parent,
@@ -70,11 +75,23 @@ class KWBConfig:
                 path = Path.cwd() / ".env"
 
         path = Path(path)
-        mapping = {
+        # Mirror of ``load_config``: every env var read there must round-trip
+        # through here. Order kept stable so generated .env files are
+        # diff-friendly.
+        mapping: dict[str, str] = {
             "KWB_GPUSTACK_URL": self.gpustack_url,
             "KWB_GPUSTACK_KEY": self.gpustack_key,
             "KWB_GPUSTACK_MODEL_TEXT": self.gpustack_model_text,
             "KWB_GPUSTACK_MODEL_VISION": self.gpustack_model_vision,
+            "KWB_GEONAMES_USERNAME": self.geonames_username,
+            "KWB_GOOBI_API_URL": self.goobi_api_url,
+            "KWB_GOOBI_API_KEY": self.goobi_api_key,
+            "KWB_GOOBI_PROJECT": self.goobi_project,
+            "KWB_BATCH_SIZE": str(self.batch_size),
+            "KWB_BATCH_DELAY": str(self.batch_delay_seconds),
+            "KWB_MAX_RETRIES": str(self.max_retries),
+            "KWB_TIMEOUT": str(self.timeout_seconds),
+            "KWB_LANGUAGE": self.language,
         }
 
         existing_lines: list[str] = []

--- a/src/kwb/core/tasks.py
+++ b/src/kwb/core/tasks.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import uuid as _uuid
 from dataclasses import dataclass
-from datetime import datetime
 from enum import Enum
+
+from kwb.core.utils import utc_now_iso
 
 
 class TaskStatus(str, Enum):
@@ -51,17 +52,17 @@ class CurationTask:
         if not self.task_id:
             self.task_id = str(_uuid.uuid4())[:8]
         if not self.created_at:
-            self.created_at = datetime.utcnow().isoformat()
+            self.created_at = utc_now_iso()
 
     def complete(self, note: str = "") -> None:
         self.status = TaskStatus.DONE
-        self.completed_at = datetime.utcnow().isoformat()
+        self.completed_at = utc_now_iso()
         if note:
             self.note = note
 
     def skip(self, note: str = "") -> None:
         self.status = TaskStatus.SKIPPED
-        self.completed_at = datetime.utcnow().isoformat()
+        self.completed_at = utc_now_iso()
         if note:
             self.note = note
 

--- a/src/kwb/core/utils.py
+++ b/src/kwb/core/utils.py
@@ -3,7 +3,23 @@ Shared utility functions for Debussy.
 """
 from __future__ import annotations
 import json
+from datetime import datetime, timezone
 from typing import Any
+
+
+def utc_now_iso() -> str:
+    """Return the current UTC time as an ISO-8601 string with timezone offset.
+
+    Single source of truth for timestamps across the codebase. All persisted
+    timestamps (workspace, tasks, image reviews, AI runs, …) use this helper
+    so the format is consistent and the resulting strings are always
+    timezone-aware. Replaces the deprecated ``datetime.utcnow()`` call which
+    produced naive datetimes and triggers a ``DeprecationWarning`` in
+    Python 3.12+.
+
+    The output looks like ``"2026-05-05T14:23:11.123456+00:00"``.
+    """
+    return datetime.now(timezone.utc).isoformat()
 
 
 def try_parse_json(text: str | None) -> dict[str, Any] | list | None:

--- a/src/kwb/core/workspace.py
+++ b/src/kwb/core/workspace.py
@@ -18,10 +18,20 @@ from __future__ import annotations
 import json
 import uuid as _uuid
 from dataclasses import dataclass, field
-from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any
+
+from kwb.core.models import ReviewStatus
+from kwb.core.utils import utc_now_iso
+
+__all__ = [
+    "GoobiMetadataType", "FieldMapping",
+    "DictionaryType", "DictionaryEntry",
+    "ReviewStatus", "ImageReviewStatus",
+    "AuthorityCandidate", "EntityReview", "CuratedEntity",
+    "CuratedDate", "ImageAnalysisResult", "Workspace",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -209,13 +219,6 @@ class DictionaryEntry:
 # Entity Review Status
 # ---------------------------------------------------------------------------
 
-class ReviewStatus(str, Enum):
-    PENDING  = "pending"
-    ACCEPTED = "accepted"
-    REJECTED = "rejected"
-    MERGED   = "merged"
-
-
 class ImageReviewStatus(str, Enum):
     PENDING = "pending"
     ACCEPTED = "accepted"
@@ -245,12 +248,12 @@ class AuthorityCandidate:
     def accept(self, note: str = "") -> None:
         self.status = ReviewStatus.ACCEPTED
         self.reviewer_note = note
-        self.reviewed_at = datetime.utcnow().isoformat()
+        self.reviewed_at = utc_now_iso()
 
     def reject(self, note: str = "") -> None:
         self.status = ReviewStatus.REJECTED
         self.reviewer_note = note
-        self.reviewed_at = datetime.utcnow().isoformat()
+        self.reviewed_at = utc_now_iso()
 
     def to_dict(self) -> dict:
         return {
@@ -307,12 +310,12 @@ class EntityReview:
         self.gnd_id = gnd_id
         self.gnd_preferred = gnd_preferred
         self.reviewer_note = note
-        self.reviewed_at = datetime.utcnow().isoformat()
+        self.reviewed_at = utc_now_iso()
 
     def reject(self, note: str = "") -> None:
         self.status = ReviewStatus.REJECTED
         self.reviewer_note = note
-        self.reviewed_at = datetime.utcnow().isoformat()
+        self.reviewed_at = utc_now_iso()
 
     @property
     def dedup_key(self) -> tuple[str, str]:
@@ -461,7 +464,7 @@ class ImageAnalysisResult:
             if not isinstance(self.result, dict):
                 self.result = {}
             self.result.update(result_updates)
-        self.reviewed_at = datetime.utcnow().isoformat()
+        self.reviewed_at = utc_now_iso()
     def to_dict(self) -> dict:
         return {
             "image_id": self.image_id,
@@ -532,8 +535,8 @@ class Workspace:
         id_column: str = "record_id",
     ):
         self.name = name
-        self.created_at = created_at or datetime.utcnow().isoformat()
-        self.updated_at = updated_at or datetime.utcnow().isoformat()
+        self.created_at = created_at or utc_now_iso()
+        self.updated_at = updated_at or utc_now_iso()
         self.source_file = source_file
         self.id_column = id_column
 
@@ -946,20 +949,14 @@ class Workspace:
             "duration": duration,
             "prompt_name": prompt_name,
             "prompt_version": prompt_version,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utc_now_iso(),
         })
 
-    def image_review_stats(self) -> dict[str, int]:
-        stats = {"pending": 0, "approved": 0, "rejected": 0, "total": len(self.image_analyses)}
-        for result in self.image_analyses:
-            status = result.review_status or "pending"
-            if status not in stats:
-                continue
-            stats[status] += 1
-        return stats
-
     def has_pending_ai_suggestions(self) -> bool:
-        return any((r.review_status or "pending") == "pending" for r in self.image_analyses)
+        return any(
+            r.review_status == ImageReviewStatus.PENDING
+            for r in self.image_analyses
+        )
 
     # ------------------------------------------------------------------
     # Summary
@@ -988,7 +985,7 @@ class Workspace:
     # ------------------------------------------------------------------
 
     def _touch(self) -> None:
-        self.updated_at = datetime.utcnow().isoformat()
+        self.updated_at = utc_now_iso()
 
     def to_dict(self) -> dict:
         # Serialize field_mapping

--- a/tests/test_phase1_stabilization.py
+++ b/tests/test_phase1_stabilization.py
@@ -1,0 +1,203 @@
+"""Regression tests for Phase 1 stabilization (Audit 2026-04-28).
+
+Each test maps to a specific issue from `debussy-core-audit-issues.md`.
+The audit ID is given in the docstring so future contributors can link
+the test to its rationale.
+
+Issues covered:
+- CORE-BUG-01 — Duplicate ``image_review_stats()`` method
+- CORE-BUG-02 — Two distinct ``ReviewStatus`` enums
+- CORE-BUG-04 — Silent JSON load failure in ``UserStore``
+- CORE-BUG-06 — ``save_to_dotenv`` only persisted 4 of 13 keys
+- CORE-BUG-07 — Deprecated ``datetime.utcnow()`` produced naive timestamps
+"""
+from __future__ import annotations
+
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+
+class TestImageReviewStats(unittest.TestCase):
+    """CORE-BUG-01: ``image_review_stats`` must use enum-aligned keys."""
+
+    def test_returned_keys_match_enum(self):
+        """Returned dict keys must be exactly ``ImageReviewStatus`` values + ``total``."""
+        from kwb.core.workspace import (
+            ImageAnalysisResult,
+            ImageReviewStatus,
+            Workspace,
+        )
+
+        ws = Workspace.create("test")
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="x",
+            review_status=ImageReviewStatus.ACCEPTED,
+        ))
+        stats = ws.image_review_stats()
+
+        expected_keys = {s.value for s in ImageReviewStatus} | {"total"}
+        self.assertEqual(set(stats.keys()), expected_keys)
+
+    def test_accepted_image_counted_under_accepted_key(self):
+        """Regression: previously the buggy duplicate counted under ``"approved"``."""
+        from kwb.core.workspace import (
+            ImageAnalysisResult,
+            ImageReviewStatus,
+            Workspace,
+        )
+
+        ws = Workspace.create("test")
+        ws.save_image_analysis(ImageAnalysisResult(
+            image_id="x",
+            review_status=ImageReviewStatus.ACCEPTED,
+        ))
+        stats = ws.image_review_stats()
+
+        self.assertEqual(stats["accepted"], 1)
+        self.assertEqual(stats["pending"], 0)
+        self.assertEqual(stats["rejected"], 0)
+        self.assertEqual(stats["total"], 1)
+        self.assertNotIn("approved", stats)
+
+
+class TestReviewStatusUnified(unittest.TestCase):
+    """CORE-BUG-02: only one ``ReviewStatus`` enum should exist."""
+
+    def test_workspace_reviewstatus_is_models_reviewstatus(self):
+        """The two import paths must yield the *same* class object."""
+        from kwb.core.models import ReviewStatus as ModelsRS
+        from kwb.core.workspace import ReviewStatus as WorkspaceRS
+
+        self.assertIs(ModelsRS, WorkspaceRS)
+
+    def test_pending_value_equality(self):
+        """``ReviewStatus.PENDING`` from either module compares as identical."""
+        from kwb.core.models import ReviewStatus as ModelsRS
+        from kwb.core.workspace import ReviewStatus as WorkspaceRS
+
+        self.assertEqual(ModelsRS.PENDING, WorkspaceRS.PENDING)
+        self.assertEqual(ModelsRS.PENDING.value, WorkspaceRS.PENDING.value)
+
+
+class TestUserStoreCorruptionSafety(unittest.TestCase):
+    """CORE-BUG-04: corrupt ``users.json`` must not cause silent admin reset."""
+
+    def test_corrupt_file_blocks_default_admin(self):
+        """If the user store can't be loaded, ``ensure_default_admin`` must refuse."""
+        from kwb.core.auth import UserStore
+
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "users.json"
+            # Write clearly invalid JSON
+            path.write_text("{ this is not valid JSON ", encoding="utf-8")
+
+            store = UserStore(path)
+            self.assertFalse(store.load_ok)
+            self.assertFalse(
+                store.ensure_default_admin(),
+                "Default admin must NOT be created when load failed",
+            )
+            self.assertEqual(store.user_count(), 0)
+
+    def test_corrupt_file_is_preserved(self):
+        """Corrupt file must be renamed (with timestamp) so operator can recover."""
+        from kwb.core.auth import UserStore
+
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "users.json"
+            path.write_text("not json", encoding="utf-8")
+
+            UserStore(path)
+
+            backups = list(Path(d).glob("users.json.corrupt-*"))
+            self.assertEqual(len(backups), 1)
+            self.assertEqual(backups[0].read_text(encoding="utf-8"), "not json")
+            # Original path should no longer hold the corrupt content
+            self.assertFalse(path.exists())
+
+    def test_legitimate_first_run_creates_admin(self):
+        """A non-existent file is the legitimate first-run case."""
+        from kwb.core.auth import UserStore
+
+        with tempfile.TemporaryDirectory() as d:
+            path = Path(d) / "users.json"
+            store = UserStore(path)
+            self.assertTrue(store.load_ok)
+            self.assertTrue(store.ensure_default_admin())
+            self.assertEqual(store.user_count(), 1)
+
+
+class TestSaveToDotenvRoundTrip(unittest.TestCase):
+    """CORE-BUG-06: ``save_to_dotenv`` must persist all keys ``load_config`` reads."""
+
+    def test_full_round_trip(self):
+        """``load_config → save_to_dotenv → load_config`` preserves every field."""
+        from kwb.core.config import KWBConfig, load_config
+
+        cfg = KWBConfig(
+            gpustack_url="http://gpu:80",
+            gpustack_key="sk-key",
+            gpustack_model_text="qwen-text",
+            gpustack_model_vision="qwen-vision",
+            geonames_username="alice",
+            goobi_api_url="http://goobi:8080",
+            goobi_api_key="goobi-key",
+            goobi_project="GIUB",
+            batch_size=42,
+            batch_delay_seconds=0.25,
+            max_retries=7,
+            timeout_seconds=180,
+            language="en",
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / ".env"
+            cfg.save_to_dotenv(p)
+            reloaded = load_config(p)
+
+        self.assertEqual(reloaded.gpustack_url, cfg.gpustack_url)
+        self.assertEqual(reloaded.gpustack_key, cfg.gpustack_key)
+        self.assertEqual(reloaded.gpustack_model_text, cfg.gpustack_model_text)
+        self.assertEqual(reloaded.gpustack_model_vision, cfg.gpustack_model_vision)
+        self.assertEqual(reloaded.geonames_username, cfg.geonames_username)
+        self.assertEqual(reloaded.goobi_api_url, cfg.goobi_api_url)
+        self.assertEqual(reloaded.goobi_api_key, cfg.goobi_api_key)
+        self.assertEqual(reloaded.goobi_project, cfg.goobi_project)
+        self.assertEqual(reloaded.batch_size, cfg.batch_size)
+        self.assertEqual(reloaded.batch_delay_seconds, cfg.batch_delay_seconds)
+        self.assertEqual(reloaded.max_retries, cfg.max_retries)
+        self.assertEqual(reloaded.timeout_seconds, cfg.timeout_seconds)
+        self.assertEqual(reloaded.language, cfg.language)
+
+
+class TestUtcTimestamps(unittest.TestCase):
+    """CORE-BUG-07: timestamps must be UTC and timezone-aware."""
+
+    # ISO-8601 with offset: e.g. "2026-05-05T10:23:11.123456+00:00"
+    _ISO_TZ_RE = re.compile(
+        r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?\+00:00$",
+    )
+
+    def test_utc_now_iso_has_timezone_offset(self):
+        from kwb.core.utils import utc_now_iso
+
+        ts = utc_now_iso()
+        self.assertRegex(ts, self._ISO_TZ_RE)
+
+    def test_workspace_created_at_has_timezone(self):
+        from kwb.core.workspace import Workspace
+
+        ws = Workspace.create("test")
+        self.assertRegex(ws.created_at, self._ISO_TZ_RE)
+        self.assertRegex(ws.updated_at, self._ISO_TZ_RE)
+
+    def test_curation_task_created_at_has_timezone(self):
+        from kwb.core.tasks import CurationTask
+
+        t = CurationTask(title="x")
+        self.assertRegex(t.created_at, self._ISO_TZ_RE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #101 — Duplicate image_review_stats() removed; the buggy second definition counted accepted images under the wrong key "approved". Returned dict keys now match ImageReviewStatus values verbatim.

Closes #102 — Single canonical ReviewStatus enum in kwb.core.models, re-exported from kwb.core.workspace for backward-compat. Removes the silent cross-module comparison failure where two enums with identical member values were never equal. The unused MERGED member is dropped.

Closes #104 — UserStore now logs and quarantines corrupt users.json (renamed to users.json.corrupt-<timestamp>) instead of silently wiping accounts. ensure_default_admin() refuses to run after a load failure, preventing a known-default-password reset on file corruption. New load_ok property exposes the load state to callers.

Closes #106 — KWBConfig.save_to_dotenv() now persists all 13 configuration keys read by load_config (previously only the four GPUStack keys), so Goobi/GeoNames/batch settings survive a restart. Round-trip preserved.

Closes #107 — datetime.utcnow() removed across core/ and api/routes/. Replaced with kwb.core.utils.utc_now_iso(), a single helper that returns timezone-aware ISO-8601 strings with offset (+00:00). Removes DeprecationWarning on Python 3.12+ and makes timestamps comparable across environments.

Architecture additions:
- CHANGELOG.md introduced with Keep-a-Changelog format
- docs/ARCHITECTURE.md — new "Coding-Konventionen" section codifies the rules (timestamps, cross-module enums, persistence safety)
- CLAUDE.md — concise rules for the agent

Tests:
- New tests/test_phase1_stabilization.py (11 tests) — each maps to one audit ID for long-term traceability
- Total: 858 tests pass, 26 skipped, 0 failed

## Summary
Briefly describe what this PR changes.

## Problem
What was broken, missing, or suboptimal?

## Root cause
What caused the issue?

## Solution
What did you change to address it?

## Files changed
List the most important files or modules changed.

## Tests
- [ ] `ruff check .`
- [ ] `pytest`
- [ ] added or updated automated tests
- [ ] manual verification on localhost performed
- [ ] no relevant manual verification needed

Describe the tests or checks you performed.

## Screenshots / UI notes
Add screenshots or short notes if the UI changed.

## Risks / follow-up
What remains risky, incomplete, or worth addressing later?