### PR TITLE
Add non-destructive ingest preview endpoint (issue #177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,27 @@ Sektionen:
 ## [Unreleased]
 
 ### Hinzugefügt
+- **Ingest-Vorschau (`POST /api/ingest/preview`)** — non-destruktiver Endpoint,
+  der für hochgeladene CSV/XLSX/XML-Dateien Encoding (mit chardet-Confidence),
+  Trennzeichen, ID-Spalten-Kandidaten, Spaltenprofile und die ersten 10 Zeilen
+  zurückgibt. Kuratoren können Encoding- und ID-Spalten-Fehlentscheidungen
+  vor dem Commit erkennen. Dashboard zeigt einen Vorschau-Karten-Stack mit
+  Übernehmen/Abbrechen-Buttons. (Issue #177, Phase 4 Schritt 1)
+- **`detect_encoding_with_confidence()`** in `kwb.ingest.csv_loader` —
+  liefert `{encoding, confidence, has_bom, chardet_available, warning}`.
+  Surface chardet-Fehlend-Warnung (Adressiert #166 anteilig).
+- **`list_sheets()`** in `kwb.ingest.xlsx_loader` — listet die Sheet-Namen
+  einer XLSX-Datei, ohne sie zu laden. Vorbereitung für späteren
+  Multi-Sheet-Commit (#181).
 - **`NERResult.completion_summary`** — Dict mit Batch-Verarbeitungsstatistiken
   (total_items, successful_parses, failed_parses, success_rate). Ermöglicht es
   der API und Callers, Ausfallquoten bei LLM-basierter NER zu tracking.
 - **Regression-Test-Suite `tests/test_phase1b_stabilization.py`** — alle
   Analyze/Enrich-Audit-Issues sind mit dedizierten Tests abgedeckt; die Audit-ID
   steht im Docstring.
+- **Tests `tests/test_ingest_preview.py`** — 11 Tests für CSV (UTF-8/Latin-1,
+  Confidence, chardet-Mock, Workspace-Isolation, Mehrdatei-Upload, abgelehnte
+  Extensions), XLSX (Single/Multi-Sheet), XML (METS/MODS, Unknown).
 
 ### Geändert
 - **`LobidGNDClient.search()`** — gibt jetzt **rank-basierte** Konfidenzwerte

--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 996/1140 Tests bestanden, 0 fehlgeschlagen, 144 übersprungen
+**Gesamtstatus:** 996/1151 Tests bestanden, 0 fehlgeschlagen, 155 übersprungen
 
 ---
 
@@ -255,6 +255,7 @@
 | test_html_report.py | 21/21 | 0 | 0 | ✅ |
 | test_image_fixtures.py | 10/10 | 0 | 0 | ✅ |
 | test_image_upload.py | 0/31 | 0 | 31 | ✅ |
+| test_ingest_preview.py | 0/11 | 0 | 11 | ✅ |
 | test_llm_quality.py | 55/55 | 0 | 0 | ✅ |
 | test_mets_mods_export.py | 42/42 | 0 | 0 | ✅ |
 | test_ner.py | 29/29 | 0 | 0 | ✅ |
@@ -277,7 +278,7 @@
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 21/21 | 0 | 0 | ✅ |
-| **Gesamt** | **996/1140** | **0** | **144** | **✅** |
+| **Gesamt** | **996/1151** | **0** | **155** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -89,7 +89,19 @@
 <div class="c">
 <h3>1b. Strukturelle Analyse</h3>
 <p style="font-size:.72rem;color:#666;margin-bottom:.3rem">7 Qualit&auml;tschecks: Fehlwerte, Duplikate, Encoding, Formate, Terme, Verkn&uuml;pfungen, GND-Abdeckung.</p>
+<div style="display:flex;gap:.4rem;flex-wrap:wrap">
+<button class="btn s" onclick="previewIngest()">&#128270; Vorschau pr&uuml;fen</button>
 <button class="btn f" onclick="runStruct()">&#128300; Analyse starten</button>
+</div>
+<p style="font-size:.68rem;color:#888;margin-top:.4rem">Tipp: <strong>Vorschau pr&uuml;fen</strong> zeigt Encoding, Trennzeichen und ID-Spalte vor dem Commit (Issue #177).</p>
+</div>
+<div class="c" id="preview-panel" style="display:none">
+<h3>1b&prime;. Ingest-Vorschau</h3>
+<div id="preview-body"></div>
+<div style="display:flex;gap:.4rem;margin-top:.6rem">
+<button class="btn f" onclick="confirmIngest()">&#10003; &Uuml;bernehmen &amp; analysieren</button>
+<button class="btn s" onclick="cancelPreview()">&#10007; Abbrechen</button>
+</div>
 </div>
 <div class="c" id="id-col-bar" style="display:none">
 <h3>1c. ID-Spalte festlegen</h3>

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -487,6 +487,98 @@ async function saveFM(){
 const _IMAGE_EXTS = new Set(['.jpg','.jpeg','.png','.tif','.tiff','.webp','.img']);
 function _fileExt(name){const i=(name||'').lastIndexOf('.');return i>=0?name.slice(i).toLowerCase():'';}
 
+// === INGEST PREVIEW (issue #177) ===
+async function previewIngest(){
+  const sel=[...document.querySelectorAll('.fcb:checked')].map(c=>c.value);
+  if(!sel.length){alert('Mindestens eine Datei auswählen.');return}
+  const docFiles=[];
+  for(const id of sel){const it=ufiles[id];if(!it)continue;if(!_IMAGE_EXTS.has(_fileExt(it.uploadName)))docFiles.push(it);}
+  if(!docFiles.length){alert('Keine Metadaten-Dateien ausgewählt (Bilder benötigen keine Vorschau).');return}
+  const fd=new FormData();for(const it of docFiles)fd.append('files',it.file,it.uploadName);
+  sp('Vorschau wird geladen …',docFiles.length+' Datei(en)');
+  try{
+    const r=await(await fetch('/api/ingest/preview',{method:'POST',body:fd})).json();
+    if(r.error)throw Error(r.error);
+    renderPreview(r.previews||[]);
+  }catch(e){alert('Vorschau-Fehler: '+e.message);}finally{hp();}
+}
+
+function renderPreview(previews){
+  const panel=$('preview-panel'),body=$('preview-body');
+  if(!panel||!body)return;
+  body.innerHTML=previews.map(p=>_renderPreviewCard(p)).join('');
+  panel.style.display='block';
+  panel.scrollIntoView({behavior:'smooth',block:'nearest'});
+}
+
+function _renderPreviewCard(p){
+  let html='<div style="border:1px solid #ddd;border-radius:4px;padding:.6rem;margin-bottom:.5rem;background:#fafafa">';
+  html+='<div style="font-weight:600;margin-bottom:.3rem">&#128196; '+esc(p.filename||'?')+' <span style="color:#888;font-weight:400;font-size:.78rem">('+esc(p.format||'')+')</span></div>';
+  if(p.error){
+    html+='<div style="background:var(--crit,#c33);color:white;padding:.4rem .6rem;border-radius:3px;font-size:.8rem">Fehler: '+esc(p.error)+'</div></div>';
+    return html;
+  }
+  // Encoding
+  if(p.encoding){
+    const conf=p.encoding.confidence;
+    const confStr=conf==null?'—':(Math.round(conf*100)+'%');
+    const bom=p.encoding.has_bom?' (BOM)':'';
+    const cdAvail=p.encoding.chardet_available;
+    const confColor=conf==null?'#666':(conf>=0.9?'var(--ok,#080)':conf>=0.7?'var(--warn,#a60)':'var(--crit,#c33)');
+    html+='<div style="font-size:.78rem;margin-bottom:.2rem">Encoding: <strong>'+esc(p.encoding.detected||'?')+'</strong>'+bom+' &middot; Konfidenz: <span style="color:'+confColor+'">'+confStr+'</span>';
+    if(!cdAvail)html+=' <span style="color:var(--warn,#a60)" title="chardet nicht installiert">⚠</span>';
+    html+='</div>';
+  }
+  if(p.delimiter!==undefined){
+    html+='<div style="font-size:.78rem;margin-bottom:.2rem">Trennzeichen: <code>'+esc(JSON.stringify(p.delimiter))+'</code></div>';
+  }
+  if(p.xml_format){
+    html+='<div style="font-size:.78rem;margin-bottom:.2rem">XML-Format: <strong>'+esc(p.xml_format)+'</strong></div>';
+  }
+  if(p.sheets&&p.sheets.length){
+    html+='<div style="font-size:.78rem;margin-bottom:.2rem">Sheets: '+p.sheets.map(s=>'<code>'+esc(s)+'</code>').join(', ')+(p.active_sheet?' &middot; aktiv: <strong>'+esc(p.active_sheet)+'</strong>':'')+'</div>';
+  }
+  if(p.row_count!==undefined){
+    html+='<div style="font-size:.78rem;margin-bottom:.2rem">'+(p.row_count||0)+' Zeilen &times; '+(p.column_count||0)+' Spalten</div>';
+  }
+  // ID column
+  if(p.id_column){
+    const idc=p.id_column;
+    html+='<div style="font-size:.78rem;margin-bottom:.2rem">ID-Spalte: <strong>'+(idc.proposed?esc(idc.proposed):'<em style="color:var(--warn,#a60)">keine gefunden</em>')+'</strong>';
+    if(idc.candidates&&idc.candidates.length>1){
+      html+=' <span style="color:#666">(Alternativen: '+idc.candidates.filter(c=>c!==idc.proposed).slice(0,5).map(c=>'<code>'+esc(c)+'</code>').join(', ')+')</span>';
+    }
+    html+='</div>';
+  }
+  // Warnings
+  if(p.warnings&&p.warnings.length){
+    html+='<div style="background:#fff7e0;border-left:3px solid var(--warn,#a60);padding:.3rem .5rem;margin:.3rem 0;font-size:.76rem">'+p.warnings.map(w=>'⚠ '+esc(w)).join('<br>')+'</div>';
+  }
+  // Head preview
+  if(p.head&&p.head.length){
+    const cols=Object.keys(p.head[0]).slice(0,8);
+    html+='<details style="margin-top:.3rem"><summary style="cursor:pointer;font-size:.78rem">Vorschau erste '+p.head.length+' Zeilen</summary>';
+    html+='<div style="overflow-x:auto;max-height:240px;margin-top:.3rem"><table style="font-size:.72rem;border-collapse:collapse"><thead><tr>'+cols.map(c=>'<th style="border:1px solid #ddd;padding:.2rem .4rem;background:#eee">'+esc(c)+'</th>').join('')+'</tr></thead><tbody>';
+    for(const row of p.head){
+      html+='<tr>'+cols.map(c=>'<td style="border:1px solid #ddd;padding:.2rem .4rem">'+esc(String(row[c]||'')).slice(0,80)+'</td>').join('')+'</tr>';
+    }
+    html+='</tbody></table></div></details>';
+  }
+  html+='</div>';
+  return html;
+}
+
+function confirmIngest(){
+  cancelPreview();
+  runStruct();
+}
+
+function cancelPreview(){
+  const panel=$('preview-panel'),body=$('preview-body');
+  if(body)body.innerHTML='';
+  if(panel)panel.style.display='none';
+}
+
 async function runStruct(){
   const sel=[...document.querySelectorAll('.fcb:checked')].map(c=>c.value);
   if(!sel.length){alert('Mindestens eine Datei auswählen.');return}

--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -27,9 +27,12 @@ from kwb.api.deps import (
     ALLOWED_EXTENSIONS, MAX_CSV_COLS, MAX_CSV_ROWS, MAX_FILE_BYTES,
     MAX_UPLOAD_FILES, get_datasets, get_provider, get_workspace, get_state,
 )
-from kwb.ingest.csv_loader import ingest_csv
-from kwb.ingest.xlsx_loader import ingest_xlsx
-from kwb.ingest.xml_loader import ingest_xml, ingest_zip
+from kwb.ingest.csv_loader import (
+    detect_encoding_with_confidence,
+    ingest_csv,
+)
+from kwb.ingest.xlsx_loader import ingest_xlsx, list_sheets
+from kwb.ingest.xml_loader import detect_xml_format, ingest_xml, ingest_zip
 from kwb.analyze.structural import analyze_datasets
 from kwb.analyze.ner import ner_hybrid, scan_problematic_terms
 from kwb.analyze.quality_report import build_quality_analysis_report
@@ -261,6 +264,261 @@ def _normalize_upload_filename(filename: str) -> str:
 # ---------------------------------------------------------------------------
 # CSV Upload + Analyse
 # ---------------------------------------------------------------------------
+
+def _preview_csv(tp: Path, fname: str) -> dict:
+    """Non-destructive CSV preview: encoding, delimiter, columns, head, id candidates."""
+    enc_info = detect_encoding_with_confidence(tp)
+    warnings: list[str] = []
+    if enc_info["warning"]:
+        warnings.append(enc_info["warning"])
+
+    df, pr = ingest_csv(tp)
+
+    # Sniff delimiter for display (best-effort; ignore errors)
+    delimiter = ","
+    try:
+        with open(tp, encoding=enc_info["encoding"], errors="replace") as fh:
+            sample = fh.read(4096)
+        try:
+            dialect = csv.Sniffer().sniff(sample, delimiters=",;\t|")
+            delimiter = dialect.delimiter
+        except csv.Error:
+            warnings.append(
+                "Trennzeichen konnte nicht eindeutig erkannt werden, "
+                "Default ',' verwendet."
+            )
+    except OSError:
+        pass
+
+    id_candidates = [
+        c.name for c in pr.columns
+        if c.unique_count == pr.row_count and pr.row_count > 0
+    ]
+
+    head_records = df.head(10).fillna("").astype(str).to_dict(orient="records")
+
+    return {
+        "filename": fname,
+        "format": "csv",
+        "size_bytes": tp.stat().st_size,
+        "row_count": pr.row_count,
+        "column_count": pr.column_count,
+        "encoding": {
+            "detected": enc_info["encoding"],
+            "confidence": enc_info["confidence"],
+            "has_bom": enc_info["has_bom"],
+            "chardet_available": enc_info["chardet_available"],
+        },
+        "delimiter": delimiter,
+        "columns": [
+            {
+                "name": c.name,
+                "fill_rate": c.fill_rate,
+                "unique_count": c.unique_count,
+                "sample_values": [str(v) for v in c.sample_values[:3]],
+            }
+            for c in pr.columns
+        ],
+        "id_column": {
+            "proposed": pr.id_column or "",
+            "candidates": id_candidates,
+            "is_unique": bool(pr.id_column),
+        },
+        "head": head_records,
+        "warnings": warnings,
+    }
+
+
+def _preview_xlsx(tp: Path, fname: str) -> dict:
+    """Non-destructive XLSX preview using the first sheet."""
+    warnings: list[str] = []
+    try:
+        sheets = list_sheets(tp)
+    except Exception as e:
+        sheets = []
+        warnings.append(f"Sheets konnten nicht aufgelistet werden: {e}")
+
+    df, pr = ingest_xlsx(tp)
+    id_candidates = [
+        c.name for c in pr.columns
+        if c.unique_count == pr.row_count and pr.row_count > 0
+    ]
+    head_records = df.head(10).fillna("").astype(str).to_dict(orient="records")
+
+    if len(sheets) > 1:
+        warnings.append(
+            f"Datei enthält {len(sheets)} Sheets — aktuell wird "
+            f"nur '{sheets[0]}' geladen."
+        )
+
+    return {
+        "filename": fname,
+        "format": "xlsx",
+        "size_bytes": tp.stat().st_size,
+        "row_count": pr.row_count,
+        "column_count": pr.column_count,
+        "sheets": sheets,
+        "active_sheet": sheets[0] if sheets else None,
+        "columns": [
+            {
+                "name": c.name,
+                "fill_rate": c.fill_rate,
+                "unique_count": c.unique_count,
+                "sample_values": [str(v) for v in c.sample_values[:3]],
+            }
+            for c in pr.columns
+        ],
+        "id_column": {
+            "proposed": pr.id_column or "",
+            "candidates": id_candidates,
+            "is_unique": bool(pr.id_column),
+        },
+        "head": head_records,
+        "warnings": warnings,
+    }
+
+
+def _preview_xml(tp: Path, fname: str) -> dict:
+    """Non-destructive XML preview with format detection."""
+    warnings: list[str] = []
+    xml_format = detect_xml_format(tp)
+    if xml_format == "unknown":
+        warnings.append(
+            "XML-Format wurde nicht als METS/MODS oder LIDO erkannt — "
+            "Import wird beim Commit fehlschlagen."
+        )
+        return {
+            "filename": fname,
+            "format": "xml",
+            "xml_format": xml_format,
+            "size_bytes": tp.stat().st_size,
+            "row_count": 0,
+            "column_count": 0,
+            "columns": [],
+            "id_column": {"proposed": "", "candidates": [], "is_unique": False},
+            "head": [],
+            "warnings": warnings,
+        }
+
+    df, pr = ingest_xml(tp)
+    id_candidates = [
+        c.name for c in pr.columns
+        if c.unique_count == pr.row_count and pr.row_count > 0
+    ]
+    head_records = df.head(10).fillna("").astype(str).to_dict(orient="records")
+
+    return {
+        "filename": fname,
+        "format": "xml",
+        "xml_format": xml_format,
+        "size_bytes": tp.stat().st_size,
+        "row_count": pr.row_count,
+        "column_count": pr.column_count,
+        "columns": [
+            {
+                "name": c.name,
+                "fill_rate": c.fill_rate,
+                "unique_count": c.unique_count,
+                "sample_values": [str(v) for v in c.sample_values[:3]],
+            }
+            for c in pr.columns
+        ],
+        "id_column": {
+            "proposed": pr.id_column or "",
+            "candidates": id_candidates,
+            "is_unique": bool(pr.id_column),
+        },
+        "head": head_records,
+        "warnings": warnings,
+    }
+
+
+@router.post("/api/ingest/preview")
+async def ingest_preview(files: list[UploadFile] = File(...)):
+    """Inspect uploaded files without committing them to the workspace.
+
+    Returns per-file diagnostics (encoding, delimiter, columns, ID candidates,
+    head sample, warnings) so the curator can confirm or adjust before
+    triggering the destructive ``/api/analyze`` step.
+    """
+    if len(files) > MAX_UPLOAD_FILES:
+        return JSONResponse({"error": f"Maximal {MAX_UPLOAD_FILES} Dateien erlaubt"}, 400)
+
+    previews: list[dict] = []
+
+    for u in files:
+        fname = _normalize_upload_filename(u.filename or "")
+        suffix = Path(fname).suffix.lower()
+        if suffix not in ALLOWED_EXTENSIONS:
+            previews.append({
+                "filename": fname,
+                "format": "unknown",
+                "error": f"Nur {', '.join(ALLOWED_EXTENSIONS)} erlaubt",
+                "warnings": [],
+            })
+            continue
+
+        content = await u.read()
+        if len(content) > MAX_FILE_BYTES:
+            previews.append({
+                "filename": fname,
+                "format": suffix.lstrip("."),
+                "error": f"Max {MAX_FILE_BYTES // (1024 * 1024)} MB",
+                "warnings": [],
+            })
+            continue
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
+            tmp.write(content)
+            tp = Path(tmp.name)
+        try:
+            if suffix in {".xlsx", ".xls"}:
+                preview = _preview_xlsx(tp, fname)
+            elif suffix == ".xml":
+                preview = _preview_xml(tp, fname)
+            elif suffix == ".zip":
+                preview = {
+                    "filename": fname,
+                    "format": "zip",
+                    "size_bytes": tp.stat().st_size,
+                    "warnings": [
+                        "ZIP-Vorschau zeigt nur die zusammengeführten Daten "
+                        "nach Commit. Bitte 'Übernehmen' klicken, um zu laden."
+                    ],
+                    "row_count": 0,
+                    "column_count": 0,
+                    "columns": [],
+                    "id_column": {
+                        "proposed": "", "candidates": [], "is_unique": False
+                    },
+                    "head": [],
+                }
+            else:
+                preview = _preview_csv(tp, fname)
+
+            if preview.get("row_count", 0) > MAX_CSV_ROWS:
+                preview.setdefault("warnings", []).append(
+                    f"Datei hat {preview['row_count']:,} Zeilen — "
+                    f"Limit ist {MAX_CSV_ROWS:,}. Commit wird fehlschlagen."
+                )
+            if preview.get("column_count", 0) > MAX_CSV_COLS:
+                preview.setdefault("warnings", []).append(
+                    f"Datei hat {preview['column_count']} Spalten — "
+                    f"Limit ist {MAX_CSV_COLS}. Commit wird fehlschlagen."
+                )
+            previews.append(preview)
+        except Exception as e:
+            previews.append({
+                "filename": fname,
+                "format": suffix.lstrip("."),
+                "error": str(e),
+                "warnings": [],
+            })
+        finally:
+            tp.unlink(missing_ok=True)
+
+    return {"previews": previews}
+
 
 @router.post("/api/analyze")
 async def analyze(files: list[UploadFile] = File(...)):

--- a/src/kwb/ingest/csv_loader.py
+++ b/src/kwb/ingest/csv_loader.py
@@ -44,23 +44,64 @@ def detect_encoding(path: str | Path) -> tuple[str, bool]:
     Returns (encoding_name, has_bom).
     Falls back to "utf-8" if chardet is not installed.
     """
+    enc, _, has_bom, _, _ = _detect_encoding_full(path)
+    return enc, has_bom
+
+
+def detect_encoding_with_confidence(path: str | Path) -> dict:
+    """
+    Detect file encoding and return a dict with confidence and diagnostic info.
+
+    Returns:
+        {
+            "encoding": str,            # detected or fallback encoding
+            "confidence": float | None, # 0..1 from chardet, None if BOM or no chardet
+            "has_bom": bool,
+            "chardet_available": bool,
+            "warning": str | None,      # non-empty if a fallback was used
+        }
+    """
+    enc, conf, has_bom, chardet_available, warning = _detect_encoding_full(path)
+    return {
+        "encoding": enc,
+        "confidence": conf,
+        "has_bom": has_bom,
+        "chardet_available": chardet_available,
+        "warning": warning,
+    }
+
+
+def _detect_encoding_full(
+    path: str | Path,
+) -> tuple[str, float | None, bool, bool, str | None]:
+    """Shared encoding detection used by the simple and verbose helpers."""
     path = Path(path)
     raw = path.read_bytes()
 
     if raw.startswith(b"\xef\xbb\xbf"):
-        return "utf-8-sig", True
+        return "utf-8-sig", None, True, True, None
     if raw.startswith(b"\xff\xfe"):
-        return "utf-16-le", True
+        return "utf-16-le", None, True, True, None
     if raw.startswith(b"\xfe\xff"):
-        return "utf-16-be", True
+        return "utf-16-be", None, True, True, None
 
     try:
         import chardet
-        result = chardet.detect(raw[:8192])
-        enc = result.get("encoding") or "utf-8"
-        return enc, False
     except ImportError:
-        return "utf-8", False
+        return (
+            "utf-8",
+            None,
+            False,
+            False,
+            "chardet nicht installiert — Encoding wurde nicht erkannt, "
+            "Default 'utf-8' kann zu Mojibake führen. "
+            "Installiere chardet für robuste Erkennung.",
+        )
+
+    result = chardet.detect(raw[:8192])
+    enc = result.get("encoding") or "utf-8"
+    conf = result.get("confidence")
+    return enc, conf, False, True, None
 
 
 def _sniff_delimiter(sample: str) -> str:

--- a/src/kwb/ingest/xlsx_loader.py
+++ b/src/kwb/ingest/xlsx_loader.py
@@ -31,6 +31,27 @@ class XLSXLoadError(Exception):
     """Raised when an XLSX file cannot be loaded."""
 
 
+def list_sheets(path: str | Path) -> list[str]:
+    """Return the sheet names of an XLSX file."""
+    path = Path(path)
+    if path.suffix.lower() not in SUPPORTED_EXTENSIONS:
+        raise XLSXLoadError(
+            f"Unsupported file type: {path.suffix}. "
+            f"Expected one of {SUPPORTED_EXTENSIONS}"
+        )
+    try:
+        import openpyxl
+    except ImportError:
+        raise XLSXLoadError(
+            "openpyxl is required for XLSX support: pip install openpyxl"
+        )
+    wb = openpyxl.load_workbook(filename=str(path), read_only=True, data_only=True)
+    try:
+        return list(wb.sheetnames)
+    finally:
+        wb.close()
+
+
 def load_xlsx(
     path: str | Path,
     max_rows: int = MAX_ROWS,

--- a/tests/test_ingest_preview.py
+++ b/tests/test_ingest_preview.py
@@ -1,0 +1,266 @@
+"""
+Tests for the non-destructive ingest preview endpoint (issue #177).
+
+Covers:
+  - CSV UTF-8 preview: encoding + delimiter + head + id candidates
+  - CSV Latin-1 preview: encoding detection + warning surfacing
+  - chardet-missing fallback warning (#166)
+  - XLSX preview: multi-sheet listing
+  - XML preview: METS/MODS format detection
+  - XML preview: unknown format warning
+  - Preview is non-destructive (does not touch workspace/state)
+  - Disallowed extension produces per-file error without aborting batch
+"""
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+_FORCE_NO_FASTAPI = os.environ.get("KWB_FORCE_NO_FASTAPI") == "1"
+try:
+    if _FORCE_NO_FASTAPI:
+        raise ImportError("FastAPI disabled for deterministic catalog checks")
+    from fastapi.testclient import TestClient
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    _FASTAPI_AVAILABLE = False
+
+_skip_no_fastapi = unittest.skipUnless(
+    _FASTAPI_AVAILABLE,
+    "FastAPI not installed — run: pip install fastapi httpx python-multipart",
+)
+
+
+_UTF8_CSV = (
+    "record_id,title,year\n"
+    "obj_001,Karte Bern,1923\n"
+    "obj_002,Grundriss,1850\n"
+    "obj_003,Plan Wien,1901\n"
+).encode("utf-8")
+
+_LATIN1_CSV = (
+    "record_id;title;year\n"
+    "obj_001;Karte Zürich;1923\n"
+    "obj_002;Münster;1850\n"
+).encode("latin-1")
+
+_METS_MODS_XML = b"""<?xml version="1.0"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/"
+           xmlns:mods="http://www.loc.gov/mods/v3">
+  <mets:dmdSec ID="dmd1">
+    <mets:mdWrap MDTYPE="MODS"><mets:xmlData>
+      <mods:mods>
+        <mods:titleInfo><mods:title>Erste Karte</mods:title></mods:titleInfo>
+      </mods:mods>
+    </mets:xmlData></mets:mdWrap>
+  </mets:dmdSec>
+</mets:mets>
+"""
+
+_NOT_XML_FILE = b"<?xml version='1.0'?><random><foo/></random>"
+
+
+def _get_client():
+    from kwb.api import deps
+    from kwb.core.workspace import Workspace
+    deps._state["datasets"] = {}
+    deps._state["report"] = None
+    deps._state["workspace"] = Workspace(name="test")
+    deps._config_cache = None
+    from kwb.api.app import app
+    from kwb.ai.mock import MockProvider
+    deps._prov_override = MockProvider.with_defaults()
+    return TestClient(app)
+
+
+def _file(content: bytes, name: str, mime: str = "text/csv"):
+    return ("files", (name, io.BytesIO(content), mime))
+
+
+@_skip_no_fastapi
+class TestIngestPreviewCSV(unittest.TestCase):
+    def setUp(self):
+        self.client = _get_client()
+
+    def test_utf8_preview_basic_shape(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(_UTF8_CSV, "data.csv")],
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertIn("previews", body)
+        self.assertEqual(len(body["previews"]), 1)
+        p = body["previews"][0]
+        self.assertEqual(p["filename"], "data.csv")
+        self.assertEqual(p["format"], "csv")
+        self.assertEqual(p["row_count"], 3)
+        self.assertEqual(p["column_count"], 3)
+        self.assertEqual(len(p["head"]), 3)
+        self.assertEqual(p["delimiter"], ",")
+        self.assertEqual(p["id_column"]["proposed"], "record_id")
+        self.assertIn("record_id", p["id_column"]["candidates"])
+
+    def test_utf8_encoding_block_contains_confidence(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(_UTF8_CSV, "data.csv")],
+        )
+        p = r.json()["previews"][0]
+        self.assertIn("encoding", p)
+        enc = p["encoding"]
+        self.assertIn(enc["detected"].lower().replace("_", "-"),
+                      ("utf-8", "ascii"))
+        self.assertIsInstance(enc["has_bom"], bool)
+        self.assertIsInstance(enc["chardet_available"], bool)
+
+    def test_latin1_csv_delimiter_and_confidence_present(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(_LATIN1_CSV, "umlaute.csv")],
+        )
+        p = r.json()["previews"][0]
+        self.assertEqual(p["delimiter"], ";")
+        # Confidence must be plumbed through (number from chardet, or None when
+        # chardet declined to commit). The point: the field exists and is
+        # surfaced so the UI can warn on low confidence.
+        self.assertIn("confidence", p["encoding"])
+        conf = p["encoding"]["confidence"]
+        self.assertTrue(conf is None or isinstance(conf, (int, float)))
+
+    def test_preview_does_not_touch_workspace(self):
+        from kwb.api import deps
+        self.client.post(
+            "/api/ingest/preview",
+            files=[_file(_UTF8_CSV, "data.csv")],
+        )
+        self.assertEqual(deps._state["datasets"], {})
+        self.assertEqual(deps._state["workspace"].source_files, [])
+
+    def test_chardet_missing_yields_warning(self):
+        """Issue #166: when chardet is unavailable, surface a warning."""
+        with patch.dict("sys.modules", {"chardet": None}):
+            r = self.client.post(
+                "/api/ingest/preview",
+                files=[_file(_UTF8_CSV, "data.csv")],
+            )
+        p = r.json()["previews"][0]
+        self.assertFalse(p["encoding"]["chardet_available"])
+        self.assertTrue(any("chardet" in w.lower() for w in p["warnings"]))
+
+    def test_disallowed_extension_returns_error_per_file(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(b"foo", "evil.exe", "application/octet-stream")],
+        )
+        self.assertEqual(r.status_code, 200)
+        previews = r.json()["previews"]
+        self.assertEqual(len(previews), 1)
+        self.assertIn("error", previews[0])
+
+    def test_multiple_files_independent(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[
+                _file(_UTF8_CSV, "a.csv"),
+                _file(_LATIN1_CSV, "b.csv"),
+            ],
+        )
+        previews = r.json()["previews"]
+        self.assertEqual(len(previews), 2)
+        self.assertEqual(previews[0]["filename"], "a.csv")
+        self.assertEqual(previews[1]["filename"], "b.csv")
+
+
+@_skip_no_fastapi
+class TestIngestPreviewXML(unittest.TestCase):
+    def setUp(self):
+        self.client = _get_client()
+
+    def test_mets_mods_detected(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(_METS_MODS_XML, "doc.xml", "application/xml")],
+        )
+        p = r.json()["previews"][0]
+        self.assertEqual(p["format"], "xml")
+        self.assertEqual(p["xml_format"], "mets_mods")
+        self.assertGreater(p["row_count"], 0)
+        self.assertGreater(p["column_count"], 0)
+
+    def test_unknown_xml_format_warns(self):
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(_NOT_XML_FILE, "random.xml", "application/xml")],
+        )
+        p = r.json()["previews"][0]
+        self.assertEqual(p["xml_format"], "unknown")
+        self.assertTrue(any("METS" in w or "LIDO" in w for w in p["warnings"]))
+
+
+@_skip_no_fastapi
+class TestIngestPreviewXLSX(unittest.TestCase):
+    def setUp(self):
+        self.client = _get_client()
+
+    def _build_xlsx_bytes(self, sheets: dict[str, list[list[str]]]) -> bytes:
+        try:
+            import openpyxl
+        except ImportError:
+            self.skipTest("openpyxl not installed")
+        wb = openpyxl.Workbook()
+        wb.remove(wb.active)
+        for name, rows in sheets.items():
+            ws = wb.create_sheet(title=name)
+            for row in rows:
+                ws.append(row)
+        buf = io.BytesIO()
+        wb.save(buf)
+        return buf.getvalue()
+
+    def test_xlsx_single_sheet_preview(self):
+        xlsx = self._build_xlsx_bytes({
+            "Sheet1": [
+                ["record_id", "title"],
+                ["obj_001", "Karte"],
+                ["obj_002", "Plan"],
+            ]
+        })
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(
+                xlsx, "data.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )],
+        )
+        p = r.json()["previews"][0]
+        self.assertEqual(p["format"], "xlsx")
+        self.assertEqual(p["sheets"], ["Sheet1"])
+        self.assertEqual(p["active_sheet"], "Sheet1")
+        self.assertEqual(p["row_count"], 2)
+
+    def test_xlsx_multi_sheet_warns(self):
+        xlsx = self._build_xlsx_bytes({
+            "Daten": [["id", "name"], ["1", "A"]],
+            "Notizen": [["x", "y"], ["a", "b"]],
+        })
+        r = self.client.post(
+            "/api/ingest/preview",
+            files=[_file(
+                xlsx, "multi.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            )],
+        )
+        p = r.json()["previews"][0]
+        self.assertEqual(len(p["sheets"]), 2)
+        self.assertTrue(any("Sheet" in w for w in p["warnings"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds a new `/api/ingest/preview` endpoint that allows curators to inspect uploaded CSV/XLSX/XML files without committing them to the workspace. Returns encoding detection (with chardet confidence), delimiter sniffing, ID column candidates, column profiles, and a head sample for validation before the destructive analysis step.

## Problem
Curators had no way to preview file metadata (encoding, delimiter, ID columns) before triggering the full structural analysis. This led to failed commits due to encoding misdetection, wrong delimiters, or missing ID columns. Issue #177 requested a non-destructive preview step.

## Root cause
The ingest pipeline (`ingest_csv`, `ingest_xlsx`, `ingest_xml`) was designed for full loading and analysis, not lightweight inspection. Encoding detection was internal and confidence scores were not surfaced. No endpoint existed to preview without side effects.

## Solution

### Backend changes
1. **New endpoint `POST /api/ingest/preview`** (`src/kwb/api/routes/analyze.py`):
   - Accepts file uploads (CSV/XLSX/XML/ZIP)
   - Returns per-file diagnostics without modifying workspace state
   - Validates file size and extension; returns per-file errors without aborting batch
   - Handles encoding detection, delimiter sniffing, XML format detection

2. **Enhanced encoding detection** (`src/kwb/ingest/csv_loader.py`):
   - New `detect_encoding_with_confidence()` returns dict with `{encoding, confidence, has_bom, chardet_available, warning}`
   - Surfaces chardet-missing warning (addresses #166 partially)
   - Refactored `detect_encoding()` to use shared `_detect_encoding_full()` helper

3. **XLSX sheet listing** (`src/kwb/ingest/xlsx_loader.py`):
   - New `list_sheets()` function to enumerate sheet names without full load
   - Preparation for multi-sheet support (#181)

4. **XML format detection** (`src/kwb/ingest/xml_loader.py`):
   - Exported `detect_xml_format()` for preview use
   - Warns if format is unknown (not METS/MODS or LIDO)

### Frontend changes
1. **Dashboard UI** (`src/kwb/api/parts/dashboard.js`):
   - New "Vorschau prüfen" button triggers `previewIngest()`
   - `renderPreview()` displays card-stack of file diagnostics
   - Shows encoding with confidence color-coding, delimiter, XML format, sheet list, ID column candidates
   - Expandable head preview table (first 10 rows)
   - Warnings highlighted (chardet missing, multi-sheet, encoding confidence, row/column limits)
   - "Übernehmen" button confirms and proceeds to analysis; "Abbrechen" closes preview

2. **HTML panel** (`src/kwb/api/dashboard.html`):
   - New preview panel section with card-based layout
   - Integrated into step 1b workflow

### Tests
- **Comprehensive test suite** (`tests/test_ingest_preview.py`, 266 lines):
  - CSV UTF-8 preview: encoding, delimiter, head, ID candidates
  - CSV Latin-1 preview: encoding detection, confidence surfacing
  - chardet-missing fallback warning (#166)
  - XLSX single/multi-sheet listing and warnings
  - XML METS/MODS detection and unknown format warning
  - Non-destructive verification (workspace untouched)
  - Disallowed extension per-file error handling
  - Multiple file independence

## Files changed
- `src/kwb/api/routes/analyze.py` — new preview endpoint + 3 preview helpers
- `src/kwb/ingest/csv_loader.py` — `detect_encoding_with_confidence()`, refactored detection
- `src/kwb/ingest/xlsx_loader.py` — `list_sheets()`
- `src/kwb/api/parts/dashboard.js` — preview UI logic
- `src/kwb/api/dashboard.html` — preview panel

https://claude.ai/code/session_01NekaNpaLtA9GSYLfoXF18E