### PR TITLE
Fix index alignment and duplicate columns in _get_affected_ids

### DIFF
--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 993/1137 Tests bestanden, 0 fehlgeschlagen, 144 übersprungen
+**Gesamtstatus:** 996/1140 Tests bestanden, 0 fehlgeschlagen, 144 übersprungen
 
 ---
 
@@ -263,7 +263,7 @@
 | test_open_issues.py | 24/32 | 0 | 8 | ✅ |
 | test_pdf_loader.py | 3/3 | 0 | 0 | ✅ |
 | test_phase1_stabilization.py | 11/11 | 0 | 0 | ✅ |
-| test_phase1b_stabilization.py | 9/9 | 0 | 0 | ✅ |
+| test_phase1b_stabilization.py | 12/12 | 0 | 0 | ✅ |
 | test_phase2_collection_agnosticism.py | 62/62 | 0 | 0 | ✅ |
 | test_pipeline.py | 18/18 | 0 | 0 | ✅ |
 | test_pipeline_steps.py | 10/10 | 0 | 0 | ✅ |
@@ -277,7 +277,7 @@
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 21/21 | 0 | 0 | ✅ |
-| **Gesamt** | **993/1137** | **0** | **144** | **✅** |
+| **Gesamt** | **996/1140** | **0** | **144** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/analyze/structural.py
+++ b/src/kwb/analyze/structural.py
@@ -11,8 +11,13 @@ def _get_affected_ids(df, mask, id_col, limit=10):
     if not id_col or id_col not in df.columns:
         return []
     try:
-        return df.loc[mask, id_col].head(limit).tolist()
-    except (IndexError, KeyError, ValueError, TypeError, pd.errors.IndexingError) as e:
+        if isinstance(mask, pd.Series) and not mask.index.equals(df.index):
+            mask = mask.reindex(df.index, fill_value=False).astype(bool)
+        ids = df.loc[mask, id_col]
+        if isinstance(ids, pd.DataFrame):
+            ids = ids.iloc[:, 0]
+        return ids.head(limit).tolist()
+    except (IndexError, KeyError, ValueError, TypeError, AssertionError, pd.errors.IndexingError) as e:
         logger.warning(
             "Failed to extract affected ids for column %r (%s: %s)",
             id_col, type(e).__name__, e,

--- a/tests/test_phase1b_stabilization.py
+++ b/tests/test_phase1b_stabilization.py
@@ -119,6 +119,55 @@ class TestAffectedIdsExceptionHandling(unittest.TestCase):
         result = _get_affected_ids(df, mask, None, limit=2)
         self.assertEqual(result, [])
 
+    def test_get_affected_ids_subset_index_mask(self):
+        """Issue #209: mask with subset index (from dropna) must not raise AssertionError."""
+        from kwb.analyze.structural import _get_affected_ids
+
+        df = pd.DataFrame({
+            "id": ["a", "b", "c", "d"],
+            "col": ["x;", "", "y,", "z;,"],
+        })
+        vals = df["col"].replace("", pd.NA).dropna().astype(str)
+        mask = vals.str.contains(";", na=False) & vals.str.contains(",", na=False)
+        # mask has subset index {0, 2, 3} — must align safely to df.index
+        result = _get_affected_ids(df, mask, "id", limit=5)
+        self.assertEqual(result, ["d"])
+
+    def test_get_affected_ids_duplicate_id_columns(self):
+        """Issue #209: df with duplicate column names must not raise AttributeError."""
+        from kwb.analyze.structural import _get_affected_ids
+
+        df = pd.DataFrame(
+            [["a", "x", "y"], ["b", "x", "y"], ["c", "x", "y"]],
+            columns=["id", "col", "id"],
+        )
+        mask = pd.Series([True, False, True])
+        result = _get_affected_ids(df, mask, "id", limit=5)
+        self.assertEqual(result, ["a", "c"])
+
+    def test_check_format_inconsistency_does_not_raise(self):
+        """Issue #209: check_format_inconsistency must not raise on mixed-delimiter rows."""
+        from kwb.analyze.structural import check_format_inconsistency
+        from kwb.core.models import DatasetProfile
+        from kwb.ingest.csv_loader import detect_id_column, profile_column
+
+        df = pd.DataFrame({
+            "id": ["1", "2", "3", "4"],
+            "tags": ["a;b", "", "c,d", "e;f,g"],
+        })
+        df_analysis = df.replace("", pd.NA)
+        profile = DatasetProfile(
+            source_path="test.csv",
+            source_name="test",
+            row_count=len(df),
+            column_count=len(df.columns),
+            columns=[profile_column(df_analysis[c]) for c in df.columns],
+            id_column=detect_id_column(df),
+        )
+        # Must not raise (was: AssertionError → HTTP 500 → frontend JSON parse error)
+        findings = check_format_inconsistency(df, profile)
+        self.assertIsInstance(findings, list)
+
 
 class TestLobidConfidenceRank(unittest.TestCase):
     """EXT-BUG-08: LobidGNDClient.search() must use rank-based confidence."""


### PR DESCRIPTION
## Summary
Fixed `_get_affected_ids()` to safely handle masks with subset indices (from operations like `dropna()`) and DataFrames with duplicate column names, preventing `AssertionError` and `AttributeError` exceptions.

## Problem
- When a boolean mask had a subset index (e.g., from `dropna()`), indexing with it raised an `AssertionError`
- When a DataFrame had duplicate column names, selecting by column name returned a `DataFrame` instead of a `Series`, causing downstream failures
- These issues caused HTTP 500 errors in the frontend when checking format inconsistencies

## Root cause
1. The mask index wasn't aligned with the DataFrame index before use
2. Duplicate column names caused `df.loc[mask, id_col]` to return a DataFrame instead of a Series
3. The exception handler didn't catch `AssertionError`

## Solution
- Reindex the mask to match the DataFrame index when indices don't align, filling missing positions with `False`
- Detect when column selection returns a DataFrame (due to duplicates) and extract the first column
- Added `AssertionError` to the exception handler

## Files changed
- `src/kwb/analyze/structural.py`: Enhanced `_get_affected_ids()` with index alignment and duplicate column handling
- `tests/test_phase1b_stabilization.py`: Added 3 new test cases covering the fixed scenarios

## Tests
- [x] `pytest` - Added 3 new unit tests:
  - `test_get_affected_ids_subset_index_mask`: Verifies mask with subset index aligns correctly
  - `test_get_affected_ids_duplicate_id_columns`: Verifies handling of duplicate column names
  - `test_check_format_inconsistency_does_not_raise`: Integration test ensuring no exceptions on mixed-delimiter data
- [x] All tests pass (996/1140 tests passing, up from 993/1137)

## Risks / follow-up
None identified. The changes are defensive and backward-compatible.

https://claude.ai/code/session_01HnmCZc6A78B2KcDyh9STSa