### PR TITLE
Fix Phase 3 export bugs: sameAs lists, NER merge, name parsing, GND IDs

### DIFF
--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 902/1040 Tests bestanden, 0 fehlgeschlagen, 138 übersprungen
+**Gesamtstatus:** 916/1054 Tests bestanden, 0 fehlgeschlagen, 138 übersprungen
 
 ---
 
@@ -257,7 +257,7 @@
 | test_llm_quality.py | 55/55 | 0 | 0 | ✅ |
 | test_ner.py | 29/29 | 0 | 0 | ✅ |
 | test_ner_edtf.py | 31/31 | 0 | 0 | ✅ |
-| test_new_features.py | 33/45 | 0 | 12 | ✅ |
+| test_new_features.py | 47/59 | 0 | 12 | ✅ |
 | test_open_issues.py | 24/32 | 0 | 8 | ✅ |
 | test_pdf_loader.py | 3/3 | 0 | 0 | ✅ |
 | test_phase1_stabilization.py | 11/11 | 0 | 0 | ✅ |
@@ -275,7 +275,7 @@
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 8/8 | 0 | 0 | ✅ |
-| **Gesamt** | **902/1040** | **0** | **138** | **✅** |
+| **Gesamt** | **916/1054** | **0** | **138** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/export/csv_export.py
+++ b/src/kwb/export/csv_export.py
@@ -160,6 +160,9 @@ def export_enriched_csv(
 
     # ------------------------------------------------------------------
     # GND columns — add gnd_id / gnd_preferred for known terms
+    # EXP-BUG-08 (#193): iterate over ALL ner_* columns, not just
+    # ner_persons. A curator's GND-enriched place gazetteer must surface
+    # in the export the same way as person IDs do.
     # ------------------------------------------------------------------
     if include_gnd and workspace.dictionary:
         term_to_gnd: dict[str, str] = {
@@ -168,20 +171,39 @@ def export_enriched_csv(
             if e.gnd_id
         }
         if term_to_gnd:
-            # Only add if NER columns exist — map preferred terms to GND IDs
-            if "ner_persons" in out.columns:
-                def _map_gnd(cell: str) -> str:
-                    if not cell:
-                        return ""
-                    ids = []
-                    for term in cell.split(separator.strip()):
-                        t = term.strip()
-                        gnd = term_to_gnd.get(t.lower(), "")
-                        if gnd:
-                            ids.append(gnd)
-                    return separator.join(ids)
+            sep_token = separator.strip()
 
-                out["gnd_ids"] = out["ner_persons"].map(_map_gnd)
+            def _gnd_ids_for_cell(cell: str) -> list[str]:
+                if not cell:
+                    return []
+                ids: list[str] = []
+                for term in cell.split(sep_token):
+                    t = term.strip()
+                    gnd = term_to_gnd.get(t.lower(), "")
+                    if gnd and gnd not in ids:
+                        ids.append(gnd)
+                return ids
+
+            # Combined column across all entity types (curator-friendly).
+            ner_cols = [c for c in out.columns if c.startswith("ner_")]
+            if ner_cols:
+                def _combined_gnd(row: pd.Series) -> str:
+                    seen: list[str] = []
+                    for col in ner_cols:
+                        for gnd in _gnd_ids_for_cell(str(row.get(col, "") or "")):
+                            if gnd not in seen:
+                                seen.append(gnd)
+                    return separator.join(seen)
+
+                out["gnd_ids"] = out.apply(_combined_gnd, axis=1)
+
+                # Also per-type columns so Goobi-style consumers can pick
+                # the IDs they need (gnd_persons_ids, gnd_places_ids, …).
+                for col in ner_cols:
+                    suffix = col[len("ner_"):]  # "persons", "places", ...
+                    out[f"gnd_{suffix}_ids"] = out[col].map(
+                        lambda cell: separator.join(_gnd_ids_for_cell(str(cell or "")))
+                    )
 
     # ------------------------------------------------------------------
     # Serialise to CSV string

--- a/src/kwb/export/goobi_xml.py
+++ b/src/kwb/export/goobi_xml.py
@@ -22,6 +22,7 @@ SUPPORTED ELEMENT TYPES (from Goobi schema):
 
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import Any
@@ -31,6 +32,8 @@ from xml.etree.ElementTree import (
 import sys
 
 import pandas as pd
+
+logger = logging.getLogger(__name__)
 
 from kwb.core.workspace import (
     FieldMapping, DictionaryEntry, Workspace
@@ -98,18 +101,45 @@ def _split_repeatable(value: str, sep: str = ";") -> list[str]:
     return [v.strip() for v in value.split(sep) if v.strip()]
 
 
+# EXP-BUG-07 (#192): Nobiliary / surname particles in DE, NL, FR, IT, ES.
+# When parsing "Firstname Lastname" form, these tokens stick to the surname
+# rather than ending up as part of the first name.
+_NOBILIARY_PARTICLES = frozenset({
+    # German / Dutch
+    "von", "vom", "zu", "zur", "van", "ten", "ter", "der",
+    # French
+    "de", "du", "des", "le", "la",
+    # Italian / Spanish
+    "del", "della", "di", "da", "dal", "dalla", "lo", "los", "las",
+})
+
+
 def _parse_name(full_name: str) -> tuple[str, str]:
     """
     Split 'Lastname, Firstname' or 'Firstname Lastname' into parts.
     Returns (firstname, lastname).
+
+    Handles nobiliary particles (#192): "von Goethe" → ("", "von Goethe"),
+    "Johann Wolfgang von Goethe" → ("Johann Wolfgang", "von Goethe").
     """
     if "," in full_name:
         parts = full_name.split(",", 1)
         return parts[1].strip(), parts[0].strip()
-    parts = full_name.rsplit(" ", 1)
-    if len(parts) == 2:
-        return parts[0], parts[1]
-    return "", full_name.strip()
+
+    tokens = full_name.split()
+    if len(tokens) < 2:
+        return "", full_name.strip()
+
+    # Walk from the right collecting particle tokens into the surname.
+    # The surname always starts at the index where the last particle begins
+    # (or, if no particle precedes the final token, just the final token).
+    surname_start = len(tokens) - 1
+    while surname_start > 0 and tokens[surname_start - 1].lower() in _NOBILIARY_PARTICLES:
+        surname_start -= 1
+
+    firstname = " ".join(tokens[:surname_start]).strip()
+    lastname = " ".join(tokens[surname_start:]).strip()
+    return firstname, lastname
 
 
 
@@ -304,16 +334,54 @@ def export_goobi_xml(
     df: pd.DataFrame,
     workspace: Workspace,
     doc_type: str = "MuseumObject",
+    auto_add_catalog_id: bool = True,
 ) -> list[tuple[str, str]]:
     """
     Export each row of a DataFrame to individual Goobi XML strings.
 
-    Returns a list of (record_id, xml_string) tuples.
+    Parameters
+    ----------
+    df:                   Source DataFrame
+    workspace:            Workspace with field_mapping
+    doc_type:             Goobi document type attribute
+    auto_add_catalog_id:  EXP-BUG-02 (#187). When True (default for
+        back-compat), the function injects a record_id → CatalogIDDigital
+        mapping if the curator has not mapped it. Each injection logs a
+        warning so it is no longer silent. Set to False to fail-fast when
+        CatalogIDDigital is unmapped — recommended for production exports
+        where any silent transformation undermines trust.
+
+    Returns
+    -------
+    A list of (record_id, xml_string) tuples.
+
+    Raises
+    ------
+    ValueError if auto_add_catalog_id=False and CatalogIDDigital is not
+    mapped in the workspace.
     """
     mappings = workspace.active_mappings()
     dict_lookup: dict[str, DictionaryEntry] = {}
     for d in workspace.dictionary:
         dict_lookup.setdefault(d.term.lower(), d)
+
+    # EXP-BUG-02 (#187): surface CatalogIDDigital handling up-front rather
+    # than silently injecting per-row. Either fail-fast or warn once.
+    mapped_goobi_types = {m.goobi_type for m in mappings}
+    catalog_id_mapped = "CatalogIDDigital" in mapped_goobi_types
+    if not catalog_id_mapped:
+        if not auto_add_catalog_id:
+            raise ValueError(
+                "CatalogIDDigital is not mapped in the workspace. "
+                "Either map a column to CatalogIDDigital in the field-mapping "
+                "screen, or pass auto_add_catalog_id=True to auto-inject "
+                "record_id (which will produce a warning per record)."
+            )
+        logger.warning(
+            "EXP-BUG-02: CatalogIDDigital was not mapped explicitly; "
+            "auto-injecting record_id → CatalogIDDigital. Map it explicitly "
+            "to silence this warning."
+        )
 
     for ent in workspace.entities:
         if getattr(ent.status, "value", ent.status) != "rejected" and ent.gnd_id:
@@ -335,10 +403,17 @@ def export_goobi_xml(
                     if isinstance(val, str) and val.strip() == dt.original:
                         row_dict[col_name] = dt.edtf
 
-        # Auto-add CatalogIDDigital for record_id if not already mapped
+        # EXP-BUG-02 (#187): Inject record_id → CatalogIDDigital only when
+        # auto_add was approved at the function level and the workspace has
+        # no explicit mapping. The function-level warning above already
+        # surfaced this once.
         auto_mappings = list(mappings)
-        mapped_cols = {m.csv_column for m in auto_mappings}
-        if "record_id" not in mapped_cols and "record_id" in row_dict:
+        if (
+            auto_add_catalog_id
+            and not catalog_id_mapped
+            and "record_id" in row_dict
+            and "record_id" not in {m.csv_column for m in auto_mappings}
+        ):
             auto_mappings.insert(0, FieldMapping(
                 csv_column="record_id",
                 goobi_type="CatalogIDDigital",

--- a/src/kwb/export/jsonld.py
+++ b/src/kwb/export/jsonld.py
@@ -60,9 +60,14 @@ def _make_entity_node(entity_review) -> dict[str, Any]:
         "@type": schema_type,
         "name": entity_review.text,
     }
+    # EXP-BUG-05 (#190): sameAs is always a list so new authorities can be
+    # appended without overwriting earlier ones.
+    same_as: list[str] = []
     if entity_review.gnd_id:
         node["@id"] = f"gnd:{entity_review.gnd_id}"
-        node["sameAs"] = f"https://d-nb.info/gnd/{entity_review.gnd_id}"
+        same_as.append(f"https://d-nb.info/gnd/{entity_review.gnd_id}")
+    if same_as:
+        node["sameAs"] = same_as
     if entity_review.gnd_preferred and entity_review.gnd_preferred != entity_review.text:
         node["alternateName"] = entity_review.text
         node["name"] = entity_review.gnd_preferred
@@ -120,19 +125,32 @@ def _make_record_node(
         else:
             node[schema_key] = str_val
 
-    # Add NER entities
+    # Add NER entities — EXP-BUG-03 (#188): merge with field-mapping values
+    # rather than silently overwriting. Field-mapped values keep precedence as
+    # the first entry; NER-derived entries are appended with _source="ner" so
+    # downstream consumers can distinguish.
+    def _merge_into(key: str, ner_entries: list[dict[str, Any]]) -> None:
+        if not ner_entries:
+            return
+        existing = node.get(key)
+        merged: list[Any] = []
+        if existing is not None:
+            if isinstance(existing, list):
+                merged.extend(existing)
+            else:
+                merged.append(existing)
+        for entry in ner_entries:
+            merged.append({**entry, "_source": "ner"})
+        node[key] = merged if len(merged) > 1 else merged[0]
+
     ents = entities_by_record.get(record_id, [])
     if ents:
-        # Group by type
         persons = [e for e in ents if e["type"] in ("PER",)]
         places = [e for e in ents if e["type"] in ("LOC", "GPE")]
         orgs = [e for e in ents if e["type"] in ("ORG",)]
-        if persons:
-            node["mentions"] = persons if len(persons) > 1 else persons[0]
-        if places:
-            node["contentLocation"] = places if len(places) > 1 else places[0]
-        if orgs:
-            node["accountablePerson"] = orgs if len(orgs) > 1 else orgs[0]
+        _merge_into("mentions", persons)
+        _merge_into("contentLocation", places)
+        _merge_into("accountablePerson", orgs)
 
     # Add EDTF dates
     dates = dates_by_record.get(record_id, [])
@@ -237,6 +255,9 @@ def export_jsonld(
         items.append(node)
 
     # Build authority entities from dictionary
+    # EXP-BUG-05 (#190): sameAs starts empty and authorities append, so adding
+    # a third authority (e.g. VIAF) is a one-line change with no risk of
+    # silently dropping earlier URIs.
     authority_graph = []
     for entry in workspace.dictionary:
         if not entry.has_authority:
@@ -245,15 +266,14 @@ def export_jsonld(
             "@type": "DefinedTerm",
             "name": entry.gnd_preferred or entry.term,
         }
+        same_as: list[str] = []
         if entry.gnd_id:
             anode["@id"] = f"gnd:{entry.gnd_id}"
-            anode["sameAs"] = f"https://d-nb.info/gnd/{entry.gnd_id}"
+            same_as.append(f"https://d-nb.info/gnd/{entry.gnd_id}")
         if entry.wikidata_id:
-            anode["sameAs"] = [
-                f"https://d-nb.info/gnd/{entry.gnd_id}" if entry.gnd_id else None,
-                f"https://www.wikidata.org/wiki/{entry.wikidata_id}",
-            ]
-            anode["sameAs"] = [s for s in anode["sameAs"] if s]
+            same_as.append(f"https://www.wikidata.org/wiki/{entry.wikidata_id}")
+        if same_as:
+            anode["sameAs"] = same_as
         authority_graph.append(anode)
 
     doc: dict[str, Any] = {

--- a/tests/test_new_features.py
+++ b/tests/test_new_features.py
@@ -483,6 +483,192 @@ class TestJSONLDExport(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Phase 3 Export Bugfixes (#188, #190, #192, #193, #187)
+# ---------------------------------------------------------------------------
+
+class TestPhase3JsonLdSameAs(unittest.TestCase):
+    """EXP-BUG-05 (#190): JSON-LD sameAs is always a list, never overwritten."""
+
+    def _make_workspace(self, **kwargs):
+        from kwb.core.workspace import Workspace, DictionaryEntry
+        ws = Workspace.create("sameAs-test")
+        ws.base_url = "https://kwb.example/collection/"
+        ws.dictionary = [DictionaryEntry(term="Goethe", **kwargs)]
+        return ws
+
+    def test_gnd_only_produces_list(self):
+        """Dictionary entry with only GND ID still produces list-shaped sameAs."""
+        from kwb.export.jsonld import export_jsonld
+        ws = self._make_workspace(gnd_id="118540238")
+        out = export_jsonld(pd.DataFrame({"record_id": ["r1"]}), ws)
+        doc = json.loads(out)
+        authority = [n for n in doc["@graph"] if n.get("@type") == "DefinedTerm"][0]
+        self.assertIsInstance(authority["sameAs"], list)
+        self.assertEqual(len(authority["sameAs"]), 1)
+        self.assertIn("d-nb.info", authority["sameAs"][0])
+
+    def test_gnd_plus_wikidata_lists_both(self):
+        """Both authority URIs appear in sameAs without overwrite."""
+        from kwb.export.jsonld import export_jsonld
+        ws = self._make_workspace(gnd_id="118540238", wikidata_id="Q5879")
+        out = export_jsonld(pd.DataFrame({"record_id": ["r1"]}), ws)
+        doc = json.loads(out)
+        authority = [n for n in doc["@graph"] if n.get("@type") == "DefinedTerm"][0]
+        self.assertEqual(len(authority["sameAs"]), 2)
+        joined = " ".join(authority["sameAs"])
+        self.assertIn("d-nb.info", joined)
+        self.assertIn("wikidata.org", joined)
+
+    def test_wikidata_only_no_overwrite_loss(self):
+        """Wikidata-only entry has its URI in sameAs list."""
+        from kwb.export.jsonld import export_jsonld
+        ws = self._make_workspace(wikidata_id="Q5879")
+        out = export_jsonld(pd.DataFrame({"record_id": ["r1"]}), ws)
+        doc = json.loads(out)
+        authority = [n for n in doc["@graph"] if n.get("@type") == "DefinedTerm"][0]
+        self.assertIsInstance(authority["sameAs"], list)
+        self.assertEqual(len(authority["sameAs"]), 1)
+        self.assertIn("wikidata.org", authority["sameAs"][0])
+
+
+class TestPhase3JsonLdMentionsMerge(unittest.TestCase):
+    """EXP-BUG-03 (#188): NER entities merge with field-mapping values."""
+
+    def test_ner_appends_to_field_mapping_mentions(self):
+        """NER-derived mentions append rather than overwrite mapped value."""
+        from kwb.core.workspace import Workspace, FieldMapping, EntityReview
+        from kwb.core.models import ReviewStatus
+        from kwb.export.jsonld import export_jsonld
+
+        ws = Workspace.create("merge-test")
+        ws.base_url = "https://kwb.example/collection/"
+        ws.id_column = "record_id"
+        ws.field_mapping = [
+            FieldMapping(csv_column="people", goobi_type="SubjectPerson",
+                         label="Personen"),
+        ]
+        ws.entity_reviews = [
+            EntityReview(
+                text="Schiller", entity_type="PER", record_id="r1",
+                status=ReviewStatus.ACCEPTED,
+            ),
+        ]
+
+        df = pd.DataFrame({"record_id": ["r1"], "people": ["Goethe"]})
+        out = export_jsonld(df, ws)
+        doc = json.loads(out)
+        record = [n for n in doc["@graph"] if n.get("@type") == "CreativeWork"][0]
+        mentions = record["mentions"]
+        self.assertIsInstance(mentions, list, "Should be list with both values")
+        # First entry is field-mapped, second is NER-derived
+        rendered = json.dumps(mentions)
+        self.assertIn("Goethe", rendered)
+        self.assertIn("Schiller", rendered)
+        # NER source annotation present on NER entry
+        ner_entries = [m for m in mentions if isinstance(m, dict) and m.get("_source") == "ner"]
+        self.assertEqual(len(ner_entries), 1)
+        self.assertEqual(ner_entries[0]["name"], "Schiller")
+
+
+class TestPhase3ParseName(unittest.TestCase):
+    """EXP-BUG-07 (#192): _parse_name handles nobiliary particles."""
+
+    def test_von_goethe(self):
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("von Goethe")
+        self.assertEqual(fn, "")
+        self.assertEqual(ln, "von Goethe")
+
+    def test_full_name_with_particle(self):
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("Johann Wolfgang von Goethe")
+        self.assertEqual(fn, "Johann Wolfgang")
+        self.assertEqual(ln, "von Goethe")
+
+    def test_de_la_roche(self):
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("Maria de la Roche")
+        self.assertEqual(fn, "Maria")
+        self.assertEqual(ln, "de la Roche")
+
+    def test_van_der_berg(self):
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("Pieter van der Berg")
+        self.assertEqual(fn, "Pieter")
+        self.assertEqual(ln, "van der Berg")
+
+    def test_comma_form_unchanged(self):
+        """Comma-form parsing must keep its existing behavior."""
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("Goethe, Johann Wolfgang")
+        self.assertEqual(fn, "Johann Wolfgang")
+        self.assertEqual(ln, "Goethe")
+
+    def test_simple_name_unchanged(self):
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("Albert Einstein")
+        self.assertEqual(fn, "Albert")
+        self.assertEqual(ln, "Einstein")
+
+    def test_single_token_returns_lastname(self):
+        from kwb.export.goobi_xml import _parse_name
+        fn, ln = _parse_name("Cher")
+        self.assertEqual(fn, "")
+        self.assertEqual(ln, "Cher")
+
+
+class TestPhase3CsvGndIds(unittest.TestCase):
+    """EXP-BUG-08 (#193): CSV gnd_ids covers all ner_* columns."""
+
+    def test_places_gnd_ids_appear(self):
+        from kwb.core.workspace import Workspace, DictionaryEntry
+        from kwb.export.csv_export import export_enriched_csv
+
+        ws = Workspace.create("gnd-test")
+        ws.dictionary = [
+            DictionaryEntry(term="Bern", gnd_id="4005831-9"),
+            DictionaryEntry(term="Goethe", gnd_id="118540238"),
+        ]
+        df = pd.DataFrame({
+            "record_id": ["r1", "r2"],
+            "ner_persons": ["Goethe", ""],
+            "ner_places": ["", "Bern"],
+        })
+        out_csv = export_enriched_csv(df, ws, include_gnd=True)
+        self.assertIn("4005831-9", out_csv, "Place GND ID missing from output")
+        self.assertIn("118540238", out_csv, "Person GND ID missing from output")
+        # Per-type columns should exist
+        self.assertIn("gnd_persons_ids", out_csv)
+        self.assertIn("gnd_places_ids", out_csv)
+
+
+class TestPhase3CatalogIdFailFast(unittest.TestCase):
+    """EXP-BUG-02 (#187): CatalogIDDigital injection is opt-in and visible."""
+
+    def test_fail_fast_raises_when_unmapped(self):
+        from kwb.core.workspace import Workspace
+        from kwb.export.goobi_xml import export_goobi_xml
+
+        ws = Workspace.create("catalog-test")
+        df = pd.DataFrame({"record_id": ["r1"], "title": ["x"]})
+        with self.assertRaises(ValueError) as ctx:
+            export_goobi_xml(df, ws, auto_add_catalog_id=False)
+        self.assertIn("CatalogIDDigital", str(ctx.exception))
+
+    def test_auto_add_default_still_works(self):
+        """Back-compat: default behavior keeps injecting record_id."""
+        from kwb.core.workspace import Workspace
+        from kwb.export.goobi_xml import export_goobi_xml
+
+        ws = Workspace.create("catalog-test")
+        df = pd.DataFrame({"record_id": ["r1"], "title": ["x"]})
+        results = export_goobi_xml(df, ws)  # default auto_add_catalog_id=True
+        self.assertEqual(len(results), 1)
+        # The injected mapping puts record_id into a CatalogIDDigital element
+        self.assertIn("CatalogIDDigital", results[0][1])
+
+
+# ---------------------------------------------------------------------------
 # F30: OCR API Endpoint (via TestClient)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fixes five critical export bugs (#187–#193) affecting JSON-LD authority URIs, NER entity merging, name parsing with nobiliary particles, CSV GND ID coverage, and CatalogIDDigital mapping transparency.

## Problem
1. **EXP-BUG-02 (#187)**: CatalogIDDigital injection was silent and unmapped, undermining trust in exports
2. **EXP-BUG-03 (#188)**: NER entities silently overwrote field-mapped values instead of merging
3. **EXP-BUG-05 (#190)**: JSON-LD `sameAs` was overwritten when adding multiple authorities (GND + Wikidata)
4. **EXP-BUG-07 (#192)**: Name parser ignored nobiliary particles ("von", "de", "van", etc.), splitting "von Goethe" incorrectly
5. **EXP-BUG-08 (#193)**: CSV GND export only covered `ner_persons`, missing places and other entity types

## Root cause
- `sameAs` was assigned as a string, then reassigned as a list, losing earlier values
- NER merging logic directly assigned to node keys without checking existing field-mapped values
- Name parser used simple `rsplit(" ", 1)` without particle awareness
- GND ID export hardcoded `ner_persons` column instead of iterating all `ner_*` columns
- CatalogIDDigital auto-injection happened silently per-row with no user visibility

## Solution

### `src/kwb/export/jsonld.py`
- **sameAs as list**: Initialize `same_as` as empty list, append GND and Wikidata URIs, assign once at end (prevents overwrites)
- **NER merge**: New `_merge_into()` helper appends NER entries to existing field-mapped values with `_source="ner"` marker for downstream distinction

### `src/kwb/export/goobi_xml.py`
- **Name parsing**: Added `_NOBILIARY_PARTICLES` frozenset (DE/NL/FR/IT/ES particles); parser now walks right-to-left collecting particles into surname
- **CatalogIDDigital**: Added `auto_add_catalog_id` parameter (default True for back-compat); function-level check with fail-fast when False and unmapped; single warning log instead of per-row silence

### `src/kwb/export/csv_export.py`
- **GND coverage**: Refactored to iterate all `ner_*` columns; creates both combined `gnd_ids` column and per-type columns (`gnd_persons_ids`, `gnd_places_ids`, etc.)

## Files changed
- `src/kwb/export/jsonld.py` — sameAs list handling, NER merge logic
- `src/kwb/export/goobi_xml.py` — nobiliary particle parsing, CatalogIDDigital transparency
- `src/kwb/export/csv_export.py` — GND ID coverage for all entity types
- `tests/test_new_features.py` — 14 new test cases covering all five bugs

## Tests
- [x] Added 14 comprehensive unit tests (4 test classes, 47 total tests in file)
  - `TestPhase3JsonLdSameAs`: GND-only, GND+Wikidata, Wikidata-only sameAs handling
  - `TestPhase3JsonLdMentionsMerge`: Field-mapped + NER entity merging
  - `TestPhase3ParseName`: Particle handling (von, de, van, etc.) + comma form + simple names
  - `TestPhase3CsvGndIds`: Multi-type GND ID export
  - `TestPhase3CatalogIdFailFast`: Fail-fast mode + back-compat auto-add
- [x] All existing tests remain passing
- [x] Test coverage includes edge cases (single token, comma form, multiple particles)

## Risks

https://claude.ai/code/session_011wfGtnc8zaLFLAqLfz1ScS