### PR TITLE
Phase 3 Wave 3: LIDO XML ingest + format dispatcher (F31)

### DIFF
--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 980/1123 Tests bestanden, 0 fehlgeschlagen, 143 übersprungen
+**Gesamtstatus:** 993/1136 Tests bestanden, 0 fehlgeschlagen, 143 übersprungen
 
 ---
 
@@ -21,7 +21,7 @@
 | ID | Funktion | Status | Tests | Modul | Hinweis |
 |----|----------|--------|-------|-------|---------|
 | F01 | CSV/TSV Ingest | ✅ Umgesetzt | 5/5 | `ingest/csv_loader.py` | Automatische Encoding-Erkennung (UTF-8, Latin-1, BOM), Zeilenende-Erkennung, Profiling aller Spalten |
-| F31 | XML-Import (METS/MODS, LIDO, EAD) | 🔴 Geplant | 0/0 | `ingest/` | Parsing mit lxml, Mapping auf internes Schema |
+| F31 | XML-Import (METS/MODS, LIDO, EAD) | 🟡 Teilweise | 21/21 | `ingest/xml_loader.py` | METS/MODS + LIDO via stdlib xml.etree; Format-Auto-Detection; EAD (hierarchisch) geplant |
 | F36 | Bild-Ingest (TIFF/JPEG/PNG) | ✅ Umgesetzt | 2/2 | `ingest/image_loader.py` | EXIF, Dimensionen, SHA-256, Base64 ohne Pillow |
 | F37 | PDF-Import | 🔴 Geplant | 0/0 | `ingest/` | Text + Seitenbilder extrahieren |
 
@@ -276,8 +276,8 @@
 | test_workspace.py | 33/33 | 0 | 0 | ✅ |
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
-| test_xml_loader.py | 8/8 | 0 | 0 | ✅ |
-| **Gesamt** | **980/1123** | **0** | **143** | **✅** |
+| test_xml_loader.py | 21/21 | 0 | 0 | ✅ |
+| **Gesamt** | **993/1136** | **0** | **143** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/ingest/xml_loader.py
+++ b/src/kwb/ingest/xml_loader.py
@@ -1,8 +1,9 @@
 """
-METS/MODS XML Ingest — parse METS/MODS metadata into a DataFrame.
+XML Ingest — parse METS/MODS and LIDO metadata into a DataFrame.
 
-Extracts mods:mods records from METS/MODS XML documents, producing
-a DataFrame with one row per record and standard MODS fields as columns.
+Extracts records from METS/MODS or LIDO XML documents, producing
+a DataFrame with one row per record and standard fields as columns.
+Format is auto-detected from the root element.
 Uses stdlib xml.etree.ElementTree — no extra dependencies.
 """
 
@@ -26,10 +27,11 @@ from kwb.ingest.csv_loader import (
 
 logger = logging.getLogger(__name__)
 
-# MODS namespace
+# Namespaces
 NS = {
     "mods": "http://www.loc.gov/mods/v3",
     "mets": "http://www.loc.gov/METS/",
+    "lido": "http://www.lido-schema.org",
 }
 
 
@@ -205,15 +207,271 @@ def load_mets_mods(path: str | Path, max_rows: int = MAX_ROWS) -> pd.DataFrame:
     return df
 
 
+# ---------------------------------------------------------------------------
+# LIDO (Lightweight Information Describing Objects) — museum metadata
+# ---------------------------------------------------------------------------
+
+
+def _lido_find(parent: ET.Element, path: str) -> ET.Element | None:
+    """Find a child by LIDO-namespaced path with bare-tag fallback."""
+    el = parent.find(path, NS)
+    if el is not None:
+        return el
+    # Fallback: strip namespace prefixes, match by local name
+    parts = [p.split(":")[-1] for p in path.split("/")]
+    current = parent
+    for part in parts:
+        found = None
+        for child in current.iter():
+            if child is current:
+                continue
+            tag = child.tag.split("}")[-1] if "}" in child.tag else child.tag
+            if tag == part:
+                # Only accept direct descendants in path order
+                found = child
+                break
+        if found is None:
+            return None
+        current = found
+    return current
+
+
+def _lido_findall(parent: ET.Element, path: str) -> list[ET.Element]:
+    """Find all elements matching a LIDO path; fall back to local-name match."""
+    els = parent.findall(path, NS)
+    if els:
+        return els
+    # Fallback: match only by terminal local name
+    terminal = path.split("/")[-1].split(":")[-1]
+    out: list[ET.Element] = []
+    for el in parent.iter():
+        tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+        if tag == terminal:
+            out.append(el)
+    return out
+
+
+def _extract_lido_record(lido: ET.Element) -> dict[str, str]:
+    """Extract fields from a single lido:lido element."""
+    record: dict[str, str] = {}
+
+    # Title — descriptiveMetadata/objectIdentificationWrap/titleWrap/titleSet/appellationValue
+    titles = []
+    for av in _lido_findall(
+        lido,
+        "lido:descriptiveMetadata/lido:objectIdentificationWrap/lido:titleWrap/"
+        "lido:titleSet/lido:appellationValue",
+    ):
+        t = _text(av)
+        if t:
+            titles.append(t)
+    record["title"] = "; ".join(titles)
+
+    # Record ID — administrativeMetadata/recordWrap/recordID
+    rec_id = _lido_find(
+        lido,
+        "lido:administrativeMetadata/lido:recordWrap/lido:recordID",
+    )
+    record["record_id"] = _text(rec_id)
+
+    # Abstract — descriptiveNoteValue (joined)
+    abstracts = []
+    for nv in _lido_findall(
+        lido,
+        "lido:descriptiveMetadata/lido:objectIdentificationWrap/"
+        "lido:objectDescriptionWrap/lido:objectDescriptionSet/"
+        "lido:descriptiveNoteValue",
+    ):
+        t = _text(nv)
+        if t:
+            abstracts.append(t)
+    record["abstract"] = "; ".join(abstracts)
+
+    # Production event → name, role, date_created, place_of_origin
+    names, roles, dates_created, places = [], [], [], []
+    for event in _lido_findall(
+        lido,
+        "lido:descriptiveMetadata/lido:eventWrap/lido:eventSet/lido:event",
+    ):
+        # Limit to production events when eventType is specified
+        etype = _lido_find(event, "lido:eventType/lido:term")
+        etype_text = _text(etype).lower() if etype is not None else ""
+        if etype_text and etype_text != "production":
+            continue
+        for actor_av in _lido_findall(
+            event,
+            "lido:eventActor/lido:actorInRole/lido:actor/lido:nameActorSet/"
+            "lido:appellationValue",
+        ):
+            t = _text(actor_av)
+            if t:
+                names.append(t)
+        for role_term in _lido_findall(
+            event,
+            "lido:eventActor/lido:actorInRole/lido:roleActor/lido:term",
+        ):
+            t = _text(role_term)
+            if t:
+                roles.append(t)
+        for dt in _lido_findall(event, "lido:eventDate/lido:displayDate"):
+            t = _text(dt)
+            if t:
+                dates_created.append(t)
+        for pl in _lido_findall(event, "lido:eventPlace/lido:displayPlace"):
+            t = _text(pl)
+            if t:
+                places.append(t)
+    record["name"] = "; ".join(names)
+    record["role"] = "; ".join(roles)
+    record["date_created"] = "; ".join(dates_created)
+    record["place_of_origin"] = "; ".join(places)
+
+    # Subjects — objectRelationWrap/subjectWrap/subjectSet/subject/subjectConcept/term
+    subjects = []
+    for term in _lido_findall(
+        lido,
+        "lido:descriptiveMetadata/lido:objectRelationWrap/lido:subjectWrap/"
+        "lido:subjectSet/lido:subject/lido:subjectConcept/lido:term",
+    ):
+        t = _text(term)
+        if t:
+            subjects.append(t)
+    record["subjects"] = "; ".join(subjects)
+
+    # Genre / object work type
+    genres = []
+    for term in _lido_findall(
+        lido,
+        "lido:descriptiveMetadata/lido:objectClassificationWrap/"
+        "lido:objectWorkTypeWrap/lido:objectWorkType/lido:term",
+    ):
+        t = _text(term)
+        if t:
+            genres.append(t)
+    record["genre"] = "; ".join(genres)
+
+    # Extent — displayObjectMeasurements
+    extents = []
+    for meas in _lido_findall(
+        lido,
+        "lido:descriptiveMetadata/lido:objectIdentificationWrap/"
+        "lido:objectMeasurementsWrap/lido:objectMeasurementsSet/"
+        "lido:displayObjectMeasurements",
+    ):
+        t = _text(meas)
+        if t:
+            extents.append(t)
+    record["extent"] = "; ".join(extents)
+
+    # Access condition — rightsType term
+    rights = []
+    for term in _lido_findall(
+        lido,
+        "lido:administrativeMetadata/lido:rightsWorkWrap/lido:rightsWorkSet/"
+        "lido:rightsType/lido:term",
+    ):
+        t = _text(term)
+        if t:
+            rights.append(t)
+    record["access_condition"] = "; ".join(rights)
+
+    return record
+
+
+def load_lido(path: str | Path, max_rows: int = MAX_ROWS) -> pd.DataFrame:
+    """Parse a LIDO XML file into a DataFrame (one row per lido:lido)."""
+    path = Path(path)
+    if not path.exists():
+        raise XMLLoadError(f"File not found: {path}")
+
+    try:
+        tree = ET.parse(path)
+    except ET.ParseError as e:
+        raise XMLLoadError(f"Invalid XML: {e}") from e
+
+    root = tree.getroot()
+
+    lido_records = root.findall(".//lido:lido", NS)
+    if not lido_records:
+        lido_records = root.findall(".//{http://www.lido-schema.org}lido")
+    if not lido_records:
+        for el in root.iter():
+            tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+            if tag == "lido":
+                lido_records.append(el)
+
+    if not lido_records:
+        raise XMLLoadError(
+            "No lido:lido elements found in XML. Expected LIDO format."
+        )
+
+    if len(lido_records) > max_rows:
+        raise XMLLoadError(
+            f"XML contains {len(lido_records):,} records, "
+            f"exceeding the limit of {max_rows:,}."
+        )
+
+    rows = [_extract_lido_record(el) for el in lido_records]
+    df = pd.DataFrame(rows)
+
+    for col in df.columns:
+        mask = df[col] == ""
+        if mask.any():
+            df[col] = df[col].where(~mask, other=pd.NA)
+    df = df.dropna(axis=1, how="all")
+
+    logger.info(
+        f"Loaded LIDO {path.name}: {len(df)} records, {len(df.columns)} fields"
+    )
+    return df
+
+
+# ---------------------------------------------------------------------------
+# Format detection + dispatch
+# ---------------------------------------------------------------------------
+
+
+def detect_xml_format(path: str | Path) -> str:
+    """Detect XML format from root element.
+
+    Returns one of: "mets_mods", "mods", "lido", "unknown".
+    Inspects only the root element to stay cheap on large files.
+    """
+    path = Path(path)
+    try:
+        for event, el in ET.iterparse(str(path), events=("start",)):
+            tag = el.tag.split("}")[-1] if "}" in el.tag else el.tag
+            ns = el.tag.split("}")[0].lstrip("{") if "}" in el.tag else ""
+            if tag == "mets" or ns == NS["mets"]:
+                return "mets_mods"
+            if tag in ("mods", "modsCollection") or ns == NS["mods"]:
+                return "mods"
+            if tag in ("lido", "lidoWrap") or ns == NS["lido"]:
+                return "lido"
+            # Only inspect the root element
+            return "unknown"
+    except ET.ParseError as e:
+        raise XMLLoadError(f"Invalid XML: {e}") from e
+    return "unknown"
+
+
 def ingest_xml(
     path: str | Path,
     max_rows: int = MAX_ROWS,
 ) -> tuple[pd.DataFrame, "DatasetProfile"]:
-    """Load a METS/MODS XML and return (DataFrame, DatasetProfile)."""
+    """Load METS/MODS or LIDO XML and return (DataFrame, DatasetProfile)."""
     from kwb.core.models import DatasetProfile
 
     path = Path(path)
-    df = load_mets_mods(path, max_rows=max_rows)
+    fmt = detect_xml_format(path)
+    if fmt == "lido":
+        df = load_lido(path, max_rows=max_rows)
+    elif fmt in ("mets_mods", "mods"):
+        df = load_mets_mods(path, max_rows=max_rows)
+    else:
+        raise XMLLoadError(
+            f"Unrecognized XML format (root not METS/MODS or LIDO): {path.name}"
+        )
 
     id_col = detect_id_column(df)
     columns = [profile_column(df[c]) for c in df.columns]

--- a/tests/test_roadmap.py
+++ b/tests/test_roadmap.py
@@ -15,11 +15,12 @@ FIXTURE_CATALOG = Path("tests/fixtures/roadmap_small_catalog.md")
 def test_parse_function_catalog_reads_known_feature():
     entries = parse_function_catalog("docs/FUNKTIONSKATALOG.md")
     feature_ids = {entry.feature_id for entry in entries}
-    assert "F31" in feature_ids
-    f31 = next(e for e in entries if e.feature_id == "F31")
-    assert f31.status == "Geplant"
-    assert f31.tests_done == 0
-    assert f31.tests_total == 0
+    # F37 PDF-Import remains a stable "Geplant" reference point
+    assert "F37" in feature_ids
+    f37 = next(e for e in entries if e.feature_id == "F37")
+    assert f37.status == "Geplant"
+    assert f37.tests_done == 0
+    assert f37.tests_total == 0
 
 
 def test_proposals_prioritize_unimplemented_features():

--- a/tests/test_xml_loader.py
+++ b/tests/test_xml_loader.py
@@ -1,11 +1,17 @@
-"""Tests for METS/MODS XML loader."""
+"""Tests for METS/MODS and LIDO XML loaders."""
 import tempfile
 import unittest
 from pathlib import Path
 
 import pandas as pd
 
-from kwb.ingest.xml_loader import load_mets_mods, ingest_xml, XMLLoadError
+from kwb.ingest.xml_loader import (
+    load_mets_mods,
+    load_lido,
+    ingest_xml,
+    detect_xml_format,
+    XMLLoadError,
+)
 
 
 SAMPLE_MODS = """\
@@ -125,6 +131,223 @@ class TestXMLLoader(unittest.TestCase):
         path = self._write_xml("not valid xml <>><<")
         with self.assertRaises(XMLLoadError):
             load_mets_mods(path)
+
+
+# ---------------------------------------------------------------------------
+# LIDO loader tests (F31)
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_LIDO_MINIMAL = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<lido:lido xmlns:lido="http://www.lido-schema.org">
+  <lido:descriptiveMetadata>
+    <lido:objectIdentificationWrap>
+      <lido:titleWrap>
+        <lido:titleSet>
+          <lido:appellationValue>Bronzefigur Athena</lido:appellationValue>
+        </lido:titleSet>
+      </lido:titleWrap>
+    </lido:objectIdentificationWrap>
+  </lido:descriptiveMetadata>
+  <lido:administrativeMetadata>
+    <lido:recordWrap>
+      <lido:recordID>inv-2024-001</lido:recordID>
+    </lido:recordWrap>
+  </lido:administrativeMetadata>
+</lido:lido>
+"""
+
+
+SAMPLE_LIDO_FULL = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<lido:lidoWrap xmlns:lido="http://www.lido-schema.org">
+  <lido:lido>
+    <lido:descriptiveMetadata>
+      <lido:objectClassificationWrap>
+        <lido:objectWorkTypeWrap>
+          <lido:objectWorkType><lido:term>Gemälde</lido:term></lido:objectWorkType>
+        </lido:objectWorkTypeWrap>
+      </lido:objectClassificationWrap>
+      <lido:objectIdentificationWrap>
+        <lido:titleWrap>
+          <lido:titleSet>
+            <lido:appellationValue>Stillleben mit Blumen</lido:appellationValue>
+          </lido:titleSet>
+        </lido:titleWrap>
+        <lido:objectDescriptionWrap>
+          <lido:objectDescriptionSet>
+            <lido:descriptiveNoteValue>Öl auf Leinwand, signiert.</lido:descriptiveNoteValue>
+          </lido:objectDescriptionSet>
+        </lido:objectDescriptionWrap>
+        <lido:objectMeasurementsWrap>
+          <lido:objectMeasurementsSet>
+            <lido:displayObjectMeasurements>50 x 40 cm</lido:displayObjectMeasurements>
+          </lido:objectMeasurementsSet>
+        </lido:objectMeasurementsWrap>
+      </lido:objectIdentificationWrap>
+      <lido:eventWrap>
+        <lido:eventSet>
+          <lido:event>
+            <lido:eventType><lido:term>production</lido:term></lido:eventType>
+            <lido:eventActor>
+              <lido:actorInRole>
+                <lido:actor>
+                  <lido:nameActorSet>
+                    <lido:appellationValue>Schmidt, Anna</lido:appellationValue>
+                  </lido:nameActorSet>
+                </lido:actor>
+                <lido:roleActor><lido:term>Malerin</lido:term></lido:roleActor>
+              </lido:actorInRole>
+            </lido:eventActor>
+            <lido:eventDate><lido:displayDate>ca. 1900</lido:displayDate></lido:eventDate>
+            <lido:eventPlace><lido:displayPlace>München</lido:displayPlace></lido:eventPlace>
+          </lido:event>
+        </lido:eventSet>
+      </lido:eventWrap>
+      <lido:objectRelationWrap>
+        <lido:subjectWrap>
+          <lido:subjectSet>
+            <lido:subject>
+              <lido:subjectConcept><lido:term>Stillleben</lido:term></lido:subjectConcept>
+            </lido:subject>
+            <lido:subject>
+              <lido:subjectConcept><lido:term>Blumen</lido:term></lido:subjectConcept>
+            </lido:subject>
+          </lido:subjectSet>
+        </lido:subjectWrap>
+      </lido:objectRelationWrap>
+    </lido:descriptiveMetadata>
+    <lido:administrativeMetadata>
+      <lido:recordWrap>
+        <lido:recordID>obj-001</lido:recordID>
+      </lido:recordWrap>
+      <lido:rightsWorkWrap>
+        <lido:rightsWorkSet>
+          <lido:rightsType><lido:term>CC BY-SA 4.0</lido:term></lido:rightsType>
+        </lido:rightsWorkSet>
+      </lido:rightsWorkWrap>
+    </lido:administrativeMetadata>
+  </lido:lido>
+  <lido:lido>
+    <lido:descriptiveMetadata>
+      <lido:objectIdentificationWrap>
+        <lido:titleWrap>
+          <lido:titleSet>
+            <lido:appellationValue>Skulptur Diana</lido:appellationValue>
+          </lido:titleSet>
+        </lido:titleWrap>
+      </lido:objectIdentificationWrap>
+    </lido:descriptiveMetadata>
+    <lido:administrativeMetadata>
+      <lido:recordWrap>
+        <lido:recordID>obj-002</lido:recordID>
+      </lido:recordWrap>
+    </lido:administrativeMetadata>
+  </lido:lido>
+</lido:lidoWrap>
+"""
+
+
+class TestLIDOLoader(unittest.TestCase):
+    """Test LIDO XML ingestion (F31)."""
+
+    def _write_xml(self, content: str, filename: str = "test.xml") -> Path:
+        path = Path(tempfile.mkdtemp()) / filename
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_load_lido_minimal(self):
+        path = self._write_xml(SAMPLE_LIDO_MINIMAL)
+        df = load_lido(path)
+        self.assertEqual(len(df), 1)
+        self.assertEqual(df.loc[0, "title"], "Bronzefigur Athena")
+        self.assertEqual(df.loc[0, "record_id"], "inv-2024-001")
+
+    def test_load_lido_collection(self):
+        path = self._write_xml(SAMPLE_LIDO_FULL)
+        df = load_lido(path)
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df.loc[0, "title"], "Stillleben mit Blumen")
+        self.assertEqual(df.loc[1, "title"], "Skulptur Diana")
+        self.assertEqual(df.loc[0, "record_id"], "obj-001")
+        self.assertEqual(df.loc[1, "record_id"], "obj-002")
+
+    def test_load_lido_actor_and_role(self):
+        path = self._write_xml(SAMPLE_LIDO_FULL)
+        df = load_lido(path)
+        self.assertEqual(df.loc[0, "name"], "Schmidt, Anna")
+        self.assertEqual(df.loc[0, "role"], "Malerin")
+        self.assertEqual(df.loc[0, "date_created"], "ca. 1900")
+        self.assertEqual(df.loc[0, "place_of_origin"], "München")
+
+    def test_load_lido_multiple_subjects_joined(self):
+        path = self._write_xml(SAMPLE_LIDO_FULL)
+        df = load_lido(path)
+        self.assertIn("Stillleben", df.loc[0, "subjects"])
+        self.assertIn("Blumen", df.loc[0, "subjects"])
+        self.assertIn(";", df.loc[0, "subjects"])
+
+    def test_load_lido_genre_extent_rights(self):
+        path = self._write_xml(SAMPLE_LIDO_FULL)
+        df = load_lido(path)
+        self.assertEqual(df.loc[0, "genre"], "Gemälde")
+        self.assertEqual(df.loc[0, "extent"], "50 x 40 cm")
+        self.assertEqual(df.loc[0, "access_condition"], "CC BY-SA 4.0")
+
+    def test_load_lido_no_records_raises(self):
+        path = self._write_xml(
+            '<?xml version="1.0"?><root><item>x</item></root>'
+        )
+        with self.assertRaises(XMLLoadError):
+            load_lido(path)
+
+
+class TestXMLFormatDetection(unittest.TestCase):
+    """Test format auto-detection and ingest_xml dispatch."""
+
+    def _write_xml(self, content: str, filename: str = "test.xml") -> Path:
+        path = Path(tempfile.mkdtemp()) / filename
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_detect_mods_collection(self):
+        path = self._write_xml(SAMPLE_MODS)
+        self.assertEqual(detect_xml_format(path), "mods")
+
+    def test_detect_mets_mods(self):
+        path = self._write_xml(SAMPLE_METS_MODS)
+        self.assertEqual(detect_xml_format(path), "mets_mods")
+
+    def test_detect_lido(self):
+        path = self._write_xml(SAMPLE_LIDO_FULL)
+        self.assertEqual(detect_xml_format(path), "lido")
+
+    def test_detect_unknown(self):
+        path = self._write_xml(
+            '<?xml version="1.0"?><other><foo/></other>'
+        )
+        self.assertEqual(detect_xml_format(path), "unknown")
+
+    def test_ingest_xml_dispatches_lido(self):
+        path = self._write_xml(SAMPLE_LIDO_FULL)
+        df, profile = ingest_xml(path)
+        self.assertEqual(profile.row_count, 2)
+        self.assertGreater(profile.column_count, 0)
+        self.assertEqual(df.loc[0, "title"], "Stillleben mit Blumen")
+
+    def test_ingest_xml_dispatches_mods(self):
+        path = self._write_xml(SAMPLE_MODS)
+        df, profile = ingest_xml(path)
+        self.assertEqual(profile.row_count, 2)
+        self.assertEqual(df.loc[0, "title"], "Ansicht von Berlin")
+
+    def test_ingest_xml_unknown_format_raises(self):
+        path = self._write_xml(
+            '<?xml version="1.0"?><foo><bar>x</bar></foo>'
+        )
+        with self.assertRaises(XMLLoadError):
+            ingest_xml(path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends `xml_loader.py` (which already handled METS/MODS) with LIDO support
and an auto-detecting front door (`detect_xml_format`). Brings F31 from
🔴 Geplant to 🟡 Teilweise — only EAD remains, deferred to a follow-up PR
because the hierarchical archival finding-aid model needs its own design.

## Why this scope

The Plan agent's audit showed:
- METS/MODS ingest already works (8 tests, `load_mets_mods` + `ingest_xml`)
- LIDO is flat per `lido:lido` and semantically close to MODS — fits cleanly
  alongside the existing loader
- EAD is hierarchical (`<c01>` → `<c02>` → `<c03>` …) and needs tree-to-row
  flattening design (one row per leaf? include `parent_id`?) — separate PR

## Field mapping (LIDO → DataFrame column)

| LIDO element | Column |
|---|---|
| `objectIdentificationWrap/titleWrap/titleSet/appellationValue` | `title` |
| `administrativeMetadata/recordWrap/recordID` | `record_id` |
| `objectDescriptionSet/descriptiveNoteValue` | `abstract` |
| production `event/eventActor/.../appellationValue` | `name` |
| production `event/eventActor/.../roleActor/term` | `role` |
| production `event/eventDate/displayDate` | `date_created` |
| production `event/eventPlace/displayPlace` | `place_of_origin` |
| `subjectConcept/term` | `subjects` (`;`-joined) |
| `objectWorkType/term` | `genre` |
| `displayObjectMeasurements` | `extent` |
| `rightsType/term` | `access_condition` |

Columns are intentionally aligned with the MODS schema so downstream
NER/EDTF/GND/enrichment/export keep working on LIDO-sourced data.

## Tests (+13, total 21/21)

- `TestLIDOLoader` (6): minimal record, lidoWrap collection of two,
  production event → name/role/date/place, multi-subject join, genre/extent/
  rights, missing-`lido:lido` raises.
- `TestXMLFormatDetection` (7): mods/mets_mods/lido/unknown detection,
  `ingest_xml` dispatches to both formats, unknown rejected.

## Open items / defers

- **EAD**: deferred to follow-up PR (hierarchical model, separate design).
- **lxml**: stayed stdlib-only (zero new deps).
- **Batch ingest** (directory / ZIP of XMLs): defer; API already accepts a
  list of `UploadFile`.

## Test plan

- [x] 1085 tests pass, 0 failed
- [x] Ruff lint clean
- [x] Catalog status updated and `update_test_catalog --update-doc` rerun
- [x] No regression on existing METS/MODS tests (8/8 still pass)

https://claude.ai/code/session_011wfGtnc8zaLFLAqLfz1ScS

---
_Generated by [Claude Code](https://claude.ai/code/session_011wfGtnc8zaLFLAqLfz1ScS)_