### PR TITLE
Add system-prompt fingerprint tracking (issue #150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ Sektionen:
 ## [Unreleased]
 
 ### Hinzugefügt
+- **System-Prompt-Fingerprint (Issue #150)** — neuer Helper
+  `kwb.ai.prompts.resolve_system_prompt(override, default, *, task)` löst
+  den Override gegen den Default auf und liefert einen Fingerprint
+  (sha256, preview, length, is_override, default_sha256, task). Wird in
+  `ner_llm`, `ner_hybrid`, `scan_problematic_terms` und
+  `_normalize_dates_llm` benutzt. `BatchReport.system_prompt_used` und
+  `NERResult.system_prompt_used` propagieren den Fingerprint nach oben.
+- **API: `system_prompt_used` in `/api/ner`, `/api/ner/stream`,
+  `/api/scan`, `/api/edtf` Antworten** — Kuratoren können verifizieren,
+  dass ihr Override beim Modell ankam, ohne API-Logs zu inspizieren.
+- **`POST /api/prompts/dry-run`** — gibt resolved Text + Fingerprint
+  zurück für `task ∈ {ner, edtf, problematic_terms}` ohne LLM-Aufruf.
+- **Dashboard: "Override prüfen"-Block** im System-Instruktionen-Panel
+  zeigt sha256, Länge und Preview des Prompts, der bei dem nächsten Lauf
+  gesendet würde. NER-Result-Panel zeigt zusätzlich, welcher Prompt
+  tatsächlich gesendet wurde.
+
+### Hinzugefügt (vorher)
 - **System-Check (`kwb.system_check`, CLI `kwb system-check`,
   `GET /api/system/check`)** — probes für optionale Abhängigkeiten und
   System-Binaries: Python, fastapi, httpx, chardet, openpyxl, pypdf,

--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 1011/1167 Tests bestanden, 0 fehlgeschlagen, 156 übersprungen
+**Gesamtstatus:** 1023/1182 Tests bestanden, 0 fehlgeschlagen, 159 übersprungen
 
 ---
 
@@ -274,12 +274,13 @@
 | test_roadmap.py | 8/8 | 0 | 0 | ✅ |
 | test_services.py | 20/20 | 0 | 0 | ✅ |
 | test_system_check.py | 15/16 | 0 | 1 | ✅ |
+| test_system_prompt_used.py | 12/15 | 0 | 3 | ✅ |
 | test_utils.py | 30/30 | 0 | 0 | ✅ |
 | test_workspace.py | 33/33 | 0 | 0 | ✅ |
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 21/21 | 0 | 0 | ✅ |
-| **Gesamt** | **1011/1167** | **0** | **156** | **✅** |
+| **Gesamt** | **1023/1182** | **0** | **159** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/ai/batch.py
+++ b/src/kwb/ai/batch.py
@@ -95,6 +95,10 @@ class BatchReport:
     prompt_fn_name: str | None = None
     started_at: datetime | None = None
     finished_at: datetime | None = None
+    # #150: fingerprint of the resolved system prompt actually sent to the
+    # model. Populated by the caller (e.g. ner_llm). See
+    # kwb.ai.prompts.resolve_system_prompt.
+    system_prompt_used: dict | None = None
 
     @property
     def success_rate(self) -> float:

--- a/src/kwb/ai/prompts.py
+++ b/src/kwb/ai/prompts.py
@@ -5,9 +5,13 @@ list, preview and (eventually) override them. Each entry is a self-
 describing record — name, version, description, parameters, factory —
 so callers can render prompts without importing the underlying Python
 functions.
+
+#150: ``resolve_system_prompt`` records which prompt actually went to the
+model so curators can verify their override took effect.
 """
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
@@ -56,6 +60,61 @@ CLASSIFICATION_CATEGORIES = {
 
 def _ctx_line(additional_context: str) -> str:
     return f"Kontext: {additional_context}\n" if additional_context else ""
+
+
+# ---------------------------------------------------------------------------
+# System-prompt override fingerprint (#150)
+# ---------------------------------------------------------------------------
+
+_FINGERPRINT_PREVIEW_LEN = 240
+
+
+def fingerprint_prompt(text: str) -> dict[str, Any]:
+    """Return a small descriptor of a system prompt for provenance.
+
+    Includes a sha256 digest, length, and a preview of the first 240
+    characters. Stable and cheap — safe to attach to every result.
+    """
+    text = text or ""
+    sha = hashlib.sha256(text.encode("utf-8", errors="replace")).hexdigest()
+    preview = text[:_FINGERPRINT_PREVIEW_LEN]
+    if len(text) > _FINGERPRINT_PREVIEW_LEN:
+        preview += "…"
+    return {
+        "sha256": sha,
+        "length": len(text),
+        "preview": preview,
+    }
+
+
+def resolve_system_prompt(
+    override: str,
+    default: str,
+    *,
+    task: str = "",
+) -> tuple[str, dict[str, Any]]:
+    """Pick the system prompt and capture a fingerprint of the result (#150).
+
+    Args:
+        override: User-supplied system prompt. Empty/whitespace means "use default".
+        default: The module-level default prompt for this task.
+        task: Optional task name surfaced in the fingerprint, e.g. ``"ner"``.
+
+    Returns:
+        Tuple of ``(resolved_text, fingerprint_dict)``. The fingerprint
+        contains ``sha256``, ``length``, ``preview``, ``is_override``,
+        ``default_sha256`` and ``task`` so the dashboard can prove which
+        text reached the model. Attach this to result records / API
+        responses so curators can verify their override took effect
+        without inspecting raw API logs.
+    """
+    is_override = bool(override and override.strip())
+    resolved = override if is_override else default
+    fp = fingerprint_prompt(resolved)
+    fp["is_override"] = is_override
+    fp["default_sha256"] = fingerprint_prompt(default)["sha256"]
+    fp["task"] = task
+    return resolved, fp
 
 
 def _quality_rules(label: str) -> str:

--- a/src/kwb/analyze/ner.py
+++ b/src/kwb/analyze/ner.py
@@ -84,6 +84,9 @@ class NERResult:
     entities: list[Entity] = field(default_factory=list)
     batch_report: BatchReport | None = None
     completion_summary: CompletionSummary | None = None
+    # #150: fingerprint of the system prompt that was actually sent to the
+    # model, so curators can verify their override took effect.
+    system_prompt_used: dict | None = None
 
     @property
     def by_type(self) -> dict[EntityType, list[Entity]]:
@@ -216,9 +219,14 @@ def ner_llm(
     model: str | None = None,
     system_prompt: str = "",
 ) -> tuple[list[Entity], BatchReport]:
+    from kwb.ai.prompts import resolve_system_prompt
+    resolved_prompt, prompt_fp = resolve_system_prompt(
+        system_prompt, SYSTEM_NER, task="ner",
+    )
+
     def _make_prompt(item: dict[str, Any]) -> list[AIMessage]:
         return [
-            AIMessage.system(system_prompt or SYSTEM_NER),
+            AIMessage.system(resolved_prompt),
             AIMessage.user(
                 f'Analysiere diesen Text und extrahiere alle Named Entities:\n\n'
                 f'Text: "{item["text"]}"\n'
@@ -254,6 +262,7 @@ def ner_llm(
                 ))
         elif not result.parsed:
             parse_failures.append(result.record_id)
+    batch.system_prompt_used = prompt_fp
     return entities, batch
 
 
@@ -364,6 +373,10 @@ def ner_hybrid(
             if k not in llm_map or e.confidence > llm_map[k].confidence:
                 llm_map[k] = e
         result.batch_report = batch
+        # #150: propagate the resolved system-prompt fingerprint so the API
+        # and dashboard can prove the user's override took effect.
+        if batch is not None:
+            result.system_prompt_used = batch.system_prompt_used
 
         # Calculate completion summary from batch report.
         # Count items (records) producing entities, NOT entity instances —
@@ -412,6 +425,16 @@ def ner_hybrid(
 # Full-dataset scan (problematic terms)
 # ---------------------------------------------------------------------------
 
+_DEFAULT_SCAN_PROMPT = """Du bist ein Experte fuer Metadatenqualitaet in GLAM-Institutionen.
+Analysiere diese Metadaten-Werte und identifiziere potentiell problematische Begriffe:
+- Veraltete oder koloniale Terminologie
+- Diskriminierende oder stigmatisierende Begriffe
+- Historisch belastete Bezeichnungen
+- Nicht mehr zeitgemaesse ethnische/geographische Bezeichnungen
+
+Antworte IMMER als valides JSON."""
+
+
 def scan_problematic_terms(
     df: pd.DataFrame,
     provider: AIProvider,
@@ -420,14 +443,10 @@ def scan_problematic_terms(
     model: str | None = None,
     system_prompt: str = "",
 ) -> tuple[list[dict], BatchReport]:
-    SYSTEM_SCAN = system_prompt or """Du bist ein Experte fuer Metadatenqualitaet in GLAM-Institutionen.
-Analysiere diese Metadaten-Werte und identifiziere potentiell problematische Begriffe:
-- Veraltete oder koloniale Terminologie
-- Diskriminierende oder stigmatisierende Begriffe
-- Historisch belastete Bezeichnungen
-- Nicht mehr zeitgemaesse ethnische/geographische Bezeichnungen
-
-Antworte IMMER als valides JSON."""
+    from kwb.ai.prompts import resolve_system_prompt
+    SYSTEM_SCAN, prompt_fp = resolve_system_prompt(
+        system_prompt, _DEFAULT_SCAN_PROMPT, task="problematic_terms",
+    )
 
     str_cols = [c for c in df.columns if df[c].dtype.kind in ('O', 'U') or str(df[c].dtype) == "string"]
     working = df.sample(n=min(sample_size, len(df)), random_state=42) if sample_size < len(df) else df
@@ -458,6 +477,7 @@ Antworte IMMER als valides JSON."""
         ]
 
     batch = process_batch(provider, items, _make_prompt, model=model)
+    batch.system_prompt_used = prompt_fp
     issues = []
     for r in batch.results:
         if r.parsed and r.parsed.get("problematic_terms"):

--- a/src/kwb/api/dashboard.html
+++ b/src/kwb/api/dashboard.html
@@ -608,6 +608,7 @@
 <h3>NER-Testergebnisse <span id="ner-count" style="font-size:.7rem;color:#888"></span></h3>
 <div id="ner-metrics" style="font-size:.72rem;color:#555;margin-bottom:.4rem"></div>
 <div id="ner-completion-banner" style="margin-bottom:.6rem"></div>
+<div id="ner-prompt-used"></div>
 <div class="fl" id="ner-status-bar" style="margin-bottom:.3rem">
 <strong style="font-size:.7rem;align-self:center">Status:</strong>
 <div class="fb2 a" onclick="filterStatus('all',this)">Alle</div>
@@ -868,6 +869,18 @@
 <option value="edtf_de">EDTF</option><option value="scan_de">Scan</option><option value="custom">Eigene</option>
 </select>
 <textarea id="cfg-sys" rows="5" style="margin-top:.3rem"></textarea>
+<div style="margin-top:.5rem;border-top:1px dashed #ccc;padding-top:.5rem">
+<label style="font-size:.78rem">Override pr&uuml;fen (Issue #150) &mdash; ohne LLM-Aufruf</label>
+<div style="display:flex;gap:.4rem;align-items:center;margin-top:.3rem;flex-wrap:wrap">
+<select id="cfg-dryrun-task" style="flex:0 0 auto">
+<option value="ner">NER</option>
+<option value="edtf">EDTF</option>
+<option value="problematic_terms">Problematische Begriffe</option>
+</select>
+<button class="btn sm" onclick="dryRunSystemPrompt()">&#128270; Prompt testen</button>
+</div>
+<div id="cfg-dryrun-out" style="display:none;margin-top:.4rem"></div>
+</div>
 </div>
 </div>
 </div>

--- a/src/kwb/api/parts/dashboard.js
+++ b/src/kwb/api/parts/dashboard.js
@@ -647,7 +647,55 @@ function renderNER(r){
   // EXT-BUG-01: Display completion summary
   renderCompletionSummary(r.completion_summary, r.parse_failures);
 
+  // #150: Show which system prompt actually went to the model
+  renderSystemPromptUsed('ner-prompt-used', r.system_prompt_used);
+
   applyNERFilters();
+}
+
+// === SYSTEM-PROMPT FINGERPRINT (issue #150) ===
+function renderSystemPromptUsed(targetId, fp){
+  const el=$(targetId);
+  if(!el)return;
+  if(!fp){el.innerHTML='';return;}
+  const isOverride=!!fp.is_override;
+  const color=isOverride?'var(--info,#06c)':'#666';
+  const label=isOverride?'&#9998; Override aktiv':'Default-Prompt';
+  let html='<div style="background:#f4f7fa;border-left:3px solid '+color+';padding:.4rem .6rem;margin:.4rem 0;font-size:.74rem">';
+  html+='<div style="display:flex;justify-content:space-between;align-items:center">';
+  html+='<span><strong style="color:'+color+'">'+label+'</strong> &middot; task: <code>'+esc(fp.task||'?')+'</code> &middot; '+(fp.length||0)+' Zeichen</span>';
+  html+='<span style="color:#888;font-family:monospace;font-size:.7rem" title="sha256 des gesendeten Prompts">'+esc((fp.sha256||'').slice(0,12))+'&hellip;</span>';
+  html+='</div>';
+  html+='<details style="margin-top:.25rem"><summary style="cursor:pointer;color:#444">Prompt-Preview anzeigen</summary>';
+  html+='<pre style="margin:.25rem 0 0;padding:.4rem;background:#fff;border:1px solid #ddd;white-space:pre-wrap;word-break:break-word;font-size:.7rem">'+esc(fp.preview||'')+'</pre></details>';
+  html+='</div>';
+  el.innerHTML=html;
+}
+
+async function dryRunSystemPrompt(){
+  const task=$('cfg-dryrun-task')?.value||'ner';
+  const override=$('cfg-sys')?.value||'';
+  const out=$('cfg-dryrun-out');
+  if(out){out.style.display='block';out.textContent='Wird geprüft …';}
+  try{
+    const r=await(await fetch('/api/prompts/dry-run',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({task,system_prompt:override}),
+    })).json();
+    if(out){
+      if(r.status==='ok'){
+        const fp=r.fingerprint||{};
+        const isOverride=!!fp.is_override;
+        out.innerHTML='<div style="font-size:.78rem;margin-bottom:.3rem"><strong style="color:'+(isOverride?'var(--info,#06c)':'#666')+'">'+(isOverride?'&#9998; Override würde verwendet':'Default-Prompt würde verwendet')+'</strong> &middot; task: <code>'+esc(task)+'</code> &middot; '+(fp.length||0)+' Zeichen &middot; sha256: <code>'+esc((fp.sha256||'').slice(0,16))+'</code></div>'+
+          '<pre style="margin:0;padding:.5rem;background:#fff;border:1px solid #ccc;white-space:pre-wrap;font-size:.72rem;max-height:240px;overflow:auto">'+esc(r.resolved||'')+'</pre>';
+      }else{
+        out.textContent='Fehler: '+(r.message||'unbekannt');
+      }
+    }
+  }catch(e){
+    if(out)out.textContent='Fehler: '+(e.message||String(e));
+  }
 }
 
 function renderCompletionSummary(summary, parseFailures){

--- a/src/kwb/api/routes/ai.py
+++ b/src/kwb/api/routes/ai.py
@@ -173,6 +173,64 @@ async def prompts_preview(request: dict):
     }
 
 
+@router.post("/api/prompts/dry-run")
+async def prompts_dry_run(request: dict):
+    """Resolve a system-prompt override against a task default and return
+    the fingerprint plus the resolved text — without making an LLM call (#150).
+
+    Body:
+        {
+          "task": "ner" | "edtf" | "problematic_terms",
+          "system_prompt": "user override or empty string for default"
+        }
+
+    Returns the resolved text and ``resolve_system_prompt`` fingerprint so
+    curators can verify their override took effect before they spend the
+    LLM budget on a real batch.
+    """
+    from kwb.ai.prompts import resolve_system_prompt
+    task = (request.get("task") or "").strip().lower()
+    override = request.get("system_prompt", "") or ""
+
+    defaults = _task_default_prompts()
+    if task not in defaults:
+        return JSONResponse(
+            {
+                "status": "error",
+                "message": (
+                    f"Unbekannter task '{task}'. Erlaubt: "
+                    f"{', '.join(sorted(defaults))}"
+                ),
+            },
+            400,
+        )
+
+    resolved, fingerprint = resolve_system_prompt(
+        override, defaults[task], task=task,
+    )
+    return {
+        "status": "ok",
+        "task": task,
+        "resolved": resolved,
+        "fingerprint": fingerprint,
+    }
+
+
+def _task_default_prompts() -> dict[str, str]:
+    """Return the canonical default system prompt per task.
+
+    Kept here (not imported at module top) to avoid triggering heavy
+    submodule imports until the endpoint is actually called.
+    """
+    from kwb.analyze.ner import SYSTEM_NER, _DEFAULT_SCAN_PROMPT
+    from kwb.normalize.edtf import SYSTEM_EDTF
+    return {
+        "ner": SYSTEM_NER,
+        "edtf": SYSTEM_EDTF,
+        "problematic_terms": _DEFAULT_SCAN_PROMPT,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Temperature tuning info (#155)
 # ---------------------------------------------------------------------------

--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -761,6 +761,15 @@ async def api_ner(request: dict):
     completion_summary = _merge_completion_summaries(completion_summaries)
     parse_failures = _collect_parse_failures(ner_results)
 
+    # #150: surface the resolved system-prompt fingerprint so curators can
+    # verify their override took effect. All chunks share the same
+    # resolved prompt, so the first non-null fingerprint suffices.
+    system_prompt_used = None
+    for r in ner_results:
+        if getattr(r, "system_prompt_used", None):
+            system_prompt_used = r.system_prompt_used
+            break
+
     return {
         "task_name": "NER", "total": len(ents),
         "prompt_name": prompt_name,
@@ -773,6 +782,7 @@ async def api_ner(request: dict):
         "ai_provenance": ai_provenance,
         "completion_summary": completion_summary,
         "parse_failures": parse_failures,
+        "system_prompt_used": system_prompt_used,
         "workspace": ws.to_summary(),
     }
 
@@ -892,6 +902,12 @@ async def api_ner_stream(request: dict):
         # EXT-BUG-01: Expose completion summary and failures for visibility
         completion_summary = _merge_completion_summaries(completion_summaries)
         parse_failures = _collect_parse_failures(ner_results)
+        # #150: surface system-prompt fingerprint
+        system_prompt_used = None
+        for r in ner_results:
+            if getattr(r, "system_prompt_used", None):
+                system_prompt_used = r.system_prompt_used
+                break
         yield _sse_event({
             "type": "done",
             "result": {
@@ -903,6 +919,7 @@ async def api_ner_stream(request: dict):
                 "run_metrics": metrics, "ai_provenance": ai_provenance,
                 "completion_summary": completion_summary,
                 "parse_failures": parse_failures,
+                "system_prompt_used": system_prompt_used,
                 "workspace": ws.to_summary(),
             },
         })
@@ -929,6 +946,7 @@ async def api_scan(request: dict):
     working, sampling = _build_sampling_plan(df, request, profile.id_column, ss)
     started = time.perf_counter()
     issues, errors, batches = [], 0, []
+    system_prompt_used = None
     for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
         try:
             i2, batch = scan_problematic_terms(
@@ -939,6 +957,8 @@ async def api_scan(request: dict):
                 system_prompt=syp,
             )
             issues.extend(i2)
+            if system_prompt_used is None:
+                system_prompt_used = getattr(batch, "system_prompt_used", None)
             batches.append({"chunk": chunk_no, "rows": len(chunk_df), "issues": len(i2), "succeeded": batch.succeeded})
         except Exception:
             errors += len(chunk_df)
@@ -960,6 +980,7 @@ async def api_scan(request: dict):
         "succeeded": succeeded, "model": mod or "default",
         "issues": issues[:200],
         "run_metrics": metrics,
+        "system_prompt_used": system_prompt_used,
     }
 
 
@@ -1073,6 +1094,7 @@ async def api_edtf(request: dict):
     all_results = []
     chunk_reports = []
     errors = 0
+    system_prompt_used = None
     for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
         items = [
             {
@@ -1085,6 +1107,8 @@ async def api_edtf(request: dict):
         try:
             results, _batch = normalize_dates(items, provider=prov, model=mod or None, system_prompt=syp)
             all_results.extend(results)
+            if system_prompt_used is None and _batch is not None:
+                system_prompt_used = getattr(_batch, "system_prompt_used", None)
             chunk_reports.append({"chunk": chunk_no, "rows": len(chunk_df), "results": len(results)})
         except Exception:
             errors += len(chunk_df)
@@ -1119,6 +1143,7 @@ async def api_edtf(request: dict):
              "confidence": round(r.confidence, 3), "method": r.method, "note": r.note}
             for r in results
         ],
+        "system_prompt_used": system_prompt_used,
     }
 
 

--- a/src/kwb/enrich/edtf.py
+++ b/src/kwb/enrich/edtf.py
@@ -48,15 +48,21 @@ def _normalize_dates_llm(
     model: str | None = None,
     system_prompt: str = "",
 ) -> tuple[list[EDTFResult], BatchReport]:
+    from kwb.ai.prompts import resolve_system_prompt
+    resolved_prompt, prompt_fp = resolve_system_prompt(
+        system_prompt, SYSTEM_EDTF, task="edtf",
+    )
+
     def _p(item):
         return [
-            AIMessage.system(system_prompt or SYSTEM_EDTF),
+            AIMessage.system(resolved_prompt),
             AIMessage.user(
                 f'Normalisiere in EDTF: "{item["text"]}"\n\n'
                 f'JSON: {{"original":"...","edtf":"...","confidence":0.0-1.0,"note":"..."}}'
             ),
         ]
     batch = process_batch(provider, items, _p, id_field="record_id", model=model)
+    batch.system_prompt_used = prompt_fp
 
     # Pre-build lookup dict for O(1) access instead of O(n²) search
     items_by_id = {item.get("record_id"): item for item in items}

--- a/src/kwb/normalize/edtf.py
+++ b/src/kwb/normalize/edtf.py
@@ -210,11 +210,16 @@ def normalize_edtf_llm(date_strings, provider, model=None, system_prompt=""):
                 llm_idx += 1
         return final, None
 
+    from kwb.ai.prompts import resolve_system_prompt
+    resolved_prompt, prompt_fp = resolve_system_prompt(
+        system_prompt, SYSTEM_EDTF, task="edtf",
+    )
+
     def _p(item):
         text = item.get("text", item.get("date", ""))
         rid = item.get("record_id", "")
         return [
-            AIMessage.system(system_prompt or SYSTEM_EDTF),
+            AIMessage.system(resolved_prompt),
             AIMessage.user(
                 f'Konvertiere in EDTF: "{text}" Record: {rid}\n\n'
                 f'JSON: {{"original":"...","edtf":"...","confidence":0.0-1.0,"note":"..."}}'
@@ -222,6 +227,7 @@ def normalize_edtf_llm(date_strings, provider, model=None, system_prompt=""):
         ]
 
     batch = process_batch(provider, llm_items, _p, model=model)
+    batch.system_prompt_used = prompt_fp
     llm_idx = 0
     final = []
     for r in results:

--- a/tests/test_system_prompt_used.py
+++ b/tests/test_system_prompt_used.py
@@ -1,0 +1,208 @@
+"""
+Tests for system-prompt override feedback (issue #150).
+
+Covers:
+  - resolve_system_prompt helper (override vs default fingerprints)
+  - fingerprint_prompt (sha256, length, preview)
+  - NERResult.system_prompt_used populated by ner_llm / ner_hybrid
+  - scan_problematic_terms BatchReport carries the fingerprint
+  - EDTF batch carries the fingerprint
+  - /api/prompts/dry-run returns the resolved text + fingerprint without
+    making an LLM call
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from kwb.ai.mock import MockProvider
+from kwb.ai.prompts import (
+    fingerprint_prompt,
+    resolve_system_prompt,
+)
+
+
+class TestResolveSystemPrompt(unittest.TestCase):
+    def test_empty_override_picks_default(self):
+        text, fp = resolve_system_prompt("", "DEFAULT TEXT", task="ner")
+        self.assertEqual(text, "DEFAULT TEXT")
+        self.assertFalse(fp["is_override"])
+        self.assertEqual(fp["task"], "ner")
+        self.assertEqual(fp["length"], len("DEFAULT TEXT"))
+
+    def test_whitespace_only_override_picks_default(self):
+        text, fp = resolve_system_prompt("   \n\t  ", "DEFAULT", task="edtf")
+        self.assertEqual(text, "DEFAULT")
+        self.assertFalse(fp["is_override"])
+
+    def test_override_text_returned(self):
+        override = "Du bist ein spezieller Kurator."
+        text, fp = resolve_system_prompt(override, "DEFAULT", task="ner")
+        self.assertEqual(text, override)
+        self.assertTrue(fp["is_override"])
+        self.assertEqual(fp["sha256"], hashlib.sha256(override.encode()).hexdigest())
+
+    def test_fingerprint_records_default_sha(self):
+        """The default's sha is always reported so the UI can compare."""
+        default = "DEFAULT TEXT"
+        _, fp = resolve_system_prompt("custom", default, task="ner")
+        expected = hashlib.sha256(default.encode()).hexdigest()
+        self.assertEqual(fp["default_sha256"], expected)
+        self.assertNotEqual(fp["sha256"], fp["default_sha256"])
+
+    def test_default_path_sha_equals_default_sha(self):
+        default = "DEFAULT TEXT"
+        _, fp = resolve_system_prompt("", default, task="ner")
+        self.assertEqual(fp["sha256"], fp["default_sha256"])
+
+    def test_preview_truncates_long_text(self):
+        long = "x" * 1000
+        fp = fingerprint_prompt(long)
+        self.assertEqual(fp["length"], 1000)
+        self.assertLessEqual(len(fp["preview"]), 1000)
+        self.assertTrue(fp["preview"].endswith("…"))
+
+    def test_preview_does_not_truncate_short(self):
+        fp = fingerprint_prompt("kurz")
+        self.assertEqual(fp["preview"], "kurz")
+        self.assertFalse(fp["preview"].endswith("…"))
+
+
+class TestNERSystemPromptCapture(unittest.TestCase):
+    def test_ner_llm_returns_fingerprint_via_batch(self):
+        from kwb.analyze.ner import ner_llm
+
+        prov = MockProvider.with_defaults()
+        ents, batch = ner_llm(
+            [{"record_id": "r1", "text": "Goethe in Weimar.", "column": "title"}],
+            prov,
+        )
+        self.assertIsNotNone(batch.system_prompt_used)
+        self.assertFalse(batch.system_prompt_used["is_override"])
+        self.assertEqual(batch.system_prompt_used["task"], "ner")
+
+    def test_ner_llm_records_override(self):
+        from kwb.analyze.ner import ner_llm
+
+        prov = MockProvider.with_defaults()
+        override = "Du bist ein Test-Kurator."
+        _, batch = ner_llm(
+            [{"record_id": "r1", "text": "Goethe", "column": "x"}],
+            prov,
+            system_prompt=override,
+        )
+        self.assertTrue(batch.system_prompt_used["is_override"])
+        self.assertEqual(
+            batch.system_prompt_used["sha256"],
+            hashlib.sha256(override.encode()).hexdigest(),
+        )
+
+    def test_ner_hybrid_surfaces_fingerprint_on_result(self):
+        import pandas as pd
+        from kwb.analyze.ner import ner_hybrid
+
+        df = pd.DataFrame({"record_id": ["r1"], "title": ["Goethe in Weimar."]})
+        prov = MockProvider.with_defaults()
+        result = ner_hybrid(
+            df, columns=["title"], provider=prov,
+            id_column="record_id", use_spacy=False, use_llm=True,
+        )
+        self.assertIsNotNone(result.system_prompt_used)
+        self.assertEqual(result.system_prompt_used["task"], "ner")
+
+
+class TestScanSystemPromptCapture(unittest.TestCase):
+    def test_scan_problematic_terms_returns_fingerprint(self):
+        import pandas as pd
+        from kwb.analyze.ner import scan_problematic_terms
+
+        df = pd.DataFrame({"record_id": ["r1"], "subject": ["Test"]})
+        prov = MockProvider.with_defaults()
+        _, batch = scan_problematic_terms(df, prov, id_column="record_id", sample_size=1)
+        self.assertIsNotNone(batch.system_prompt_used)
+        self.assertEqual(batch.system_prompt_used["task"], "problematic_terms")
+
+
+class TestEDTFSystemPromptCapture(unittest.TestCase):
+    def test_normalize_dates_llm_records_fingerprint(self):
+        from kwb.enrich.edtf import _normalize_dates_llm
+
+        prov = MockProvider.with_defaults()
+        _, batch = _normalize_dates_llm(
+            [{"record_id": "r1", "text": "ca. 1923"}],
+            prov,
+        )
+        self.assertIsNotNone(batch.system_prompt_used)
+        self.assertEqual(batch.system_prompt_used["task"], "edtf")
+
+
+_FORCE_NO_FASTAPI = os.environ.get("KWB_FORCE_NO_FASTAPI") == "1"
+try:
+    if _FORCE_NO_FASTAPI:
+        raise ImportError("FastAPI disabled for deterministic catalog checks")
+    from fastapi.testclient import TestClient
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    _FASTAPI_AVAILABLE = False
+
+_skip_no_fastapi = unittest.skipUnless(
+    _FASTAPI_AVAILABLE, "FastAPI not installed",
+)
+
+
+@_skip_no_fastapi
+class TestDryRunEndpoint(unittest.TestCase):
+    def _client(self):
+        from kwb.api import deps
+        from kwb.core.workspace import Workspace
+        deps._state["datasets"] = {}
+        deps._state["workspace"] = Workspace(name="test")
+        from kwb.api.app import app
+        return TestClient(app)
+
+    def test_default_path(self):
+        r = self._client().post(
+            "/api/prompts/dry-run",
+            json={"task": "ner", "system_prompt": ""},
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["status"], "ok")
+        self.assertEqual(body["task"], "ner")
+        self.assertFalse(body["fingerprint"]["is_override"])
+        self.assertEqual(
+            body["fingerprint"]["sha256"],
+            body["fingerprint"]["default_sha256"],
+        )
+
+    def test_override_path(self):
+        override = "Mein eigener Prompt."
+        r = self._client().post(
+            "/api/prompts/dry-run",
+            json={"task": "edtf", "system_prompt": override},
+        )
+        self.assertEqual(r.status_code, 200)
+        body = r.json()
+        self.assertEqual(body["resolved"], override)
+        self.assertTrue(body["fingerprint"]["is_override"])
+        self.assertNotEqual(
+            body["fingerprint"]["sha256"],
+            body["fingerprint"]["default_sha256"],
+        )
+
+    def test_unknown_task_rejected(self):
+        r = self._client().post(
+            "/api/prompts/dry-run",
+            json={"task": "bogus", "system_prompt": ""},
+        )
+        self.assertEqual(r.status_code, 400)
+        self.assertEqual(r.json()["status"], "error")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds provenance tracking for system-prompt overrides across all LLM-based analysis tasks. Curators can now verify that their custom system prompts actually reached the model without inspecting raw API logs.

## Problem
When curators override system prompts for NER, EDTF normalization, or problematic-terms scanning, there was no way to verify that their override took effect. They had to trust API logs or re-run expensive batches to confirm.

## Root cause
System-prompt resolution happened inline in each task function without recording which prompt was actually sent. Results didn't carry provenance metadata.

## Solution
- **New helper `resolve_system_prompt(override, default, *, task)`** in `kwb.ai.prompts`: resolves override vs. default and returns a fingerprint dict containing sha256, length, preview, is_override flag, default_sha256, and task name.
- **Fingerprint propagation**: `BatchReport.system_prompt_used` and `NERResult.system_prompt_used` now carry the fingerprint through the result chain.
- **API endpoints updated**: `/api/ner`, `/api/ner/stream`, `/api/scan`, `/api/edtf` now include `system_prompt_used` in responses.
- **New dry-run endpoint `POST /api/prompts/dry-run`**: returns resolved text + fingerprint for any task without making an LLM call, letting curators preview their override before spending budget.
- **Dashboard UI**: 
  - New "Override prüfen" block in system-instructions panel shows sha256, length, and preview of the prompt that will be sent.
  - NER results panel displays which prompt was actually used.

## Files changed
- `src/kwb/ai/prompts.py`: New `fingerprint_prompt()` and `resolve_system_prompt()` helpers
- `src/kwb/ai/batch.py`: Added `system_prompt_used` field to `BatchReport`
- `src/kwb/analyze/ner.py`: Integrated prompt resolution in `ner_llm()`, `ner_hybrid()`, `scan_problematic_terms()`; added `system_prompt_used` to `NERResult`
- `src/kwb/enrich/edtf.py`: Integrated prompt resolution in `_normalize_dates_llm()`
- `src/kwb/normalize/edtf.py`: Integrated prompt resolution in `normalize_edtf_llm()`
- `src/kwb/api/routes/ai.py`: New `/api/prompts/dry-run` endpoint
- `src/kwb/api/routes/analyze.py`: Surface `system_prompt_used` in NER and scan API responses
- `src/kwb/api/parts/dashboard.js`: New `renderSystemPromptUsed()` and `dryRunSystemPrompt()` functions
- `src/kwb/api/dashboard.html`: Added UI elements for dry-run preview and result display
- `tests/test_system_prompt_used.py`: Comprehensive test suite (12 tests covering all tasks and endpoints)
- `CHANGELOG.md`: Documented new features
- `docs/FUNKTIONSKATALOG.md`: Updated test counts

## Tests
- ✅ Added 12 new unit tests in `test_system_prompt_used.py` covering:
  - `resolve_system_prompt()` behavior (empty/whitespace overrides, fingerprint fields)
  - `fingerprint_prompt()` truncation and preview logic
  - System-prompt capture in `ner_llm()`, `ner_hybrid()`, `scan_problematic_terms()`, `_normalize_dates_llm()`
  - `/api/prompts/dry-run` endpoint (default path, override path, error handling)
- ✅ All existing tests pass
- ✅ Ruff linting passes

## Screenshots / UI notes
- Dashboard now shows a collapsible "Prompt-Preview anzeigen" section in NER results displaying the actual prompt sent.
- System-instructions panel includes a new "Override prüfen" block with a task selector and "Prüfen" button that calls `/api

https://claude.ai/code/session_01NekaNpaLtA9GSYLfoXF18E