### PR TITLE
Surface system_prompt_used in scan/EDTF streaming endpoints (#150 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Sektionen:
 
 ## [Unreleased]
 
+### Behoben
+- **Streaming-Endpoints liefern jetzt ebenfalls `system_prompt_used`**
+  (#150-Follow-up, Codex-Review auf PR #215). Der finale SSE-`done`-Payload
+  von `/api/scan/stream` und `/api/edtf/stream` enthält den
+  Prompt-Fingerprint. Vorher war das Feld nur in den nicht-streamenden
+  Routen verfügbar, und das Dashboard nutzt für Scan und EDTF ausschließlich
+  die Streaming-Pfade — die Provenance-Anzeige fehlte daher im UI.
+
 ### Hinzugefügt
 - **System-Prompt-Fingerprint (Issue #150)** — neuer Helper
   `kwb.ai.prompts.resolve_system_prompt(override, default, *, task)` löst

--- a/docs/FUNKTIONSKATALOG.md
+++ b/docs/FUNKTIONSKATALOG.md
@@ -2,7 +2,7 @@
 
 **Version:** 0.6.0  
 **Stand:** 2026-03-05  
-**Gesamtstatus:** 1023/1182 Tests bestanden, 0 fehlgeschlagen, 159 übersprungen
+**Gesamtstatus:** 1023/1185 Tests bestanden, 0 fehlgeschlagen, 162 übersprungen
 
 ---
 
@@ -273,6 +273,7 @@
 | test_review.py | 54/54 | 0 | 0 | ✅ |
 | test_roadmap.py | 8/8 | 0 | 0 | ✅ |
 | test_services.py | 20/20 | 0 | 0 | ✅ |
+| test_streaming_prompt_fingerprint.py | 0/3 | 0 | 3 | ✅ |
 | test_system_check.py | 15/16 | 0 | 1 | ✅ |
 | test_system_prompt_used.py | 12/15 | 0 | 3 | ✅ |
 | test_utils.py | 30/30 | 0 | 0 | ✅ |
@@ -280,7 +281,7 @@
 | test_workspace_export.py | 26/26 | 0 | 0 | ✅ |
 | test_xlsx_loader.py | 1/5 | 0 | 4 | ✅ |
 | test_xml_loader.py | 21/21 | 0 | 0 | ✅ |
-| **Gesamt** | **1023/1182** | **0** | **159** | **✅** |
+| **Gesamt** | **1023/1185** | **0** | **162** | **✅** |
 <!-- AUTO-TESTS-END -->
 
 ---

--- a/src/kwb/api/routes/analyze.py
+++ b/src/kwb/api/routes/analyze.py
@@ -1008,6 +1008,7 @@ async def api_scan_stream(request: dict):
     async def generate():
         started = time.perf_counter()
         issues, errors, batches = [], 0, []
+        system_prompt_used = None
         for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
             try:
                 i2, batch = scan_problematic_terms(
@@ -1018,6 +1019,8 @@ async def api_scan_stream(request: dict):
                     system_prompt=syp,
                 )
                 issues.extend(i2)
+                if system_prompt_used is None:
+                    system_prompt_used = getattr(batch, "system_prompt_used", None)
                 batches.append({
                     "chunk": chunk_no, "rows": len(chunk_df),
                     "issues": len(i2), "succeeded": batch.succeeded,
@@ -1055,6 +1058,7 @@ async def api_scan_stream(request: dict):
                 "task_name": "Scan", "total": len(working),
                 "succeeded": succeeded, "model": mod or "default",
                 "issues": issues[:200], "run_metrics": metrics,
+                "system_prompt_used": system_prompt_used,
             },
         })
 
@@ -1184,6 +1188,7 @@ async def api_edtf_stream(request: dict):
         all_results = []
         chunk_reports = []
         errors = 0
+        system_prompt_used = None
         for chunk_no, chunk_df in _iter_chunks(working, chunk_size):
             items = [
                 {
@@ -1200,6 +1205,8 @@ async def api_edtf_stream(request: dict):
                     items, provider=prov, model=mod or None, system_prompt=syp,
                 )
                 all_results.extend(results)
+                if system_prompt_used is None and _batch is not None:
+                    system_prompt_used = getattr(_batch, "system_prompt_used", None)
                 chunk_reports.append({
                     "chunk": chunk_no, "rows": len(chunk_df),
                     "results": len(results),
@@ -1251,6 +1258,7 @@ async def api_edtf_stream(request: dict):
                      "method": r.method, "note": r.note}
                     for r in results
                 ],
+                "system_prompt_used": system_prompt_used,
             },
         })
 

--- a/tests/test_streaming_prompt_fingerprint.py
+++ b/tests/test_streaming_prompt_fingerprint.py
@@ -1,0 +1,143 @@
+"""
+Tests for system-prompt fingerprint in streaming endpoints (#150 follow-up).
+
+Codex review on PR #215 flagged that ``system_prompt_used`` was added to
+the non-streaming /api/scan and /api/edtf responses but missing from
+the corresponding /stream variants — which is what the dashboard uses
+in practice. These tests assert the fingerprint shows up in the final
+SSE ``done`` payload for both stream endpoints.
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+_FORCE_NO_FASTAPI = os.environ.get("KWB_FORCE_NO_FASTAPI") == "1"
+try:
+    if _FORCE_NO_FASTAPI:
+        raise ImportError("FastAPI disabled for deterministic catalog checks")
+    from fastapi.testclient import TestClient
+    _FASTAPI_AVAILABLE = True
+except ImportError:
+    _FASTAPI_AVAILABLE = False
+
+_skip_no_fastapi = unittest.skipUnless(
+    _FASTAPI_AVAILABLE, "FastAPI not installed",
+)
+
+
+_SAMPLE_CSV = (
+    b"record_id,title,year,subject\n"
+    b"r1,Karte Bern,1923,Stadtplan\n"
+    b"r2,Foto Bern,ca. 1850,Fotografie\n"
+    b"r3,Plan Bern,1901,Plan\n"
+)
+
+
+def _client():
+    from kwb.api import deps
+    from kwb.core.workspace import Workspace
+    deps._state["datasets"] = {}
+    deps._state["report"] = None
+    deps._state["workspace"] = Workspace(name="test")
+    deps._config_cache = None
+    from kwb.api.app import app
+    from kwb.ai.mock import MockProvider
+    deps._prov_override = MockProvider.with_defaults()
+    return TestClient(app)
+
+
+def _upload(client, name="data.csv"):
+    client.post(
+        "/api/analyze",
+        files=[("files", (name, io.BytesIO(_SAMPLE_CSV), "text/csv"))],
+    )
+
+
+def _final_done(text: str) -> dict:
+    """Pull the last SSE ``done`` event payload out of a stream response."""
+    matches = re.findall(r"data: ({.*?})\n\n", text)
+    self_test = []
+    for raw in matches:
+        try:
+            evt = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if evt.get("type") == "done":
+            self_test.append(evt)
+    assert self_test, f"No done event found in stream:\n{text[:500]}"
+    return self_test[-1]
+
+
+@_skip_no_fastapi
+class TestScanStreamFingerprint(unittest.TestCase):
+    def test_scan_stream_includes_fingerprint_on_done(self):
+        client = _client()
+        _upload(client, "scan.csv")
+        with client.stream(
+            "POST",
+            "/api/scan/stream",
+            json={"dataset": "scan.csv", "sample_size": 2},
+        ) as resp:
+            self.assertEqual(resp.status_code, 200)
+            text = "".join(chunk for chunk in resp.iter_text())
+        done = _final_done(text)
+        result = done["result"]
+        self.assertIn("system_prompt_used", result)
+        fp = result["system_prompt_used"]
+        # When a scan actually invoked the LLM the fingerprint must be a dict
+        # with a sha256. If no items reached the provider (e.g. all blank) the
+        # field is null — accept either but never absent.
+        self.assertTrue(fp is None or "sha256" in fp)
+        if fp is not None:
+            self.assertEqual(fp.get("task"), "problematic_terms")
+
+
+@_skip_no_fastapi
+class TestEDTFStreamFingerprint(unittest.TestCase):
+    def test_edtf_stream_with_llm_includes_fingerprint(self):
+        client = _client()
+        _upload(client, "edtf.csv")
+        with client.stream(
+            "POST",
+            "/api/edtf/stream",
+            json={
+                "dataset": "edtf.csv",
+                "column": "year",
+                "use_llm": True,
+            },
+        ) as resp:
+            self.assertEqual(resp.status_code, 200)
+            text = "".join(chunk for chunk in resp.iter_text())
+        done = _final_done(text)
+        result = done["result"]
+        self.assertIn("system_prompt_used", result)
+
+    def test_edtf_stream_without_llm_still_has_field(self):
+        """Even rules-only runs should report system_prompt_used (likely null)."""
+        client = _client()
+        _upload(client, "edtf.csv")
+        with client.stream(
+            "POST",
+            "/api/edtf/stream",
+            json={
+                "dataset": "edtf.csv",
+                "column": "year",
+                "use_llm": False,
+            },
+        ) as resp:
+            text = "".join(chunk for chunk in resp.iter_text())
+        done = _final_done(text)
+        # Key must exist so the dashboard never crashes on a missing field
+        self.assertIn("system_prompt_used", done["result"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Codex review on PR #215 flagged that system_prompt_used was added to
/api/scan and /api/edtf but missing from the /stream variants — which
is what dashboard.js runScan / runEDTF actually call. As a result the
prompt-override provenance never reached the curator's screen.

- /api/scan/stream: capture batch.system_prompt_used in the chunk loop
  and emit it in the final SSE done payload
- /api/edtf/stream: same treatment for _batch.system_prompt_used
- tests/test_streaming_prompt_fingerprint.py: three integration tests
  that parse the final done event and assert system_prompt_used is
  present (and is a fingerprint dict when LLM was invoked)